### PR TITLE
[UPD] ssi_timesheet_attendance_shift: bangkitkan attendance schedule dari shift roster

### DIFF
--- a/ssi_timesheet_attendance_shift/__manifest__.py
+++ b/ssi_timesheet_attendance_shift/__manifest__.py
@@ -27,6 +27,8 @@
         "views/hr_attendance_shift_views.xml",
         "views/hr_attendance_shift_pattern_views.xml",
         "views/hr_attendance_shift_assignment_views.xml",
+        "views/hr_timesheet_views.xml",
+        "views/hr_employee_views.xml",
         "views/ssi_timesheet_attendance_shift_assets.xml",
     ],
 }

--- a/ssi_timesheet_attendance_shift/models/__init__.py
+++ b/ssi_timesheet_attendance_shift/models/__init__.py
@@ -6,3 +6,6 @@ from . import hr_attendance_shift
 from . import hr_attendance_shift_pattern
 from . import hr_attendance_shift_pattern_detail
 from . import hr_attendance_shift_assignment
+from . import hr_timesheet
+from . import hr_employee
+from . import hr_timesheet_attendance_schedule

--- a/ssi_timesheet_attendance_shift/models/hr_employee.py
+++ b/ssi_timesheet_attendance_shift/models/hr_employee.py
@@ -1,0 +1,33 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrEmployeeBase(models.AbstractModel):
+    """
+    Adds a default attendance schedule source to the employee.
+    ``schedule_source`` is copied onto a new ``hr.timesheet`` of this
+    employee (via ``onchange_schedule_source``) so each employee's
+    usual generation mode does not have to be re-selected on every
+    timesheet.
+    """
+
+    _inherit = "hr.employee.base"
+    _name = "hr.employee.base"
+
+    schedule_source = fields.Selection(
+        string="Schedule Source",
+        selection=[
+            ("working_schedule", "Working Schedule"),
+            ("shift", "Shift Roster"),
+        ],
+        required=True,
+        default="working_schedule",
+        help=(
+            "Default attendance schedule source copied onto a new "
+            "timesheet's own Schedule Source when this employee is "
+            "set on it."
+        ),
+    )

--- a/ssi_timesheet_attendance_shift/models/hr_timesheet.py
+++ b/ssi_timesheet_attendance_shift/models/hr_timesheet.py
@@ -1,0 +1,190 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime, timedelta
+
+import pytz
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class HrTimesheet(models.Model):
+    """
+    Adds a shift-roster based schedule generator to ``hr.timesheet``.
+    Lets a timesheet pick between the pre-existing working-schedule
+    generation (``resource.calendar``-based, untouched by this
+    module) and a shift-roster generation that walks the employee's
+    ``hr.attendance_shift_assignment`` day by day and produces one
+    schedule line per shift, able to cross midnight as a single
+    block instead of being split at day boundaries.
+    """
+
+    _inherit = "hr.timesheet"
+
+    schedule_source = fields.Selection(
+        string="Schedule Source",
+        selection=[
+            ("working_schedule", "Working Schedule"),
+            ("shift", "Shift Roster"),
+        ],
+        required=True,
+        default="working_schedule",
+        readonly=True,
+        states={
+            "draft": [("readonly", False)],
+        },
+        help=(
+            "Where this timesheet's attendance schedule "
+            "(``schedule_ids``) is generated from. Working Schedule "
+            "keeps the pre-existing resource.calendar-based "
+            "generation; Shift Roster generates one schedule line "
+            "per shift from the employee's rotation assignment "
+            "instead."
+        ),
+    )
+    working_schedule_id = fields.Many2one(
+        required=False,
+    )
+
+    @api.constrains("schedule_source", "working_schedule_id")
+    def _check_working_schedule_id_required(self):
+        """Reject a missing Working Schedule when it is still needed.
+
+        :raises ValidationError: when ``schedule_source`` is
+            ``working_schedule`` and ``working_schedule_id`` is empty
+        """
+        for record in self.sudo():
+            if not record._check_working_schedule_id_required_condition():
+                error_message = (
+                    "Working schedule is required when schedule "
+                    "source is working schedule"
+                )
+                raise ValidationError(_(error_message))
+
+    def _check_working_schedule_id_required_condition(self):
+        """Tell whether Working Schedule is set when it is required.
+
+        Reproduces, unchanged, the obligation the field used to
+        enforce unconditionally as ``required=True`` — now scoped to
+        the ``working_schedule`` source only.
+
+        Extension point: override to relax or tighten the condition.
+
+        :return: True when valid; never raises
+        """
+        self.ensure_one()
+        if self.schedule_source == "working_schedule":
+            return bool(self.working_schedule_id)
+        return True
+
+    @api.onchange("employee_id")
+    def onchange_schedule_source(self):
+        self.schedule_source = "working_schedule"
+        if self.employee_id:
+            self.schedule_source = self.employee_id.schedule_source
+
+    def _get_schedule_data(self):
+        """Dispatch schedule generation by ``schedule_source``.
+
+        Falls through to ``super()`` untouched when the source is
+        not ``shift`` — the working-schedule branch is never
+        modified by this module. When the source is ``shift``, walks
+        every calendar date from ``date_start`` to ``date_end``
+        (inclusive) and, for each date, resolves the shift owned by
+        that date via ``_get_shift_for_date``. A shift is owned by
+        its *start* date only: the generated line's end may extend
+        past ``date_end`` without being clipped, and a shift starting
+        on the period's last day is booked whole into this period —
+        the next period will not regenerate it.
+
+        :return: list of ``(0, 0, values)`` tuples for
+            ``schedule_ids``
+        """
+        self.ensure_one()
+        if self.schedule_source != "shift":
+            return super(HrTimesheet, self)._get_schedule_data()
+        res = []
+        if not (self.employee_id and self.date_start and self.date_end):
+            return res
+        obj_public_holiday = self.env["base.public.holiday"]
+        tz = self._get_shift_timezone()
+        num_days = (self.date_end - self.date_start).days
+        for offset in range(num_days + 1):
+            date_check = self.date_start + timedelta(days=offset)
+            shift = self._get_shift_for_date(self.employee_id, date_check)
+            if not shift:
+                continue
+            if obj_public_holiday.is_public_holiday(date_check, self.employee_id.id):
+                continue
+            naive_start = datetime.combine(date_check, datetime.min.time()) + timedelta(
+                hours=shift.hour_start
+            )
+            start_dt = tz.localize(naive_start)
+            stop_dt = start_dt + timedelta(hours=shift.duration)
+            schedule_data = self._prepare_schedule_data(start_dt, stop_dt)
+            schedule_data["shift_id"] = shift.id
+            res.append((0, 0, schedule_data))
+        return res
+
+    def _get_shift_timezone(self):
+        """Resolve the timezone used to localize shift start times.
+
+        Falls back in order: the employee's resource timezone, the
+        employee's company calendar timezone, the current user's
+        timezone, then UTC. The result is always applied with
+        ``pytz``'s ``localize()`` — never
+        ``datetime.replace(tzinfo=...)``, which would produce a
+        historical LMT offset instead of the real UTC offset.
+
+        :return: a ``pytz`` timezone object
+        """
+        self.ensure_one()
+        tz_name = (
+            self.employee_id.resource_id.tz
+            or self.employee_id.company_id.resource_calendar_id.tz
+            or self.env.user.tz
+            or "UTC"
+        )
+        return pytz.timezone(tz_name)
+
+    def _get_shift_for_date(self, employee, date_check):
+        """Resolve the shift an employee's roster assigns on a date.
+
+        Searches ``hr.attendance_shift_assignment`` for the
+        assignment covering ``date_check``, then resolves the
+        day-in-cycle against its pattern to read the matching detail
+        line's shift. This is the official override point for a
+        separate roster-resolution module: extend this method,
+        never re-implement pattern resolution inside
+        ``_get_schedule_data``.
+
+        :param employee: ``hr.employee`` record the shift is looked
+            up for
+        :param date_check: ``datetime.date`` the shift is looked up
+            on
+        :return: ``hr.attendance_shift`` recordset, empty when the
+            employee has no active assignment on ``date_check`` or
+            the matching cycle day is a day off
+        """
+        self.ensure_one()
+        obj_assignment = self.env["hr.attendance_shift_assignment"]
+        domain = [
+            ("employee_id", "=", employee.id),
+            ("date_start", "<=", date_check),
+            "|",
+            ("date_end", ">=", date_check),
+            ("date_end", "=", False),
+        ]
+        assignment = obj_assignment.search(domain, limit=1)
+        if not assignment:
+            return self.env["hr.attendance_shift"]
+        pattern = assignment.pattern_id
+        day_in_cycle = (
+            (date_check - pattern.date_anchor).days - assignment.cycle_offset
+        ) % pattern.cycle_length + 1
+        detail = pattern.detail_ids.filtered(lambda d: d.day_index == day_in_cycle)
+        if not detail or not detail.shift_id:
+            return self.env["hr.attendance_shift"]
+        return detail.shift_id

--- a/ssi_timesheet_attendance_shift/models/hr_timesheet_attendance_schedule.py
+++ b/ssi_timesheet_attendance_shift/models/hr_timesheet_attendance_schedule.py
@@ -1,0 +1,29 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrTimesheetAttendanceSchedule(models.Model):
+    """
+    Adds the originating shift to a generated attendance schedule.
+    Populated by the shift schedule generator
+    (``hr.timesheet._get_schedule_data``) so that downstream modules
+    — attendance matching, tolerance lookup — can read back which
+    ``hr.attendance_shift`` a schedule line was generated from.
+    """
+
+    _inherit = "hr.timesheet_attendance_schedule"
+
+    shift_id = fields.Many2one(
+        string="Shift",
+        comodel_name="hr.attendance_shift",
+        ondelete="restrict",
+        help=(
+            "Shift this schedule line was generated from, when the "
+            "owning timesheet's Schedule Source is Shift Roster. "
+            "Left empty for schedule lines generated from a Working "
+            "Schedule."
+        ),
+    )

--- a/ssi_timesheet_attendance_shift/tests/__init__.py
+++ b/ssi_timesheet_attendance_shift/tests/__init__.py
@@ -5,6 +5,7 @@
 from . import test_hr_attendance_shift
 from . import test_hr_attendance_shift_pattern
 from . import test_hr_attendance_shift_assignment
+from . import test_hr_timesheet_shift_schedule
 from . import test_ui_hr_attendance_shift
 from . import test_ui_hr_attendance_shift_pattern
 from . import test_ui_hr_attendance_shift_assignment

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_shift_schedule.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_shift_schedule.yaml
@@ -1,0 +1,724 @@
+scenarios:
+  - name: "Shift Schedule - One Week Pattern Generates Expected Records"
+    steps:
+      - step: "Create night shift crossing midnight"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "night_shift"
+        values:
+          name: "Night Shift"
+          code: "/"
+          hour_start: 18.0
+          duration: 12.0
+
+      - step: "Create day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "day_shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create 7-day pattern: 1 night, 4 day, 2 off"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Week Pattern"
+          code: "/"
+          cycle_length: 7
+          date_anchor: 2024-01-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: night_shift.id"
+            - - 0
+              - 0
+              - day_index: 2
+                shift_id: "REC: day_shift.id"
+            - - 0
+              - 0
+              - day_index: 3
+                shift_id: "REC: day_shift.id"
+            - - 0
+              - 0
+              - day_index: 4
+                shift_id: "REC: day_shift.id"
+            - - 0
+              - 0
+              - day_index: 5
+                shift_id: "REC: day_shift.id"
+            - - 0
+              - 0
+              - day_index: 6
+            - - 0
+              - 0
+              - day_index: 7
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Week Pattern Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the pattern from cycle day 1"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-01
+
+      - step: "Create shift-roster timesheet for the week"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-14
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Assert 5 schedule lines generated (1 night + 4 day)"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "all_schedules"
+        expect_count: 5
+
+      - step: "Fetch the night shift schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"], ["date", "=", 2024-01-08]]
+        save_as: "night_schedule"
+        limit: 1
+
+      - step: "Assert night shift line hours, date and shift"
+        action: "assert"
+        target: "night_schedule"
+        asserts:
+          schedule_work_hour:
+            type: "value"
+            expected: 12.0
+          date:
+            type: "value"
+            expected: 2024-01-08
+          shift_id:
+            type: "m2o"
+            expected: "REC: night_shift"
+
+      - step: "Assert a day-off cycle day generates no schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"], ["date", "=", 2024-01-13]]
+        save_as: "off_day_schedule"
+        expect_count: 0
+
+  - name: "Shift Schedule - Working Schedule Source Single-Slot Regression"
+    steps:
+      - step: "Create single-slot Mon-Fri calendar"
+        action: "create"
+        model: "resource.calendar"
+        save_as: "calendar"
+        values:
+          name: "Single Slot Calendar"
+          tz: "UTC"
+          attendance_ids:
+            - - 0
+              - 0
+              - name: "Monday"
+                dayofweek: "0"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Tuesday"
+                dayofweek: "1"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Wednesday"
+                dayofweek: "2"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Thursday"
+                dayofweek: "3"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Friday"
+                dayofweek: "4"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+
+      - step: "Create employee for the single-slot regression"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Single Slot Employee"
+          tz: "UTC"
+
+      - step: "Create working-schedule timesheet for the week"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-01-08
+          date_end: 2024-01-14
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Assert one schedule line per working day (5)"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "all_schedules"
+        expect_count: 5
+
+  - name: "Shift Schedule - Working Schedule Multi-Slot Per Day Regression"
+    steps:
+      - step: "Create two-slot-per-day Mon-Fri calendar"
+        action: "create"
+        model: "resource.calendar"
+        save_as: "calendar"
+        values:
+          name: "Multi Slot Calendar"
+          tz: "UTC"
+          attendance_ids:
+            - - 0
+              - 0
+              - name: "Monday Morning"
+                dayofweek: "0"
+                hour_from: 8.0
+                hour_to: 12.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Monday Afternoon"
+                dayofweek: "0"
+                hour_from: 13.0
+                hour_to: 17.0
+                day_period: "afternoon"
+            - - 0
+              - 0
+              - name: "Tuesday Morning"
+                dayofweek: "1"
+                hour_from: 8.0
+                hour_to: 12.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Tuesday Afternoon"
+                dayofweek: "1"
+                hour_from: 13.0
+                hour_to: 17.0
+                day_period: "afternoon"
+            - - 0
+              - 0
+              - name: "Wednesday Morning"
+                dayofweek: "2"
+                hour_from: 8.0
+                hour_to: 12.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Wednesday Afternoon"
+                dayofweek: "2"
+                hour_from: 13.0
+                hour_to: 17.0
+                day_period: "afternoon"
+            - - 0
+              - 0
+              - name: "Thursday Morning"
+                dayofweek: "3"
+                hour_from: 8.0
+                hour_to: 12.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Thursday Afternoon"
+                dayofweek: "3"
+                hour_from: 13.0
+                hour_to: 17.0
+                day_period: "afternoon"
+            - - 0
+              - 0
+              - name: "Friday Morning"
+                dayofweek: "4"
+                hour_from: 8.0
+                hour_to: 12.0
+                day_period: "morning"
+            - - 0
+              - 0
+              - name: "Friday Afternoon"
+                dayofweek: "4"
+                hour_from: 13.0
+                hour_to: 17.0
+                day_period: "afternoon"
+
+      - step: "Create employee for the multi-slot regression"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Multi Slot Employee"
+          tz: "UTC"
+
+      - step: "Create working-schedule timesheet for the week"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-01-08
+          date_end: 2024-01-14
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Assert two schedule lines per working day (10), super() untouched"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "all_schedules"
+        expect_count: 10
+
+      - step: "Fetch Monday morning session"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain:
+          [
+            ["sheet_id", "=", "REC: timesheet.id"],
+            ["date", "=", 2024-01-08],
+            ["schedule_work_hour", "=", 4.0],
+          ]
+        save_as: "monday_sessions"
+        expect_count: 2
+
+  - name: "Shift Schedule - Working Schedule With ID Saves Successfully"
+    steps:
+      - step: "Create default calendar"
+        action: "create"
+        model: "resource.calendar"
+        save_as: "calendar"
+        values:
+          name: "Default Calendar"
+          tz: "UTC"
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "With Schedule Employee"
+          tz: "UTC"
+
+      - step: "Create timesheet with working schedule filled"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-06-03
+          date_end: 2024-06-09
+
+      - step: "Assert timesheet saved"
+        action: "assert"
+        target: "timesheet"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Shift Schedule - Working Schedule Without ID Rejected"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Without Schedule Employee"
+          tz: "UTC"
+
+      - step: "Create timesheet without working schedule must be rejected"
+        action: "create"
+        model: "hr.timesheet"
+        expect_error:
+          type: "ValidationError"
+          message_contains:
+            "Working schedule is required when schedule source is working schedule"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          date_start: 2024-06-10
+          date_end: 2024-06-16
+
+  - name: "Shift Schedule - Assignment Switch Mid-Period Changes Shift"
+    steps:
+      - step: "Create morning shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift_morning"
+        values:
+          name: "Morning Shift"
+          code: "/"
+          hour_start: 6.0
+          duration: 6.0
+
+      - step: "Create evening shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift_evening"
+        values:
+          name: "Evening Shift"
+          code: "/"
+          hour_start: 14.0
+          duration: 6.0
+
+      - step: "Create always-morning pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern_morning"
+        values:
+          name: "Always Morning Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-02-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift_morning.id"
+
+      - step: "Create always-evening pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern_evening"
+        values:
+          name: "Always Evening Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-02-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift_evening.id"
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Switching Crew Employee"
+          tz: "UTC"
+
+      - step: "Assign morning pattern for the first half"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment_morning"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern_morning.id"
+          cycle_offset: 0
+          date_start: 2024-02-01
+          date_end: 2024-02-15
+
+      - step: "Assign evening pattern from the switch date"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment_evening"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern_evening.id"
+          cycle_offset: 0
+          date_start: 2024-02-16
+
+      - step: "Create timesheet spanning the switch date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-02-14
+          date_end: 2024-02-17
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Fetch schedule line before the switch"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"], ["date", "=", 2024-02-14]]
+        save_as: "schedule_before"
+        limit: 1
+
+      - step: "Assert shift before the switch is the morning shift"
+        action: "assert"
+        target: "schedule_before"
+        asserts:
+          shift_id:
+            type: "m2o"
+            expected: "REC: shift_morning"
+
+      - step: "Fetch schedule line on the switch date"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"], ["date", "=", 2024-02-16]]
+        save_as: "schedule_after"
+        limit: 1
+
+      - step: "Assert shift on the switch date is the evening shift"
+        action: "assert"
+        target: "schedule_after"
+        asserts:
+          shift_id:
+            type: "m2o"
+            expected: "REC: shift_evening"
+
+  - name: "Shift Schedule - Employee Without Assignment Generates No Records"
+    steps:
+      - step: "Create employee without any assignment"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Unassigned Employee"
+          tz: "UTC"
+
+      - step: "Create shift-roster timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-03-18
+          date_end: 2024-03-24
+
+      - step: "Generate the schedule without error"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Assert no schedule line was generated"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "all_schedules"
+        expect_count: 0
+
+  - name: "Shift Schedule - Shift Starting On Period's Last Day Not Regenerated"
+    steps:
+      - step: "Create alternating shift/off shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "cutoff_shift"
+        values:
+          name: "Cutoff Night Shift"
+          code: "/"
+          hour_start: 18.0
+          duration: 12.0
+
+      - step: "Create alternating cutoff pattern anchored on the cutoff date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "cutoff_pattern"
+        values:
+          name: "Cutoff Pattern"
+          code: "/"
+          cycle_length: 2
+          date_anchor: 2024-04-07
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: cutoff_shift.id"
+            - - 0
+              - 0
+              - day_index: 2
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Cutoff Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the cutoff pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: cutoff_pattern.id"
+          cycle_offset: 0
+          date_start: 2024-04-01
+
+      - step: "Create the first period ending on the cutoff date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "period_one"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-04-01
+          date_end: 2024-04-07
+
+      - step: "Generate the schedule for the first period"
+        action: "call"
+        target: "period_one"
+        method: "action_compute_schedule"
+
+      - step: "Assert the cutoff-day shift is booked into the first period"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: period_one.id"], ["date", "=", 2024-04-07]]
+        save_as: "cutoff_schedule"
+        expect_count: 1
+
+      - step: "Create the second period starting the day after the cutoff"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "period_two"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-04-08
+          date_end: 2024-04-14
+
+      - step: "Generate the schedule for the second period"
+        action: "call"
+        target: "period_two"
+        method: "action_compute_schedule"
+
+      - step: "Assert the second period does not regenerate the cutoff shift"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: period_two.id"], ["date", "=", 2024-04-08]]
+        save_as: "not_regenerated_schedule"
+        expect_count: 0
+
+  - name: "Shift Schedule - Public Holiday On Shift Start Date Skips Generation"
+    steps:
+      - step: "Create daily shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "daily_shift"
+        values:
+          name: "Holiday Test Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create every-day pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "daily_pattern"
+        values:
+          name: "Daily Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-05-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: daily_shift.id"
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Holiday Test Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the daily pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: daily_pattern.id"
+          cycle_offset: 0
+          date_start: 2024-05-01
+
+      - step: "Declare a national public holiday in the middle of the week"
+        action: "create"
+        model: "base.public.holiday"
+        save_as: "holiday_year"
+        values:
+          year: 2024
+          line_ids:
+            - - 0
+              - 0
+              - name: "Test National Holiday"
+                date: 2024-05-15
+
+      - step: "Create shift-roster timesheet covering the holiday"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-05-13
+          date_end: 2024-05-17
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Assert the holiday date has no schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"], ["date", "=", 2024-05-15]]
+        save_as: "holiday_schedule"
+        expect_count: 0
+
+      - step: "Assert the other 4 working days still generated a line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "all_schedules"
+        expect_count: 4

--- a/ssi_timesheet_attendance_shift/tests/test_hr_timesheet_shift_schedule.py
+++ b/ssi_timesheet_attendance_shift/tests/test_hr_timesheet_shift_schedule.py
@@ -1,0 +1,79 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrTimesheetShiftSchedule(YamlTransactionCase):
+    """Cover shift-roster schedule generation on ``hr.timesheet``."""
+
+    def test_hr_timesheet_shift_schedule(self):
+        """Run the shift-roster schedule generator YAML scenarios."""
+        self.run_yaml_scenario("test_data_hr_timesheet_shift_schedule.yaml")
+
+    def test_get_shift_for_date_returns_matching_shift(self):
+        """Assert the recordset ``_get_shift_for_date`` returns.
+
+        Pure Python — trigger P1 (the value under test is the
+        method's return value, not a side effect it leaves on a
+        stored record), grounded in L-01 (``action: call`` discards
+        whatever a method returns) and L-02 (the actual side of every
+        YAML assert is always a dotted ``getattr`` on a record
+        already sitting in the registry, so a bare recordset that is
+        never stored anywhere cannot be compared at all).
+        """
+        obj_shift = self.env["hr.attendance_shift"]
+        obj_pattern = self.env["hr.attendance_shift_pattern"]
+        obj_assignment = self.env["hr.attendance_shift_assignment"]
+        obj_employee = self.env["hr.employee"]
+        obj_timesheet = self.env["hr.timesheet"]
+
+        day_shift = obj_shift.create(
+            {
+                "name": "P1 Day Shift",
+                "code": "/",
+                "hour_start": 8.0,
+                "duration": 8.0,
+            }
+        )
+        pattern = obj_pattern.create(
+            {
+                "name": "P1 Pattern",
+                "code": "/",
+                "cycle_length": 2,
+                "date_anchor": date(2024, 5, 1),
+                "detail_ids": [
+                    (0, 0, {"day_index": 1, "shift_id": day_shift.id}),
+                    (0, 0, {"day_index": 2}),
+                ],
+            }
+        )
+        employee = obj_employee.create({"name": "P1 Employee", "tz": "UTC"})
+        employee_no_assignment = obj_employee.create(
+            {"name": "P1 Employee Without Assignment", "tz": "UTC"}
+        )
+        obj_assignment.create(
+            {
+                "employee_id": employee.id,
+                "pattern_id": pattern.id,
+                "cycle_offset": 0,
+                "date_start": date(2024, 5, 1),
+            }
+        )
+        timesheet = obj_timesheet.new({})
+
+        shift_on_day = timesheet._get_shift_for_date(employee, date(2024, 5, 1))
+        shift_on_off_day = timesheet._get_shift_for_date(employee, date(2024, 5, 2))
+        shift_without_assignment = timesheet._get_shift_for_date(
+            employee_no_assignment, date(2024, 5, 1)
+        )
+
+        self.assertEqual(shift_on_day, day_shift)
+        self.assertFalse(shift_on_off_day)
+        self.assertFalse(shift_without_assignment)

--- a/ssi_timesheet_attendance_shift/views/hr_employee_views.xml
+++ b/ssi_timesheet_attendance_shift/views/hr_employee_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_employee_view_shift_form" model="ir.ui.view">
+    <field name="name">hr.employee shift form</field>
+    <field name="model">hr.employee</field>
+    <field name="inherit_id" ref="ssi_timesheet_attendance.hr_employee_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='attendance_status']" position="after">
+                <field name="schedule_source" />
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>

--- a/ssi_timesheet_attendance_shift/views/hr_timesheet_views.xml
+++ b/ssi_timesheet_attendance_shift/views/hr_timesheet_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_timesheet_view_shift_form" model="ir.ui.view">
+    <field name="name">hr.timesheet shift form</field>
+    <field name="model">hr.timesheet</field>
+    <field
+            name="inherit_id"
+            ref="ssi_timesheet_attendance.hr_timesheet_view_attendance_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='working_schedule_id']" position="before">
+                <field name="schedule_source" />
+            </xpath>
+            <xpath
+                    expr="//field[@name='schedule_ids']/tree/field[@name='date']"
+                    position="after"
+                >
+                <field name="shift_id" />
+            </xpath>
+            <xpath
+                    expr="//field[@name='schedule_ids']/form//group[@name='schedule_1_1']/field[@name='date']"
+                    position="after"
+                >
+                <field name="shift_id" />
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan kemampuan `hr.timesheet` untuk membangkitkan attendance schedule dari shift roster (`hr.attendance_shift_pattern` + `hr.attendance_shift_assignment`) sebagai alternatif dari working schedule (`resource.calendar`) yang sudah ada.

* Field `schedule_source` (Selection `working_schedule`/`shift`, required, default `working_schedule`) ditambahkan pada `hr.timesheet` dan `hr.employee.base`.
* `working_schedule_id` dilonggarkan menjadi tidak required, digantikan `@api.constrains` yang mewajibkannya hanya bila `schedule_source = working_schedule` (mereproduksi kewajiban lama persis, tanpa syarat tambahan).
* Field `shift_id` (Many2one ke `hr.attendance_shift`, `ondelete=restrict`) ditambahkan pada `hr.timesheet_attendance_schedule`.
* Override `_get_schedule_data()`: jatuh ke `super()` tanpa perubahan bila bukan jalur shift; bila jalur shift, menelusuri tiap tanggal `date_start`..`date_end` dan membangkitkan satu record jadwal per shift (boleh melewati tengah malam sebagai satu blok utuh).
* Aturan cut-off: shift dimiliki oleh tanggal MULAI-nya — shift yang mulai di hari terakhir periode dibukukan penuh ke periode itu, periode berikutnya tidak membangkitkannya ulang.
* Method `_get_shift_for_date(employee, date_check)` disediakan sebagai titik override resmi bagi modul roster override terpisah.
* Hari libur nasional dievaluasi sekali pada tanggal mulai shift (`base.public.holiday.is_public_holiday`).
* Timezone konversi berurutan: `employee.resource_id.tz` → tz kalender perusahaan → `env.user.tz`, selalu memakai `localize()` pytz (bukan `datetime.replace(tzinfo=...)`).
* **Non-regresi:** seluruh perubahan ditulis sebagai `_inherit` di `ssi_timesheet_attendance_shift`. Berkas modul `ssi_timesheet_attendance` (termasuk `models/hr_timesheet.py`) tidak diubah satu baris pun.

## Unit Test

Skenario `odoo-yaml-test` mencakup: pembangkitan jadwal shift satu minggu (termasuk shift malam lintas tengah malam), regresi jalur `working_schedule` (kalender single-slot maupun multi-slot per hari, membuktikan cabang `super()` tidak tersentuh), constraint `working_schedule_id`, pergantian penugasan di tengah periode, hari tanpa shift/penugasan, cut-off shift di hari terakhir periode, dan hari libur nasional pada tanggal mulai shift. Ditambah satu test Python murni (P1/L-01/L-02) untuk nilai balik `_get_shift_for_date()`.

## Migrasi data

`schedule_source` diisi otomatis oleh `_init_column` Odoo (default kolom di-backfill ke seluruh baris lama saat kolom baru dibuat) — tidak diperlukan skrip migrasi tambahan.

Closes #106