### PR TITLE
[UPD] ssi_timesheet_attendance_shift - cocokkan kehadiran lintas hari ke jadwal shift

### DIFF
--- a/ssi_timesheet_attendance_shift/models/__init__.py
+++ b/ssi_timesheet_attendance_shift/models/__init__.py
@@ -9,3 +9,4 @@ from . import hr_attendance_shift_assignment
 from . import hr_timesheet
 from . import hr_employee
 from . import hr_timesheet_attendance_schedule
+from . import hr_timesheet_attendance

--- a/ssi_timesheet_attendance_shift/models/hr_timesheet.py
+++ b/ssi_timesheet_attendance_shift/models/hr_timesheet.py
@@ -149,6 +149,38 @@ class HrTimesheet(models.Model):
         )
         return pytz.timezone(tz_name)
 
+    def _sign_out(self, reason=False):
+        """Close a cross-day shift attendance, skipping the anomaly path.
+
+        Delegates unchanged to ``super()`` unless the employee's open
+        attendance (``latest_attendance_id``) is pinned to a schedule
+        line generated from a shift whose ``cross_day`` is True. For
+        such an attendance, a check-out landing on the next calendar
+        day is expected, not an anomaly: the date-mismatch comparison
+        and ``checkout_buffer`` branch inherited from
+        ``ssi_timesheet_attendance`` — which would otherwise leave
+        the attendance open and create a new one — are skipped
+        entirely, and the open attendance is closed directly. Every
+        other case, including shift attendances that do not cross a
+        day, keeps going through the inherited anomaly branch
+        unchanged.
+
+        :param reason: ``hr.attendance_reason`` record for the
+            check-out, or a falsy value
+        :return: nothing
+        """
+        self.ensure_one()
+        latest_attendance_id = self.employee_id.latest_attendance_id
+        if (
+            latest_attendance_id
+            and latest_attendance_id._is_cross_day_shift_attendance()
+        ):
+            latest_attendance_id.write(
+                self._prepare_attendance_data_update(reason=reason)
+            )
+            return
+        super(HrTimesheet, self)._sign_out(reason=reason)
+
     def _get_shift_for_date(self, employee, date_check):
         """Resolve the shift an employee's roster assigns on a date.
 

--- a/ssi_timesheet_attendance_shift/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance_shift/models/hr_timesheet_attendance.py
@@ -1,0 +1,91 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class HrTimesheetAttendance(models.Model):
+    """Matches a shift-roster attendance to its schedule by time range.
+
+    ``ssi_timesheet_attendance`` matches an attendance to a schedule
+    line by exact calendar-date equality, which cannot represent a
+    shift crossing midnight: a check-in after midnight would land on
+    the wrong schedule line, or none at all. This module adds a
+    tolerance-window, time-based match for timesheets whose Schedule
+    Source is Shift Roster, and derives the attendance's business
+    ``date`` from the matched schedule so the whole cross-day
+    interval books under a single calendar date — the shift's start
+    date. Timesheets whose Schedule Source is Working Schedule are
+    untouched: they keep going through ``super()`` unchanged.
+    """
+
+    _inherit = "hr.timesheet_attendance"
+
+    @api.depends(
+        "check_in",
+        "sheet_id",
+        "sheet_id.schedule_source",
+    )
+    def _compute_schedule(self):
+        """Match by check-in time window for shift-roster timesheets.
+
+        Falls through to ``super()`` untouched whenever the owning
+        timesheet (``sheet_id``) is empty or its ``schedule_source``
+        is not ``shift`` — the Working Schedule branch inherited from
+        ``ssi_timesheet_attendance`` is never modified by this
+        module, and an attendance without a timesheet yet never
+        raises because of this override. For Shift Roster timesheets,
+        searches the employee's shift-generated schedule lines for
+        the one whose tolerance window (``date_start`` minus the
+        shift's early check-in tolerance, to ``date_end`` plus the
+        shift's late check-out tolerance) contains ``check_in``; when
+        several match, the one whose ``date_start`` is closest to
+        ``check_in`` wins. When a match is found, ``date`` is
+        overwritten with the matched schedule's ``date`` — the
+        shift's start date. Falls back to ``super()`` when no
+        schedule line matches, so a shift-roster attendance without a
+        matching shift schedule never raises either.
+
+        :return: nothing; assigns ``schedule_id`` and, only for a
+            matched shift schedule, ``date``
+        """
+        obj_schedule = self.env["hr.timesheet_attendance_schedule"]
+        for attn in self:
+            if not attn.sheet_id or attn.sheet_id.schedule_source != "shift":
+                super(HrTimesheetAttendance, attn)._compute_schedule()
+                continue
+            domain = [
+                ("employee_id", "=", attn.employee_id.id),
+                ("shift_id", "!=", False),
+            ]
+            candidates = obj_schedule.search(domain)
+            matches = candidates.filtered(
+                lambda schedule, attn=attn: schedule._match_shift_check_in(
+                    attn.check_in
+                )
+            )
+            if not matches:
+                super(HrTimesheetAttendance, attn)._compute_schedule()
+                continue
+            best = min(
+                matches,
+                key=lambda schedule: abs(
+                    (schedule.date_start - attn.check_in).total_seconds()
+                ),
+            )
+            attn.schedule_id = best.id
+            attn.date = best.date
+
+    def _is_cross_day_shift_attendance(self):
+        """Tell whether this attendance is pinned to a cross-day shift.
+
+        Used by this module's ``hr.timesheet._sign_out()`` override to
+        decide whether the date-anomaly branch inherited from
+        ``ssi_timesheet_attendance`` should be skipped.
+
+        :return: True when ``schedule_id.shift_id.cross_day`` is set
+        """
+        self.ensure_one()
+        shift = self.schedule_id.shift_id
+        return bool(shift and shift.cross_day)

--- a/ssi_timesheet_attendance_shift/models/hr_timesheet_attendance_schedule.py
+++ b/ssi_timesheet_attendance_shift/models/hr_timesheet_attendance_schedule.py
@@ -2,6 +2,8 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from datetime import timedelta
+
 from odoo import fields, models
 
 
@@ -27,3 +29,28 @@ class HrTimesheetAttendanceSchedule(models.Model):
             "Schedule."
         ),
     )
+
+    def _match_shift_check_in(self, check_in):
+        """Tell whether ``check_in`` falls in this line's shift window.
+
+        The window spans from ``date_start`` minus the originating
+        shift's early check-in tolerance to ``date_end`` plus its
+        late check-out tolerance, both read from ``shift_id``. Used
+        by ``hr.timesheet_attendance._compute_schedule()`` to match a
+        shift-roster attendance to the schedule line it belongs to.
+
+        :param check_in: ``datetime`` to test, or a falsy value
+        :return: True when ``check_in`` lies in the tolerance window;
+            always False when this line has no ``shift_id``, no
+            ``date_start``/``date_end``, or ``check_in`` is falsy
+        """
+        self.ensure_one()
+        if not (self.shift_id and self.date_start and self.date_end and check_in):
+            return False
+        window_start = self.date_start - timedelta(
+            hours=self.shift_id.early_check_in_tolerance
+        )
+        window_end = self.date_end + timedelta(
+            hours=self.shift_id.late_check_out_tolerance
+        )
+        return window_start <= check_in <= window_end

--- a/ssi_timesheet_attendance_shift/tests/__init__.py
+++ b/ssi_timesheet_attendance_shift/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_hr_attendance_shift
 from . import test_hr_attendance_shift_pattern
 from . import test_hr_attendance_shift_assignment
 from . import test_hr_timesheet_shift_schedule
+from . import test_hr_timesheet_attendance_shift
 from . import test_ui_hr_attendance_shift
 from . import test_ui_hr_attendance_shift_pattern
 from . import test_ui_hr_attendance_shift_assignment

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_attendance_shift.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_attendance_shift.yaml
@@ -1,0 +1,637 @@
+scenarios:
+  - name: "Attendance Shift - Cross-Day Check-In Matches Shift And Sets Business Date"
+    steps:
+      - step: "Create night shift crossing midnight with explicit tolerances"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "night_shift"
+        values:
+          name: "Night Shift"
+          code: "/"
+          hour_start: 18.0
+          duration: 12.0
+          early_check_in_tolerance: 2.0
+          late_check_out_tolerance: 3.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Night Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: night_shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Cross Day Match Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the night pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Fetch the generated night schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "night_schedule"
+        limit: 1
+
+      - step: "Create the cross-day attendance"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 18:00:00"
+          check_out: "2024-01-09 06:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert the attendance matched the night schedule line"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: night_schedule"
+
+      - step: "Assert the whole 12-hour block counts as valid hours"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          total_valid_hour:
+            type: "value"
+            expected: 12.0
+
+      - step: "Assert the business date is the shift's start date"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          date:
+            type: "value"
+            expected: 2024-01-08
+
+  - name: "Attendance Shift - Early Check-In Within Tolerance Still Matches"
+    steps:
+      - step: "Create night shift crossing midnight with explicit tolerances"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "night_shift"
+        values:
+          name: "Night Shift"
+          code: "/"
+          hour_start: 18.0
+          duration: 12.0
+          early_check_in_tolerance: 2.0
+          late_check_out_tolerance: 3.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Night Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: night_shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Early Tolerance Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the night pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Fetch the generated night schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "night_schedule"
+        limit: 1
+
+      - step: "Create an attendance checking in 1 hour early (within 2h tolerance)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 17:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert the early check-in still matched the night schedule"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: night_schedule"
+
+  - name: "Attendance Shift - Check-In Outside Tolerance Does Not Match"
+    steps:
+      - step: "Create night shift crossing midnight with explicit tolerances"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "night_shift"
+        values:
+          name: "Night Shift"
+          code: "/"
+          hour_start: 18.0
+          duration: 12.0
+          early_check_in_tolerance: 2.0
+          late_check_out_tolerance: 3.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Night Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: night_shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Outside Tolerance Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the night pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Create an attendance checking in 4 hours early (outside 2h tolerance)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-01
+          check_in: "2024-01-08 14:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert the too-early check-in did not match any schedule"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          schedule_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Attendance Shift - Employee Without Any Shift Schedule Does Not Raise"
+    steps:
+      - step: "Create employee without any shift assignment"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "No Schedule Employee"
+          tz: "UTC"
+
+      - step: "Create shift-roster timesheet with no generated schedule"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-03-18
+          date_end: 2024-03-24
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule (no assignment, no lines)"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Create an attendance with no schedule to match, without error"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-03-18
+          check_in: "2024-03-18 09:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert the attendance was created without a schedule"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          schedule_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Attendance Shift - Sign Out Closes Cross-Day Attendance Without Anomaly"
+    steps:
+      - step: "Create night shift crossing midnight"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "night_shift"
+        values:
+          name: "Night Shift"
+          code: "/"
+          hour_start: 18.0
+          duration: 12.0
+          early_check_in_tolerance: 2.0
+          late_check_out_tolerance: 3.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Night Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: night_shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Sign Out Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the night pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Check in without checking out yet (open attendance)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 18:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert exactly one attendance exists before sign out"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "before_sign_out"
+        expect_count: 1
+
+      - step: "Sign out from the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_sign_out"
+        as_user: "base.user_admin"
+
+      - step: "Assert the attendance count did not increase"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "after_sign_out"
+        expect_count: 1
+
+      - step: "Assert the same attendance is now closed"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          check_out:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Attendance Shift - Working Schedule Regression - Exact Date Matching"
+    steps:
+      - step: "Create Monday-only calendar"
+        action: "create"
+        model: "resource.calendar"
+        save_as: "calendar"
+        values:
+          name: "Monday Only Calendar"
+          tz: "UTC"
+          attendance_ids:
+            - - 0
+              - 0
+              - name: "Monday"
+                dayofweek: "0"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+
+      - step: "Create employee for the working-schedule regression"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Working Schedule Regression Employee"
+          tz: "UTC"
+
+      - step: "Create working-schedule timesheet for the Monday"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Fetch the generated working-schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "monday_schedule"
+        limit: 1
+
+      - step: "Create attendance matching the working day exactly"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 08:00:00"
+          check_out: "2024-01-08 17:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert the attendance matched the working-schedule line"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: monday_schedule"
+
+      - step: "Assert the business date is unchanged (the check-in date)"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          date:
+            type: "value"
+            expected: 2024-01-08
+
+      - step: "Assert the total valid hour is unchanged (same-day arithmetic)"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          total_valid_hour:
+            type: "value"
+            expected: 9.0
+
+  - name: "Attendance Shift - Working Schedule Regression - Sign Out Anomaly Path"
+    steps:
+      - step: "Create Monday-only calendar"
+        action: "create"
+        model: "resource.calendar"
+        save_as: "calendar"
+        values:
+          name: "Monday Only Calendar"
+          tz: "UTC"
+          attendance_ids:
+            - - 0
+              - 0
+              - name: "Monday"
+                dayofweek: "0"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+
+      - step: "Create employee for the sign-out regression"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Working Schedule Sign Out Employee"
+          tz: "UTC"
+
+      - step: "Create working-schedule timesheet for the Monday"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Check in without checking out yet (open attendance)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert exactly one attendance exists before sign out"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "before_sign_out"
+        expect_count: 1
+
+      - step: "Sign out at a real time far past the fixed check-in date"
+        action: "call"
+        target: "timesheet"
+        method: "action_sign_out"
+        as_user: "base.user_admin"
+
+      - step: "Assert the anomaly branch created a second attendance"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "after_sign_out"
+        expect_count: 2
+
+      - step: "Assert the original open attendance was left unclosed"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          check_out:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_attendance_shift.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_attendance_shift.yaml
@@ -220,20 +220,23 @@ scenarios:
           early_check_in_tolerance: 2.0
           late_check_out_tolerance: 3.0
 
-      - step: "Create single-day pattern anchored on the shift date"
+      - step: "Create two-day pattern: night shift then a day off"
         action: "create"
         model: "hr.attendance_shift_pattern"
         save_as: "pattern"
         values:
-          name: "Night Only Pattern"
+          name: "Night Then Off Pattern"
           code: "/"
-          cycle_length: 1
+          cycle_length: 2
           date_anchor: 2024-01-08
           detail_ids:
             - - 0
               - 0
               - day_index: 1
                 shift_id: "REC: night_shift.id"
+            - - 0
+              - 0
+              - day_index: 2
 
       - step: "Create employee in UTC"
         action: "create"
@@ -253,7 +256,7 @@ scenarios:
           cycle_offset: 0
           date_start: 2024-01-08
 
-      - step: "Create shift-roster timesheet for the shift date"
+      - step: "Create shift-roster timesheet spanning the shift day and the day off"
         action: "create"
         model: "hr.timesheet"
         save_as: "timesheet"
@@ -262,7 +265,7 @@ scenarios:
           employee_id: "REC: employee.id"
           schedule_source: "shift"
           date_start: 2024-01-08
-          date_end: 2024-01-08
+          date_end: 2024-01-09
 
       - step: "Open the timesheet"
         action: "call"
@@ -282,7 +285,7 @@ scenarios:
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee.id"
-          date: 2024-01-01
+          date: 2024-01-09
           check_in: "2024-01-08 14:00:00"
           sheet_id: "REC: timesheet.id"
 

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_attendance_shift.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_attendance_shift.yaml
@@ -614,9 +614,27 @@ scenarios:
       - step: "Assert exactly one attendance exists before sign out"
         action: "search"
         model: "hr.timesheet_attendance"
-        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        domain: [["employee_id", "=", "REC: employee.id"]]
         save_as: "before_sign_out"
         expect_count: 1
+
+      - step: "Create a second, non-overlapping open timesheet covering today"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "catch_all_timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-01-09
+          date_end: 2099-12-31
+
+      - step: "Open the catch-all timesheet"
+        action: "call"
+        target: "catch_all_timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
 
       - step: "Sign out at a real time far past the fixed check-in date"
         action: "call"
@@ -627,7 +645,7 @@ scenarios:
       - step: "Assert the anomaly branch created a second attendance"
         action: "search"
         model: "hr.timesheet_attendance"
-        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        domain: [["employee_id", "=", "REC: employee.id"]]
         save_as: "after_sign_out"
         expect_count: 2
 

--- a/ssi_timesheet_attendance_shift/tests/test_hr_timesheet_attendance_shift.py
+++ b/ssi_timesheet_attendance_shift/tests/test_hr_timesheet_attendance_shift.py
@@ -1,0 +1,16 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrTimesheetAttendanceShift(YamlTransactionCase):
+    """Cover shift-roster attendance matching and cross-day sign out."""
+
+    def test_hr_timesheet_attendance_shift(self):
+        """Run the shift-roster attendance matching YAML scenarios."""
+        self.run_yaml_scenario("test_data_hr_timesheet_attendance_shift.yaml")


### PR DESCRIPTION
## Ringkasan

* Override `_compute_schedule()` pada `hr.timesheet_attendance`: kehadiran milik timesheet ber-`schedule_source` `shift` kini dicocokkan ke `hr.timesheet_attendance_schedule` berdasarkan rentang waktu check-in (`date_start - early_check_in_tolerance` s.d. `date_end + late_check_out_tolerance`, dari `shift_id` jadwal), bukan lagi kecocokan tanggal persis. Jatuh kembali ke `super()` bila tidak ada yang cocok atau timesheet-nya bukan `schedule_source` shift — jalur `working_schedule` tidak berubah sama sekali.
* Business date: `date` pada kehadiran yang cocok ke jadwal shift diisi dari tanggal mulai shift, sehingga satu shift malam lintas hari dibukukan penuh di satu tanggal.
* Override `_sign_out()` pada `hr.timesheet`: melewati cabang anomali beda-tanggal (dan `checkout_buffer`) saat kehadiran terbuka menempel ke jadwal ber-`shift_id.cross_day` True, sehingga sign out pada shift lintas hari menutup kehadiran yang ada, bukan membuat kehadiran baru.
* Unit test (`odoo-yaml-test`): pencocokan lintas hari, toleransi check-in (dalam & luar batas), business date, sign out tanpa anomali, serta regresi jalur `working_schedule` (pencocokan tanggal persis & sign out tetap memicu anomali lama).
* Seluruh perubahan lewat `_inherit` — berkas modul `ssi_timesheet_attendance` tidak disentuh.

Closes open-synergy/opnsynid-hr-timesheet#107

## Test plan

- [x] Unit test YAML ditulis, mencakup seluruh Kriteria Penerimaan issue #107
- [ ] CI hijau (pre-commit + pytest)