### PR TITLE
[UPD] ssi_timesheet_attendance_shift - Tambah pola rotasi shift dan penugasan regu ke karyawan

### DIFF
--- a/ssi_timesheet_attendance_shift/README.rst
+++ b/ssi_timesheet_attendance_shift/README.rst
@@ -20,6 +20,15 @@ Work Instruction
 * `Delete Attendance Shift <docs/hr_attendance_shift/index.html>`_
 * `Deactivate Attendance Shift <docs/hr_attendance_shift/index.html>`_
 * `Activate Attendance Shift <docs/hr_attendance_shift/index.html>`_
+* `Create Attendance Shift Pattern <docs/hr_attendance_shift_pattern/index.html>`_
+* `Edit Attendance Shift Pattern <docs/hr_attendance_shift_pattern/index.html>`_
+* `Delete Attendance Shift Pattern <docs/hr_attendance_shift_pattern/index.html>`_
+* `Create Attendance Shift Assignment
+  <docs/hr_attendance_shift_assignment/index.html>`_
+* `Edit Attendance Shift Assignment
+  <docs/hr_attendance_shift_assignment/index.html>`_
+* `Delete Attendance Shift Assignment
+  <docs/hr_attendance_shift_assignment/index.html>`_
 
 
 Installation

--- a/ssi_timesheet_attendance_shift/__manifest__.py
+++ b/ssi_timesheet_attendance_shift/__manifest__.py
@@ -22,7 +22,11 @@
     "data": [
         "security/res_groups/hr_attendance_shift.xml",
         "security/ir_model_access/hr_attendance_shift.xml",
+        "security/ir_model_access/hr_attendance_shift_pattern.xml",
+        "security/ir_model_access/hr_attendance_shift_assignment.xml",
         "views/hr_attendance_shift_views.xml",
+        "views/hr_attendance_shift_pattern_views.xml",
+        "views/hr_attendance_shift_assignment_views.xml",
         "views/ssi_timesheet_attendance_shift_assets.xml",
     ],
 }

--- a/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_assignment/01-create.md
+++ b/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_assignment/01-create.md
@@ -1,0 +1,38 @@
+# Create Attendance Shift Assignment
+
+> **Module:** ssi_timesheet_attendance_shift
+>
+> **Model:** `hr.attendance_shift_assignment`
+>
+> **Menu:** Human Resource > Configurations > Attendance > Attendance Shift Assignments
+>
+> **Actor:** user in group _Attendance Shift_
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Shift_.
+- **Record:** At least one Employee and one Attendance Shift Pattern exist.
+
+## Flow
+
+1. Open the **Human Resource > Configurations > Attendance > Attendance Shift
+   Assignments** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Employee** _(required)_: Select the employee (crew member) this assignment is
+     for.
+   - **Pattern** _(required)_: Select the rotation pattern to assign.
+   - **Cycle Offset (Days)** _(required)_: Enter the number of days that distinguishes
+     this crew's rotation start from another crew sharing the same **Pattern**. Defaults
+     to 0.
+   - **Date Start** _(required)_: Enter the first calendar date this assignment applies
+     from.
+   - **Date End**: Enter the last calendar date this assignment applies to. Leave empty
+     for an assignment with no end date.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new attendance shift assignment record is created, linking the employee to the
+  pattern.
+- An assignment with **Date End** left empty applies indefinitely.

--- a/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_assignment/02-edit.md
+++ b/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_assignment/02-edit.md
@@ -1,0 +1,29 @@
+# Edit Attendance Shift Assignment
+
+> **Module:** ssi_timesheet_attendance_shift
+>
+> **Model:** `hr.attendance_shift_assignment`
+>
+> **Menu:** Human Resource > Configurations > Attendance > Attendance Shift Assignments
+>
+> **Actor:** user in group _Attendance Shift_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Shift_.
+
+## Flow
+
+1. Open the **Human Resource > Configurations > Attendance > Attendance Shift
+   Assignments** menu.
+2. Find and open the record to edit.
+3. Change the required fields, for example **Pattern**, **Cycle Offset (Days)**, **Date
+   Start**, or **Date End**.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- Saving a date range that overlaps another assignment of the same employee is rejected.

--- a/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_assignment/03-delete.md
+++ b/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_assignment/03-delete.md
@@ -1,0 +1,28 @@
+# Delete Attendance Shift Assignment
+
+> **Module:** ssi_timesheet_attendance_shift
+>
+> **Model:** `hr.attendance_shift_assignment`
+>
+> **Menu:** Human Resource > Configurations > Attendance > Attendance Shift Assignments
+>
+> **Actor:** user in group _Attendance Shift_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Shift_.
+
+## Flow
+
+1. Open the **Human Resource > Configurations > Attendance > Attendance Shift
+   Assignments** menu.
+2. Open the record to delete.
+3. Click the **Action** menu and select **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The record is permanently removed from the system.
+- The deleted assignment no longer appears in the Attendance Shift Assignments list.

--- a/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_pattern/01-create.md
+++ b/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_pattern/01-create.md
@@ -1,0 +1,42 @@
+# Create Attendance Shift Pattern
+
+> **Module:** ssi_timesheet_attendance_shift
+>
+> **Model:** `hr.attendance_shift_pattern`
+>
+> **Menu:** Human Resource > Configurations > Attendance > Attendance Shift Patterns
+>
+> **Actor:** user in group _Attendance Shift_
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Shift_.
+- **Record:** At least one Attendance Shift exists, if a cycle day should point at a
+  shift instead of being a day off.
+
+## Flow
+
+1. Open the **Human Resource > Configurations > Attendance > Attendance Shift Patterns**
+   menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter a short label for the pattern (for example "Three Crew
+     Rotation").
+   - **Code** _(required)_: Enter a unique code, or fill in "/" to assign one
+     automatically.
+   - **Cycle Length (Days)** _(required)_: Enter the number of days in one full
+     rotation. Defaults to 7.
+   - **Cycle Anchor Date** _(required)_: Enter the global reference date day-in-cycle 1
+     is resolved from.
+4. Open the **Cycle Days** tab.
+5. For each day-in-cycle from 1 up to **Cycle Length (Days)**, add a line:
+   - **Day Index** _(required)_: Enter the position of this day within the cycle,
+     between 1 and **Cycle Length (Days)**.
+   - **Shift**: Select the shift that applies on that day-in-cycle. Leave empty for a
+     day off.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new attendance shift pattern record is created together with its cycle day lines.
+- A cycle day line with **Shift** left empty represents a day off.

--- a/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_pattern/02-edit.md
+++ b/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_pattern/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Attendance Shift Pattern
+
+> **Module:** ssi_timesheet_attendance_shift
+>
+> **Model:** `hr.attendance_shift_pattern`
+>
+> **Menu:** Human Resource > Configurations > Attendance > Attendance Shift Patterns
+>
+> **Actor:** user in group _Attendance Shift_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Shift_.
+
+## Flow
+
+1. Open the **Human Resource > Configurations > Attendance > Attendance Shift Patterns**
+   menu.
+2. Find and open the record to edit.
+3. Change the required fields, for example **Name**, **Cycle Length (Days)**, or **Cycle
+   Anchor Date**, or add/change lines in the **Cycle Days** tab.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_pattern/03-delete.md
+++ b/ssi_timesheet_attendance_shift/docs/hr_attendance_shift_pattern/03-delete.md
@@ -1,0 +1,30 @@
+# Delete Attendance Shift Pattern
+
+> **Module:** ssi_timesheet_attendance_shift
+>
+> **Model:** `hr.attendance_shift_pattern`
+>
+> **Menu:** Human Resource > Configurations > Attendance > Attendance Shift Patterns
+>
+> **Actor:** user in group _Attendance Shift_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Shift_.
+- **Record:** The pattern is not referenced by any Attendance Shift Assignment —
+  deleting a pattern still in use is rejected.
+
+## Flow
+
+1. Open the **Human Resource > Configurations > Attendance > Attendance Shift Patterns**
+   menu.
+2. Open the record to delete.
+3. Click the **Action** menu and select **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The record is permanently removed from the system, together with its cycle day lines.
+- The deleted pattern no longer appears in the Attendance Shift Patterns list.

--- a/ssi_timesheet_attendance_shift/models/__init__.py
+++ b/ssi_timesheet_attendance_shift/models/__init__.py
@@ -3,3 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import hr_attendance_shift
+from . import hr_attendance_shift_pattern
+from . import hr_attendance_shift_pattern_detail
+from . import hr_attendance_shift_assignment

--- a/ssi_timesheet_attendance_shift/models/hr_attendance_shift_assignment.py
+++ b/ssi_timesheet_attendance_shift/models/hr_attendance_shift_assignment.py
@@ -1,0 +1,132 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class HrAttendanceShiftAssignment(models.Model):
+    """Assigns an attendance shift pattern to one employee (crew).
+
+    Standalone record with no workflow of its own: it links an
+    employee to a rotation pattern for a date range, with a
+    ``cycle_offset`` that is the sole thing distinguishing one crew
+    from another when several crews share the same pattern. A given
+    calendar date's day-in-cycle is resolved as::
+
+        ((date - pattern.date_anchor).days - cycle_offset)
+            % pattern.cycle_length + 1
+
+    That formula is a binding design decision consumed by the shift
+    generator (out of scope for this module) and must not be
+    reimplemented differently there. An empty ``date_end`` means the
+    assignment has no end date — it applies indefinitely.
+    """
+
+    _name = "hr.attendance_shift_assignment"
+    _description = "Attendance Shift Assignment"
+    _order = "employee_id, date_start desc"
+    _rec_name = "employee_id"
+
+    employee_id = fields.Many2one(
+        string="Employee",
+        comodel_name="hr.employee",
+        required=True,
+        ondelete="cascade",
+    )
+    pattern_id = fields.Many2one(
+        string="Pattern",
+        comodel_name="hr.attendance_shift_pattern",
+        required=True,
+        ondelete="restrict",
+        help="Rotation pattern this employee is assigned to.",
+    )
+    cycle_offset = fields.Integer(
+        string="Cycle Offset (Days)",
+        required=True,
+        default=0,
+        help=(
+            "Number of days subtracted from the day-in-cycle formula "
+            "before taking the modulo. This is the crew distinguisher: "
+            "several employees can share the same Pattern with "
+            "different offsets so each starts the rotation on a "
+            "different day."
+        ),
+    )
+    date_start = fields.Date(
+        string="Date Start",
+        required=True,
+        help="First calendar date this assignment applies from.",
+    )
+    date_end = fields.Date(
+        string="Date End",
+        help=(
+            "Last calendar date this assignment applies to. Left "
+            "empty, the assignment has no end date."
+        ),
+    )
+
+    @api.constrains("employee_id", "date_start", "date_end")
+    def _check_date_overlap(self):
+        """Reject a date range overlapping another of the same employee.
+
+        :raises ValidationError: when this assignment's date range
+            overlaps another assignment of the same employee
+        """
+        for record in self.sudo():
+            if not record._check_date_overlap_condition():
+                error_message = (
+                    "Shift assignment date range cannot overlap for "
+                    "the same employee"
+                )
+                raise ValidationError(_(error_message))
+
+    def _check_date_overlap_condition(self):
+        """Tell whether no sibling assignment overlaps this one.
+
+        An empty ``date_end`` (either on this record or on the
+        sibling being compared to) is treated as unbounded into the
+        future.
+
+        Extension point: override to change the overlap rule.
+
+        :return: True when no overlap is found; never raises
+        """
+        self.ensure_one()
+        domain = [
+            ("employee_id", "=", self.employee_id.id),
+            ("id", "!=", self.id),
+        ]
+        if self.date_end:
+            domain.append(("date_start", "<=", self.date_end))
+        domain += [
+            "|",
+            ("date_end", ">=", self.date_start),
+            ("date_end", "=", False),
+        ]
+        return self.search_count(domain) == 0
+
+    @api.constrains("date_start", "date_end")
+    def _check_date_end(self):
+        """Reject a Date End earlier than Date Start.
+
+        :raises ValidationError: when ``date_end`` precedes
+            ``date_start``
+        """
+        for record in self.sudo():
+            if not record._check_date_end_condition():
+                error_message = "Date end cannot be earlier than date start"
+                raise ValidationError(_(error_message))
+
+    def _check_date_end_condition(self):
+        """Tell whether Date End is not earlier than Date Start.
+
+        Extension point: override to relax or tighten the bounds.
+
+        :return: True when valid; never raises
+        """
+        self.ensure_one()
+        if not self.date_end:
+            return True
+        return self.date_end >= self.date_start

--- a/ssi_timesheet_attendance_shift/models/hr_attendance_shift_pattern.py
+++ b/ssi_timesheet_attendance_shift/models/hr_attendance_shift_pattern.py
@@ -1,0 +1,63 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrAttendanceShiftPattern(models.Model):
+    """Represents a fixed-length rotation cycle of attendance shifts.
+
+    ``resource.calendar`` only understands a two-week (odd/even)
+    rotation, which cannot express a three-crew rolling pattern or a
+    four-days-on/two-days-off pattern. This model instead stores an
+    arbitrary-length cycle (``cycle_length`` days) as a set of detail
+    lines (``detail_ids``), one per day-in-cycle, each optionally
+    pointing at an ``hr.attendance_shift``.
+
+    The cycle is always resolved relative to ``date_anchor`` — a
+    single global reference date — never relative to a timesheet
+    period's start date. This is a deliberate, binding design choice:
+    anchoring to the timesheet period would reset the cycle every
+    time a period boundary is crossed, breaking a rotation that spans
+    across it. Several crews can reuse the same pattern by being
+    assigned to it (``hr.attendance_shift_assignment``) with a
+    different ``cycle_offset``, which shifts which day-in-cycle a
+    given calendar date resolves to for that crew.
+    """
+
+    _name = "hr.attendance_shift_pattern"
+    _inherit = ["mixin.master_data"]
+    _description = "Attendance Shift Pattern"
+
+    cycle_length = fields.Integer(
+        string="Cycle Length (Days)",
+        required=True,
+        default=7,
+        help=(
+            "Number of days in one full rotation of this pattern. "
+            "Every detail line's Day Index must fall within 1 and "
+            "this value."
+        ),
+    )
+    date_anchor = fields.Date(
+        string="Cycle Anchor Date",
+        required=True,
+        help=(
+            "Global reference date day-in-cycle 1 is resolved from. "
+            "Shared by every crew assigned to this pattern — a crew's "
+            "own Cycle Offset (on its assignment) is what makes its "
+            "rotation start on a different day, not a different "
+            "anchor."
+        ),
+    )
+    detail_ids = fields.One2many(
+        string="Cycle Days",
+        comodel_name="hr.attendance_shift_pattern.detail",
+        inverse_name="pattern_id",
+        help=(
+            "One line per day-in-cycle, from 1 to Cycle Length (Days). "
+            "A line whose Shift is left empty means that day-in-cycle "
+            "is a day off."
+        ),
+    )

--- a/ssi_timesheet_attendance_shift/models/hr_attendance_shift_pattern_detail.py
+++ b/ssi_timesheet_attendance_shift/models/hr_attendance_shift_pattern_detail.py
@@ -1,0 +1,94 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class HrAttendanceShiftPatternDetail(models.Model):
+    """Represents one day-in-cycle line of an attendance shift pattern.
+
+    Belongs to exactly one ``hr.attendance_shift_pattern`` and states
+    which ``hr.attendance_shift`` (if any) applies on that day-in-cycle.
+    An empty ``shift_id`` is a first-class value meaning "day off" —
+    it is intentionally not required.
+    """
+
+    _name = "hr.attendance_shift_pattern.detail"
+    _description = "Attendance Shift Pattern - Detail"
+    _order = "pattern_id, day_index"
+
+    pattern_id = fields.Many2one(
+        string="# Pattern",
+        comodel_name="hr.attendance_shift_pattern",
+        required=True,
+        ondelete="cascade",
+    )
+    day_index = fields.Integer(
+        string="Day Index",
+        required=True,
+        help=(
+            "Position of this line within the parent pattern's cycle, "
+            "counted from 1 to the pattern's Cycle Length (Days)."
+        ),
+    )
+    shift_id = fields.Many2one(
+        string="Shift",
+        comodel_name="hr.attendance_shift",
+        help=(
+            "Shift that applies on this day-in-cycle. Left empty, this "
+            "day-in-cycle is a day off — not incomplete data."
+        ),
+    )
+
+    @api.constrains("day_index", "pattern_id")
+    def _check_day_index_range(self):
+        """Reject a Day Index outside the parent's cycle length.
+
+        :raises ValidationError: when ``day_index`` is not between 1
+            and the parent pattern's ``cycle_length``
+        """
+        for record in self.sudo():
+            if not record._check_day_index_range_condition():
+                error_message = (
+                    "Day index must be between 1 and the pattern " "cycle length"
+                )
+                raise ValidationError(_(error_message))
+
+    def _check_day_index_range_condition(self):
+        """Tell whether ``day_index`` lies within ``[1, cycle_length]``.
+
+        Extension point: override to relax or tighten the bounds.
+
+        :return: True when valid; never raises
+        """
+        self.ensure_one()
+        return 1 <= self.day_index <= self.pattern_id.cycle_length
+
+    @api.constrains("day_index", "pattern_id")
+    def _check_day_index_unique(self):
+        """Reject a Day Index already used by a sibling detail line.
+
+        :raises ValidationError: when another line of the same
+            pattern already uses this ``day_index``
+        """
+        for record in self.sudo():
+            if not record._check_day_index_unique_condition():
+                error_message = "Day index must be unique within a pattern"
+                raise ValidationError(_(error_message))
+
+    def _check_day_index_unique_condition(self):
+        """Tell whether ``day_index`` is unique within the pattern.
+
+        Extension point: override to change the uniqueness rule.
+
+        :return: True when unique; never raises
+        """
+        self.ensure_one()
+        domain = [
+            ("pattern_id", "=", self.pattern_id.id),
+            ("day_index", "=", self.day_index),
+            ("id", "!=", self.id),
+        ]
+        return self.search_count(domain) == 0

--- a/ssi_timesheet_attendance_shift/security/ir_model_access/hr_attendance_shift_assignment.xml
+++ b/ssi_timesheet_attendance_shift/security/ir_model_access/hr_attendance_shift_assignment.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_attendance_shift_assignment_all_access" model="ir.model.access">
+    <field name="name">hr.attendance_shift_assignment - all</field>
+    <field name="model_id" ref="model_hr_attendance_shift_assignment" />
+    <field name="group_id" ref="base.group_user" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_unlink" eval="0" />
+</record>
+
+<record id="hr_attendance_shift_assignment_user_access" model="ir.model.access">
+    <field name="name">hr.attendance_shift_assignment - user</field>
+    <field name="model_id" ref="model_hr_attendance_shift_assignment" />
+    <field name="group_id" ref="attendance_shift_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+</odoo>

--- a/ssi_timesheet_attendance_shift/security/ir_model_access/hr_attendance_shift_pattern.xml
+++ b/ssi_timesheet_attendance_shift/security/ir_model_access/hr_attendance_shift_pattern.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_attendance_shift_pattern_all_access" model="ir.model.access">
+    <field name="name">hr.attendance_shift_pattern - all</field>
+    <field name="model_id" ref="model_hr_attendance_shift_pattern" />
+    <field name="group_id" ref="base.group_user" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_unlink" eval="0" />
+</record>
+
+<record id="hr_attendance_shift_pattern_user_access" model="ir.model.access">
+    <field name="name">hr.attendance_shift_pattern - user</field>
+    <field name="model_id" ref="model_hr_attendance_shift_pattern" />
+    <field name="group_id" ref="attendance_shift_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+<record id="hr_attendance_shift_pattern_detail_all_access" model="ir.model.access">
+    <field name="name">hr.attendance_shift_pattern.detail - all</field>
+    <field name="model_id" ref="model_hr_attendance_shift_pattern_detail" />
+    <field name="group_id" ref="base.group_user" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_unlink" eval="0" />
+</record>
+
+<record id="hr_attendance_shift_pattern_detail_user_access" model="ir.model.access">
+    <field name="name">hr.attendance_shift_pattern.detail - user</field>
+    <field name="model_id" ref="model_hr_attendance_shift_pattern_detail" />
+    <field name="group_id" ref="attendance_shift_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+</odoo>

--- a/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_assignment_tour.js
+++ b/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_assignment_tour.js
@@ -1,0 +1,236 @@
+odoo.define(
+    "ssi_timesheet_attendance_shift.hr_attendance_shift_assignment_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared opening steps: Human Resource > Configurations > Attendance >
+        // Attendance Shift Assignments. "Attendance" (level 3) has children of
+        // its own, so it is rendered as a non-clickable dropdown header and is
+        // skipped here — only the leaf "Attendance Shift Assignments" item
+        // gets a step.
+        function openAttendanceShiftAssignmentMenuSteps() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Human Resource app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+                },
+                {
+                    content: "Open the Configurations menu",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_hr.menu_human_resource_configuration"]',
+                },
+                {
+                    content: "Open the Attendance Shift Assignments menu",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_timesheet_attendance_shift.hr_attendance_shift_assignment_menu"]',
+                },
+                {
+                    // Gate: wait for the TARGET action, not just any list view —
+                    // the app landing action is also a .o_list_view.
+                    content: "Attendance Shift Assignments list is displayed",
+                    trigger:
+                        ".o_control_panel " +
+                        ".breadcrumb-item.active:contains(Attendance Shift Assignments)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click action.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/hr_attendance_shift_assignment/01-create.md
+        tour.register(
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_assignment_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openAttendanceShiftAssignmentMenuSteps(), [
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Select the Employee",
+                    trigger: ".o_field_many2one[name='employee_id'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR-ASSIGN-CREATE-EMPLOYEE",
+                },
+                {
+                    content: "Pick the employee from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR-ASSIGN-CREATE-EMPLOYEE)",
+                    in_modal: false,
+                },
+                {
+                    content: "Select the Pattern",
+                    trigger: ".o_field_many2one[name='pattern_id'] input",
+                    run: "text TOUR-ASSIGN-PATTERN",
+                },
+                {
+                    content: "Pick the pattern from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR-ASSIGN-PATTERN)",
+                    in_modal: false,
+                },
+                {
+                    content: "Fill in Cycle Offset (Days)",
+                    trigger: ".o_field_widget[name='cycle_offset']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 0",
+                },
+                {
+                    content: "Fill in Date Start",
+                    trigger: ".o_field_widget[name='date_start'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 01/15/2026",
+                },
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ])
+        );
+
+        // IK: docs/hr_attendance_shift_assignment/02-edit.md
+        tour.register(
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_assignment_edit",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openAttendanceShiftAssignmentMenuSteps(), [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR-ASSIGN-EDIT-EMPLOYEE) " +
+                        ".o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Change Cycle Offset (Days)",
+                    trigger: ".o_field_widget[name='cycle_offset']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 3",
+                },
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ])
+        );
+
+        // IK: docs/hr_attendance_shift_assignment/03-delete.md
+        tour.register(
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_assignment_delete",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openAttendanceShiftAssignmentMenuSteps(), [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR-ASSIGN-DELETE-EMPLOYEE) " +
+                        ".o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    // Action menu items are Owl components; match the exact
+                    // label so "Archive" is never picked instead.
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                {
+                    content: "Back to the Attendance Shift Assignments list",
+                    trigger:
+                        ".breadcrumb-item.o_back_button a:contains(Attendance Shift Assignments)",
+                },
+                {
+                    content: "Deleted assignment no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(TOUR-ASSIGN-DELETE-EMPLOYEE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ])
+        );
+    }
+);

--- a/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_pattern_tour.js
+++ b/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_pattern_tour.js
@@ -117,10 +117,16 @@ odoo.define(
                     in_modal: false,
                 },
                 {
+                    // The <td> wrapping an o2m cell carries no `name`
+                    // attribute in 14.0 (only the field widget itself
+                    // does — abstract_field.js sets it on `this.$el`,
+                    // not on the surrounding cell), and there is only
+                    // one row here so there is no sibling cell to click
+                    // instead. Blur the still-open row by clicking the
+                    // always-visible Name field above the notebook
+                    // instead — a plain click does not change its text.
                     content: "Commit the cycle day line",
-                    trigger:
-                        ".o_field_widget[name='detail_ids'] " +
-                        ".o_data_row .o_field_cell[name='day_index']",
+                    trigger: ".o_field_widget[name='name']",
                     run: function () {
                         this.$anchor[0].click();
                     },

--- a/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_pattern_tour.js
+++ b/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_pattern_tour.js
@@ -1,0 +1,258 @@
+odoo.define(
+    "ssi_timesheet_attendance_shift.hr_attendance_shift_pattern_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared opening steps: Human Resource > Configurations > Attendance >
+        // Attendance Shift Patterns. "Attendance" (level 3) has children of its
+        // own, so it is rendered as a non-clickable dropdown header and is
+        // skipped here — only the leaf "Attendance Shift Patterns" item gets a
+        // step.
+        function openAttendanceShiftPatternMenuSteps() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Human Resource app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+                },
+                {
+                    content: "Open the Configurations menu",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_hr.menu_human_resource_configuration"]',
+                },
+                {
+                    content: "Open the Attendance Shift Patterns menu",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_timesheet_attendance_shift.hr_attendance_shift_pattern_menu"]',
+                },
+                {
+                    // Gate: wait for the TARGET action, not just any list view —
+                    // the app landing action is also a .o_list_view.
+                    content: "Attendance Shift Patterns list is displayed",
+                    trigger:
+                        ".o_control_panel " +
+                        ".breadcrumb-item.active:contains(Attendance Shift Patterns)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click action.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/hr_attendance_shift_pattern/01-create.md
+        tour.register(
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_pattern_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openAttendanceShiftPatternMenuSteps(), [
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Fill in Name",
+                    trigger: ".o_field_widget[name='name']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR-PATTERN-CREATE",
+                },
+                {
+                    content: "Fill in Code",
+                    trigger: ".o_field_widget[name='code']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text /",
+                },
+                {
+                    content: "Fill in Cycle Length (Days)",
+                    trigger: ".o_field_widget[name='cycle_length']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 7",
+                },
+                {
+                    content: "Fill in Cycle Anchor Date",
+                    trigger: ".o_field_widget[name='date_anchor'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 01/15/2026",
+                },
+                {
+                    content: "Open the Cycle Days tab",
+                    trigger: ".o_notebook .nav-link:contains(Cycle Days)",
+                },
+                {
+                    content: "Add a cycle day line",
+                    trigger:
+                        ".o_field_widget[name='detail_ids'] " +
+                        ".o_field_x2many_list_row_add a",
+                },
+                {
+                    content: "Fill in Day Index",
+                    trigger: ".o_selected_row .o_field_widget[name='day_index']",
+                    run: "text 1",
+                },
+                {
+                    content: "Select the Shift",
+                    trigger: ".o_selected_row .o_field_widget[name='shift_id'] input",
+                    run: "text TOUR-PATTERN-SHIFT",
+                },
+                {
+                    content: "Pick the shift from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR-PATTERN-SHIFT)",
+                    in_modal: false,
+                },
+                {
+                    content: "Commit the cycle day line",
+                    trigger:
+                        ".o_field_widget[name='detail_ids'] " +
+                        ".o_data_row .o_field_cell[name='day_index']",
+                    run: function () {
+                        this.$anchor[0].click();
+                    },
+                },
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ])
+        );
+
+        // IK: docs/hr_attendance_shift_pattern/02-edit.md
+        tour.register(
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_pattern_edit",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openAttendanceShiftPatternMenuSteps(), [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR-PATTERN-EDIT) .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Change Cycle Length (Days)",
+                    trigger: ".o_field_widget[name='cycle_length']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 14",
+                },
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ])
+        );
+
+        // IK: docs/hr_attendance_shift_pattern/03-delete.md
+        tour.register(
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_pattern_delete",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openAttendanceShiftPatternMenuSteps(), [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR-PATTERN-DELETE) .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    // Action menu items are Owl components; match the exact
+                    // label so "Archive" is never picked instead.
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                {
+                    content: "Back to the Attendance Shift Patterns list",
+                    trigger:
+                        ".breadcrumb-item.o_back_button a:contains(Attendance Shift Patterns)",
+                },
+                {
+                    content: "Deleted pattern no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(TOUR-PATTERN-DELETE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ])
+        );
+    }
+);

--- a/ssi_timesheet_attendance_shift/tests/__init__.py
+++ b/ssi_timesheet_attendance_shift/tests/__init__.py
@@ -3,4 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_attendance_shift
+from . import test_hr_attendance_shift_pattern
+from . import test_hr_attendance_shift_assignment
 from . import test_ui_hr_attendance_shift
+from . import test_ui_hr_attendance_shift_pattern
+from . import test_ui_hr_attendance_shift_assignment

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_attendance_shift_assignment.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_attendance_shift_assignment.yaml
@@ -1,0 +1,203 @@
+setup:
+  steps:
+    - step: "Create pattern for assignment"
+      action: "create"
+      model: "hr.attendance_shift_pattern"
+      save_as: "pattern"
+      values:
+        name: "Assignment Test Pattern"
+        code: "/"
+        cycle_length: 7
+        date_anchor: 2024-01-01
+
+    - step: "Create employee for assignment"
+      action: "create"
+      model: "hr.employee"
+      save_as: "employee"
+      values:
+        name: "Assignment Test Employee"
+
+scenarios:
+  - name: "Attendance Shift Assignment - Create"
+    steps:
+      - step: "Create assignment"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-01
+
+      - step: "Assert assignment created"
+        action: "assert"
+        target: "assignment"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          cycle_offset:
+            type: "value"
+            expected: 0
+
+  - name: "Attendance Shift Assignment - Edit"
+    steps:
+      - step: "Create assignment"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-02-01
+          date_end: 2024-02-29
+
+      - step: "Edit assignment"
+        action: "write"
+        target: "assignment"
+        values:
+          cycle_offset: 3
+          date_end: 2024-03-31
+
+      - step: "Assert edited"
+        action: "assert"
+        target: "assignment"
+        asserts:
+          cycle_offset:
+            type: "value"
+            expected: 3
+          date_end:
+            type: "value"
+            expected: 2024-03-31
+
+  - name: "Attendance Shift Assignment - Delete"
+    steps:
+      - step: "Create assignment"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-04-01
+          date_end: 2024-04-30
+
+      - step: "Delete assignment"
+        action: "unlink"
+        target: "assignment"
+
+      - step: "Verify deleted"
+        action: "search"
+        model: "hr.attendance_shift_assignment"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", 2024-04-01]]
+        save_as: "result"
+        expect_count: 0
+
+  - name: "Attendance Shift Assignment - Open-Ended Date End"
+    steps:
+      - step: "Create assignment without date_end"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 1
+          date_start: 2024-05-01
+
+      - step: "Assert date_end is empty"
+        action: "assert"
+        target: "assignment"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          date_end:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Attendance Shift Assignment - Two Non-Overlapping Assignments Saved"
+    steps:
+      - step: "Create first assignment"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment_1"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-06-01
+          date_end: 2024-06-30
+
+      - step: "Create second non-overlapping assignment"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment_2"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 2
+          date_start: 2024-07-01
+          date_end: 2024-07-31
+
+      - step: "Assert first assignment saved"
+        action: "assert"
+        target: "assignment_1"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert second assignment saved"
+        action: "assert"
+        target: "assignment_2"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Attendance Shift Assignment - Overlapping Range Rejected"
+    steps:
+      - step: "Create first assignment"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment_1"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-08-01
+          date_end: 2024-08-31
+
+      - step: "Create overlapping assignment must be rejected"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        expect_error:
+          type: "ValidationError"
+          message_contains:
+            "Shift assignment date range cannot overlap for the same employee"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 1
+          date_start: 2024-08-15
+          date_end: 2024-09-15
+
+  - name: "Attendance Shift Assignment - Date End Before Date Start Rejected"
+    steps:
+      - step: "Create assignment with date_end before date_start must be rejected"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Date end cannot be earlier than date start"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-09-10
+          date_end: 2024-09-01

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_attendance_shift_pattern.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_attendance_shift_pattern.yaml
@@ -1,0 +1,335 @@
+setup:
+  steps:
+    - step: "Create shift for pattern details"
+      action: "create"
+      model: "hr.attendance_shift"
+      save_as: "shift"
+      values:
+        name: "Pattern Test Shift"
+        code: "/"
+        hour_start: 7.0
+        duration: 8.0
+
+scenarios:
+  - name: "Attendance Shift Pattern - Create"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Three Crew Rotation"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Assert pattern created"
+        action: "assert"
+        target: "pattern"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          name:
+            type: "value"
+            expected: "Three Crew Rotation"
+          cycle_length:
+            type: "value"
+            expected: 7
+
+  - name: "Attendance Shift Pattern - Edit"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Edit Me Pattern"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Edit pattern"
+        action: "write"
+        target: "pattern"
+        values:
+          name: "Edited Pattern"
+          cycle_length: 14
+
+      - step: "Assert edited"
+        action: "assert"
+        target: "pattern"
+        asserts:
+          name:
+            type: "value"
+            expected: "Edited Pattern"
+          cycle_length:
+            type: "value"
+            expected: 14
+
+  - name: "Attendance Shift Pattern - Delete"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Pattern To Delete"
+          code: "PATDEL001"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Delete pattern"
+        action: "unlink"
+        target: "pattern"
+
+      - step: "Verify deleted"
+        action: "search"
+        model: "hr.attendance_shift_pattern"
+        domain: [["code", "=", "PATDEL001"]]
+        save_as: "result"
+        expect_count: 0
+
+  - name: "Attendance Shift Pattern - Three Detail Lines"
+    steps:
+      - step: "Create pattern with three detail lines"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Pattern With Details"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 2
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 3
+                shift_id: "REC: shift.id"
+
+      - step: "Assert three detail lines"
+        action: "assert"
+        target: "pattern"
+        asserts:
+          detail_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+  - name: "Attendance Shift Pattern - Detail Line Without Shift Is A Day Off"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Pattern With Day Off"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Create detail line without shift"
+        action: "create"
+        model: "hr.attendance_shift_pattern.detail"
+        save_as: "detail"
+        values:
+          pattern_id: "REC: pattern.id"
+          day_index: 1
+
+      - step: "Assert shift_id is empty"
+        action: "assert"
+        target: "detail"
+        asserts:
+          shift_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Attendance Shift Pattern - Cycle Length 21 With 21 Detail Lines"
+    steps:
+      - step: "Create pattern with 21-day cycle and 21 detail lines"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "21-Day Rotation"
+          code: "/"
+          cycle_length: 21
+          date_anchor: 2024-01-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 2
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 3
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 4
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 5
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 6
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 7
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 8
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 9
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 10
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 11
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 12
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 13
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 14
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 15
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 16
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 17
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 18
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 19
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 20
+                shift_id: "REC: shift.id"
+            - - 0
+              - 0
+              - day_index: 21
+                shift_id: "REC: shift.id"
+
+      - step: "Assert 21 detail lines"
+        action: "assert"
+        target: "pattern"
+        asserts:
+          detail_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 21
+
+  - name: "Attendance Shift Pattern Detail - Day Index Zero Rejected"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Range Check Pattern Zero"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Create detail with day_index 0 must be rejected"
+        action: "create"
+        model: "hr.attendance_shift_pattern.detail"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Day index must be between 1 and the pattern cycle length"
+        values:
+          pattern_id: "REC: pattern.id"
+          day_index: 0
+
+  - name: "Attendance Shift Pattern Detail - Day Index Exceeds Cycle Length Rejected"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Range Check Pattern Overflow"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Create detail with day_index 8 must be rejected"
+        action: "create"
+        model: "hr.attendance_shift_pattern.detail"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Day index must be between 1 and the pattern cycle length"
+        values:
+          pattern_id: "REC: pattern.id"
+          day_index: 8
+
+  - name: "Attendance Shift Pattern Detail - Duplicate Day Index Rejected"
+    steps:
+      - step: "Create pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Duplicate Check Pattern"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+
+      - step: "Create first detail line"
+        action: "create"
+        model: "hr.attendance_shift_pattern.detail"
+        save_as: "detail_1"
+        values:
+          pattern_id: "REC: pattern.id"
+          day_index: 1
+          shift_id: "REC: shift.id"
+
+      - step: "Create duplicate day_index must be rejected"
+        action: "create"
+        model: "hr.attendance_shift_pattern.detail"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Day index must be unique within a pattern"
+        values:
+          pattern_id: "REC: pattern.id"
+          day_index: 1
+          shift_id: "REC: shift.id"

--- a/ssi_timesheet_attendance_shift/tests/test_hr_attendance_shift_assignment.py
+++ b/ssi_timesheet_attendance_shift/tests/test_hr_attendance_shift_assignment.py
@@ -1,0 +1,16 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrAttendanceShiftAssignment(YamlTransactionCase):
+    """Cover CRUD and negative path of ``hr.attendance_shift_assignment``."""
+
+    def test_hr_attendance_shift_assignment(self):
+        """Run the ``hr.attendance_shift_assignment`` YAML scenarios."""
+        self.run_yaml_scenario("test_data_hr_attendance_shift_assignment.yaml")

--- a/ssi_timesheet_attendance_shift/tests/test_hr_attendance_shift_pattern.py
+++ b/ssi_timesheet_attendance_shift/tests/test_hr_attendance_shift_pattern.py
@@ -1,0 +1,53 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+from psycopg2 import IntegrityError
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestHrAttendanceShiftPattern(YamlTransactionCase):
+    """Cover CRUD, detail lines, and negative path of the pattern models.
+
+    Covers ``hr.attendance_shift_pattern`` and its ``.detail`` child.
+    """
+
+    def test_hr_attendance_shift_pattern(self):
+        """Run the ``hr.attendance_shift_pattern`` YAML scenarios."""
+        self.run_yaml_scenario("test_data_hr_attendance_shift_pattern.yaml")
+
+    @mute_logger("odoo.sql_db")
+    def test_unlink_pattern_in_use_is_restricted(self):
+        """Reject deleting a pattern still referenced by an assignment.
+
+        Pure Python — trigger P5 (L-22: ``psycopg2.IntegrityError``
+        raised by the ``pattern_id`` field's ``ondelete="restrict"``
+        is outside the 12 error types ``expect_error`` understands).
+        ``mute_logger("odoo.sql_db")`` silences the PostgreSQL ERROR
+        line this deliberately triggers; without it
+        ``oca_checklog_odoo`` fails the CI even though the test
+        itself passes.
+        """
+        pattern = self.env["hr.attendance_shift_pattern"].create(
+            {
+                "name": "In-Use Pattern",
+                "code": "/",
+                "cycle_length": 7,
+                "date_anchor": "2024-01-01",
+            }
+        )
+        employee = self.env["hr.employee"].create({"name": "In-Use Pattern Employee"})
+        self.env["hr.attendance_shift_assignment"].create(
+            {
+                "employee_id": employee.id,
+                "pattern_id": pattern.id,
+                "cycle_offset": 0,
+                "date_start": "2024-01-01",
+            }
+        )
+        with self.assertRaises(IntegrityError):
+            pattern.unlink()

--- a/ssi_timesheet_attendance_shift/tests/test_ui_hr_attendance_shift_assignment.py
+++ b/ssi_timesheet_attendance_shift/tests/test_ui_hr_attendance_shift_assignment.py
@@ -1,0 +1,96 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrAttendanceShiftAssignment(HttpSavepointCase):
+    """Tour tests for ``hr.attendance_shift_assignment`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed records visible to the browser session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group and seed data the tours reuse."""
+        super().setUpClass()
+        # Pre-Condition: the Attendance Shift Assignments menu is gated
+        # by the "Attendance Shift" configurator group. Without it the
+        # tour dies on its first step — the menu is never rendered for
+        # "admin".
+        cls.env.ref(
+            "ssi_timesheet_attendance_shift.attendance_shift_group"
+        ).sudo().write({"users": [(4, cls.env.ref("base.user_admin").id)]})
+        cls.pattern = cls.env["hr.attendance_shift_pattern"].create(
+            {
+                "name": "TOUR-ASSIGN-PATTERN",
+                "code": "/",
+                "cycle_length": 7,
+                "date_anchor": "2024-01-01",
+            }
+        )
+        cls.employee_create = cls.env["hr.employee"].create(
+            {"name": "TOUR-ASSIGN-CREATE-EMPLOYEE"}
+        )
+        cls.employee_edit = cls.env["hr.employee"].create(
+            {"name": "TOUR-ASSIGN-EDIT-EMPLOYEE"}
+        )
+        cls.assignment_edit = cls.env["hr.attendance_shift_assignment"].create(
+            {
+                "employee_id": cls.employee_edit.id,
+                "pattern_id": cls.pattern.id,
+                "cycle_offset": 0,
+                "date_start": "2024-01-01",
+            }
+        )
+        cls.employee_delete = cls.env["hr.employee"].create(
+            {"name": "TOUR-ASSIGN-DELETE-EMPLOYEE"}
+        )
+        cls.assignment_delete = cls.env["hr.attendance_shift_assignment"].create(
+            {
+                "employee_id": cls.employee_delete.id,
+                "pattern_id": cls.pattern.id,
+                "cycle_offset": 0,
+                "date_start": "2024-01-01",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.attendance_shift_assignment``.
+
+        IK: docs/hr_attendance_shift_assignment/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_assignment_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.attendance_shift_assignment``.
+
+        IK: docs/hr_attendance_shift_assignment/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_assignment_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.attendance_shift_assignment``.
+
+        IK: docs/hr_attendance_shift_assignment/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_assignment_delete",
+            login="admin",
+        )

--- a/ssi_timesheet_attendance_shift/tests/test_ui_hr_attendance_shift_pattern.py
+++ b/ssi_timesheet_attendance_shift/tests/test_ui_hr_attendance_shift_pattern.py
@@ -1,0 +1,87 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrAttendanceShiftPattern(HttpSavepointCase):
+    """Tour tests for the ``hr.attendance_shift_pattern`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed records visible to the browser session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group and seed data the tours reuse."""
+        super().setUpClass()
+        # Pre-Condition: the Attendance Shift Patterns menu is gated by
+        # the "Attendance Shift" configurator group. Without it the tour
+        # dies on its first step — the menu is never rendered for
+        # "admin".
+        cls.env.ref(
+            "ssi_timesheet_attendance_shift.attendance_shift_group"
+        ).sudo().write({"users": [(4, cls.env.ref("base.user_admin").id)]})
+        cls.shift = cls.env["hr.attendance_shift"].create(
+            {
+                "name": "TOUR-PATTERN-SHIFT",
+                "code": "/",
+                "hour_start": 7.0,
+                "duration": 8.0,
+            }
+        )
+        cls.pattern_edit = cls.env["hr.attendance_shift_pattern"].create(
+            {
+                "name": "TOUR-PATTERN-EDIT",
+                "code": "/",
+                "cycle_length": 7,
+                "date_anchor": "2024-01-01",
+            }
+        )
+        cls.pattern_delete = cls.env["hr.attendance_shift_pattern"].create(
+            {
+                "name": "TOUR-PATTERN-DELETE",
+                "code": "/",
+                "cycle_length": 7,
+                "date_anchor": "2024-01-01",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.attendance_shift_pattern``.
+
+        IK: docs/hr_attendance_shift_pattern/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_pattern_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.attendance_shift_pattern``.
+
+        IK: docs/hr_attendance_shift_pattern/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_pattern_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.attendance_shift_pattern``.
+
+        IK: docs/hr_attendance_shift_pattern/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_shift_hr_attendance_shift_pattern_delete",
+            login="admin",
+        )

--- a/ssi_timesheet_attendance_shift/views/hr_attendance_shift_assignment_views.xml
+++ b/ssi_timesheet_attendance_shift/views/hr_attendance_shift_assignment_views.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_attendance_shift_assignment_view_search" model="ir.ui.view">
+    <field name="name">hr.attendance_shift_assignment - search</field>
+    <field name="model">hr.attendance_shift_assignment</field>
+    <field name="arch" type="xml">
+        <search>
+            <field name="employee_id" />
+            <field name="pattern_id" />
+            <group name="group_by" string="Group By">
+                <filter
+                        name="group_by_employee_id"
+                        string="Employee"
+                        context="{'group_by': 'employee_id'}"
+                    />
+                <filter
+                        name="group_by_pattern_id"
+                        string="Pattern"
+                        context="{'group_by': 'pattern_id'}"
+                    />
+            </group>
+        </search>
+    </field>
+</record>
+
+<record id="hr_attendance_shift_assignment_view_tree" model="ir.ui.view">
+    <field name="name">hr.attendance_shift_assignment - tree</field>
+    <field name="model">hr.attendance_shift_assignment</field>
+    <field name="arch" type="xml">
+        <tree>
+            <field name="employee_id" />
+            <field name="pattern_id" />
+            <field name="cycle_offset" />
+            <field name="date_start" />
+            <field name="date_end" />
+        </tree>
+    </field>
+</record>
+
+<record id="hr_attendance_shift_assignment_view_form" model="ir.ui.view">
+    <field name="name">hr.attendance_shift_assignment - form</field>
+    <field name="model">hr.attendance_shift_assignment</field>
+    <field name="arch" type="xml">
+        <form>
+            <sheet>
+                <group name="group_1">
+                    <field name="employee_id" />
+                    <field name="pattern_id" />
+                    <field name="cycle_offset" />
+                    <field name="date_start" />
+                    <field name="date_end" />
+                </group>
+            </sheet>
+        </form>
+    </field>
+</record>
+
+<record id="hr_attendance_shift_assignment_action" model="ir.actions.act_window">
+    <field name="name">Attendance Shift Assignments</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">hr.attendance_shift_assignment</field>
+    <field name="view_mode">tree,form</field>
+</record>
+
+<menuitem
+        id="hr_attendance_shift_assignment_menu"
+        name="Attendance Shift Assignments"
+        parent="ssi_timesheet_attendance.menu_hr_attendance_configuration"
+        groups="attendance_shift_group"
+        action="hr_attendance_shift_assignment_action"
+        sequence="5"
+    />
+
+</odoo>

--- a/ssi_timesheet_attendance_shift/views/hr_attendance_shift_pattern_views.xml
+++ b/ssi_timesheet_attendance_shift/views/hr_attendance_shift_pattern_views.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_attendance_shift_pattern_view_search" model="ir.ui.view">
+    <field name="name">hr.attendance_shift_pattern - search</field>
+    <field name="model">hr.attendance_shift_pattern</field>
+    <field
+            name="inherit_id"
+            ref="ssi_master_data_mixin.mixin_master_data_view_search"
+        />
+    <field name="mode">primary</field>
+    <field name="arch" type="xml">
+        <data />
+    </field>
+</record>
+
+<record id="hr_attendance_shift_pattern_view_tree" model="ir.ui.view">
+    <field name="name">hr.attendance_shift_pattern - tree</field>
+    <field name="model">hr.attendance_shift_pattern</field>
+    <field name="inherit_id" ref="ssi_master_data_mixin.mixin_master_data_view_tree" />
+    <field name="mode">primary</field>
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="cycle_length" />
+                <field name="date_anchor" />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="hr_attendance_shift_pattern_view_form" model="ir.ui.view">
+    <field name="name">hr.attendance_shift_pattern - form</field>
+    <field name="model">hr.attendance_shift_pattern</field>
+    <field name="inherit_id" ref="ssi_master_data_mixin.mixin_master_data_view_form" />
+    <field name="mode">primary</field>
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='active']" position="after">
+                <field name="cycle_length" />
+                <field name="date_anchor" />
+            </xpath>
+            <xpath expr="//notebook/page[@name='note']" position="before">
+                <page name="cycle_days" string="Cycle Days">
+                    <field name="detail_ids">
+                        <tree editable="bottom">
+                            <field name="day_index" />
+                            <field name="shift_id" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="hr_attendance_shift_pattern_action" model="ir.actions.act_window">
+    <field name="name">Attendance Shift Patterns</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">hr.attendance_shift_pattern</field>
+    <field name="view_mode">tree,form</field>
+</record>
+
+<menuitem
+        id="hr_attendance_shift_pattern_menu"
+        name="Attendance Shift Patterns"
+        parent="ssi_timesheet_attendance.menu_hr_attendance_configuration"
+        groups="attendance_shift_group"
+        action="hr_attendance_shift_pattern_action"
+        sequence="4"
+    />
+
+</odoo>

--- a/ssi_timesheet_attendance_shift/views/ssi_timesheet_attendance_shift_assets.xml
+++ b/ssi_timesheet_attendance_shift/views/ssi_timesheet_attendance_shift_assets.xml
@@ -13,6 +13,14 @@
                 type="text/javascript"
                 src="/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_tour.js"
             />
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_pattern_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet_attendance_shift/static/tests/tours/hr_attendance_shift_assignment_tour.js"
+            />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
## Ringkasan

- Tambah model `hr.attendance_shift_pattern` (pola rotasi shift siklus berpanjang bebas, berpatokan pada `date_anchor` global) beserta `hr.attendance_shift_pattern.detail` (baris hari dalam siklus, `shift_id` kosong berarti hari libur).
- Tambah model `hr.attendance_shift_assignment` (penugasan pola ke karyawan/regu dengan `cycle_offset` sebagai pembeda regu dan masa berlaku `date_start`/`date_end`).
- Tambah security (grup `attendance_shift_group` yang sudah ada), view, dan menu untuk kedua model baru di bawah Attendance Configuration.
- Tambah unit test skenario YAML (`odoo-yaml-test`) untuk CRUD, baris detail, dan negative path kedua model, plus satu test Python murni (P5/L-22) untuk `ondelete="restrict"` saat pola masih dipakai penugasan.
- Tambah Instruksi Kerja (create/edit/delete) dan tour UI pasangannya untuk kedua model baru.

## Test plan

- [x] CI: pre-commit (lint) hijau
- [ ] CI: unit test YAML hijau
- [ ] CI: tour UI hijau

Closes #105