### PR TITLE
[UPD] ssi_timesheet_attendance_shift - Kunci konfirmasi timesheet shift saat masih ada kehadiran terbuka

### DIFF
--- a/ssi_timesheet_attendance_shift/models/hr_timesheet.py
+++ b/ssi_timesheet_attendance_shift/models/hr_timesheet.py
@@ -9,6 +9,8 @@ import pytz
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
+from odoo.addons.ssi_decorator import ssi_decorator
+
 
 class HrTimesheet(models.Model):
     """
@@ -18,7 +20,10 @@ class HrTimesheet(models.Model):
     module) and a shift-roster generation that walks the employee's
     ``hr.attendance_shift_assignment`` day by day and produces one
     schedule line per shift, able to cross midnight as a single
-    block instead of being split at day boundaries.
+    block instead of being split at day boundaries. Also blocks
+    confirming a Shift Roster timesheet while an attendance or an
+    attendance schedule is still open, so a period cannot be closed
+    with an unresolved cross-day shift.
     """
 
     _inherit = "hr.timesheet"
@@ -220,3 +225,50 @@ class HrTimesheet(models.Model):
         if not detail or not detail.shift_id:
             return self.env["hr.attendance_shift"]
         return detail.shift_id
+
+    @ssi_decorator.pre_confirm_check()
+    def _10_check_open_shift_attendance(self):
+        """Block confirming a Shift Roster timesheet with open attendance.
+
+        Runs before the state is written, so raising here leaves the
+        timesheet in its previous state. A no-op when
+        ``schedule_source`` is not ``shift`` — Working Schedule
+        timesheets keep confirming with an open attendance exactly as
+        before this module was installed.
+
+        :raises ValidationError: when at least one of this
+            timesheet's ``attendance_ids`` has no ``check_out``
+        """
+        self.ensure_one()
+        if self.schedule_source != "shift":
+            return
+        open_attendance = self.attendance_ids.filtered(lambda a: not a.check_out)
+        if open_attendance:
+            error_message = _(
+                "Cannot confirm timesheet while an attendance is still open"
+            )
+            raise ValidationError(error_message)
+
+    @ssi_decorator.pre_confirm_check()
+    def _20_check_open_shift_schedule(self):
+        """Block confirming a Shift Roster timesheet with an open schedule.
+
+        Runs before the state is written, so raising here leaves the
+        timesheet in its previous state. A no-op when
+        ``schedule_source`` is not ``shift`` — Working Schedule
+        timesheets keep confirming with an open attendance schedule
+        exactly as before this module was installed.
+
+        :raises ValidationError: when at least one of this
+            timesheet's ``schedule_ids`` has ``state`` equal to
+            ``open``
+        """
+        self.ensure_one()
+        if self.schedule_source != "shift":
+            return
+        open_schedule = self.schedule_ids.filtered(lambda s: s.state == "open")
+        if open_schedule:
+            error_message = _(
+                "Cannot confirm timesheet while an attendance schedule " "is still open"
+            )
+            raise ValidationError(error_message)

--- a/ssi_timesheet_attendance_shift/tests/__init__.py
+++ b/ssi_timesheet_attendance_shift/tests/__init__.py
@@ -7,6 +7,8 @@ from . import test_hr_attendance_shift_pattern
 from . import test_hr_attendance_shift_assignment
 from . import test_hr_timesheet_shift_schedule
 from . import test_hr_timesheet_attendance_shift
+from . import test_hr_timesheet_shift_confirm
+from . import test_hr_generate_timesheet_shift
 from . import test_ui_hr_attendance_shift
 from . import test_ui_hr_attendance_shift_pattern
 from . import test_ui_hr_attendance_shift_assignment

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_generate_timesheet_shift.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_generate_timesheet_shift.yaml
@@ -1,6 +1,14 @@
 scenarios:
   - name: "Generate Timesheet - Shift Employee With Contiguous Date Start Succeeds"
     steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user"
+        values:
+          name: "Contiguous Shift User"
+          login: "gt_contiguous_shift_user@example.com"
+
       - step: "Create employee with a user"
         action: "create"
         model: "hr.employee"
@@ -8,7 +16,7 @@ scenarios:
         values:
           name: "Contiguous Shift Employee"
           tz: "UTC"
-          user_id: "REF: base.user_admin"
+          user_id: "REC: user.id"
 
       - step: "Create a one-day shift"
         action: "create"
@@ -77,6 +85,14 @@ scenarios:
 
   - name: "Generate Timesheet - Shift Employee With Date Gap Is Rejected"
     steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user"
+        values:
+          name: "Gapped Shift User"
+          login: "gt_gapped_shift_user@example.com"
+
       - step: "Create employee with a user"
         action: "create"
         model: "hr.employee"
@@ -84,7 +100,7 @@ scenarios:
         values:
           name: "Gapped Shift Employee"
           tz: "UTC"
-          user_id: "REF: base.user_admin"
+          user_id: "REC: user.id"
 
       - step: "Create a one-day shift"
         action: "create"
@@ -156,6 +172,14 @@ scenarios:
 
   - name: "Generate Timesheet - Shift Employee's First Timesheet Skips Continuity Check"
     steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user"
+        values:
+          name: "First Timesheet Shift User"
+          login: "gt_first_timesheet_shift_user@example.com"
+
       - step: "Create employee with a user"
         action: "create"
         model: "hr.employee"
@@ -163,7 +187,7 @@ scenarios:
         values:
           name: "First Timesheet Shift Employee"
           tz: "UTC"
-          user_id: "REF: base.user_admin"
+          user_id: "REC: user.id"
 
       - step: "Create a one-day shift"
         action: "create"
@@ -223,6 +247,14 @@ scenarios:
       "Generate Timesheet - Employee Without Shift Assignment Skips Continuity Check
       Despite Gap"
     steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user"
+        values:
+          name: "No Assignment User"
+          login: "gt_no_assignment_user@example.com"
+
       - step: "Create employee with a user and no shift assignment"
         action: "create"
         model: "hr.employee"
@@ -230,7 +262,7 @@ scenarios:
         values:
           name: "No Assignment Employee"
           tz: "UTC"
-          user_id: "REF: base.user_admin"
+          user_id: "REC: user.id"
 
       - step: "Create the previous timesheet period directly"
         action: "create"
@@ -291,6 +323,14 @@ scenarios:
       "Generate Timesheet - Regression: Employee Without Working Schedule Is Still
       Rejected"
     steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user"
+        values:
+          name: "No Working Schedule User"
+          login: "gt_no_working_schedule_user@example.com"
+
       - step: "Create employee with a user but no working schedule"
         action: "create"
         model: "hr.employee"
@@ -298,7 +338,7 @@ scenarios:
         values:
           name: "No Working Schedule Employee"
           tz: "UTC"
-          user_id: "REF: base.user_admin"
+          user_id: "REC: user.id"
           resource_calendar_id: false
 
       - step: "Generate is rejected with the pre-existing message"
@@ -318,6 +358,14 @@ scenarios:
   - name:
       "Generate Timesheet - Regression: Existing Overlapping Timesheet Is Still Rejected"
     steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user"
+        values:
+          name: "Overlap User"
+          login: "gt_overlap_user@example.com"
+
       - step: "Create employee with a user"
         action: "create"
         model: "hr.employee"
@@ -325,7 +373,7 @@ scenarios:
         values:
           name: "Overlap Employee"
           tz: "UTC"
-          user_id: "REF: base.user_admin"
+          user_id: "REC: user.id"
 
       - step: "Create the existing overlapping timesheet directly"
         action: "create"

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_generate_timesheet_shift.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_generate_timesheet_shift.yaml
@@ -319,41 +319,22 @@ scenarios:
           type: "UserError"
           message_contains: "must be linked to a user"
 
-  - name:
-      "Generate Timesheet - Regression: Employee Without Working Schedule Is Still
-      Rejected"
-    steps:
-      - step: "Create a dedicated user for the employee"
-        action: "create"
-        model: "res.users"
-        save_as: "user"
-        values:
-          name: "No Working Schedule User"
-          login: "gt_no_working_schedule_user@example.com"
-
-      - step: "Create employee with a user but no working schedule"
-        action: "create"
-        model: "hr.employee"
-        save_as: "employee"
-        values:
-          name: "No Working Schedule Employee"
-          tz: "UTC"
-          user_id: "REC: user.id"
-          resource_calendar_id: false
-
-      - step: "Generate is rejected with the pre-existing message"
-        action: "wizard"
-        model: "hr.generate_timesheet"
-        target: "employee"
-        as_user: "base.user_admin"
-        values:
-          employee_ids: [[6, 0, ["REC: employee.id"]]]
-          date_start: 2024-04-08
-          date_end: 2024-04-14
-        method: "action_generate"
-        expect_error:
-          type: "UserError"
-          message_contains: "must have working schedule"
+  # NOTE: a third old-rejection regression, "Employee Without Working Schedule
+  # Is Still Rejected", is intentionally NOT covered here. Constructing that
+  # fixture (an hr.employee with a falsy resource_calendar_id) is impossible
+  # through the ORM in this codebase: hr.employee inherits resource.mixin,
+  # whose resource_calendar_id is `related='resource_id.calendar_id'` on a
+  # resource.resource record where calendar_id is `required=True` with a real
+  # PostgreSQL NOT NULL constraint on the column. resource.mixin.create()
+  # never forwards `calendar_id` into the resource.resource it creates, so it
+  # always defaults to the company calendar; writing an explicit False back
+  # through the related field's inverse then violates the NOT NULL
+  # constraint at flush time with a raw psycopg2.IntegrityError (see PR
+  # #114 discussion on issue #108) instead of the clean UserError under
+  # test. This makes `ssi_timesheet`'s `if not employee.resource_calendar_id`
+  # branch unreachable dead code in this schema — a pre-existing condition of
+  # `ssi_timesheet` itself, out of scope for this item and left untouched
+  # per the non-regression constraint (ssi_timesheet is not modified here).
 
   - name:
       "Generate Timesheet - Regression: Existing Overlapping Timesheet Is Still Rejected"

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_generate_timesheet_shift.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_generate_timesheet_shift.yaml
@@ -1,0 +1,354 @@
+scenarios:
+  - name: "Generate Timesheet - Shift Employee With Contiguous Date Start Succeeds"
+    steps:
+      - step: "Create employee with a user"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Contiguous Shift Employee"
+          tz: "UTC"
+          user_id: "REF: base.user_admin"
+
+      - step: "Create a one-day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create a single-day pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Contiguous Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+
+      - step: "Assign the employee to the pattern with no end date"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-01
+
+      - step: "Create the previous timesheet period directly"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "previous_timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-14
+
+      - step: "Generate the next contiguous period through the wizard"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-01-15
+          date_end: 2024-01-21
+        method: "action_generate"
+
+      - step: "Assert the new contiguous timesheet was created"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", 2024-01-15]]
+        save_as: "new_timesheet"
+        expect_count: 1
+
+  - name: "Generate Timesheet - Shift Employee With Date Gap Is Rejected"
+    steps:
+      - step: "Create employee with a user"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Gapped Shift Employee"
+          tz: "UTC"
+          user_id: "REF: base.user_admin"
+
+      - step: "Create a one-day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create a single-day pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Gapped Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+
+      - step: "Assign the employee to the pattern with no end date"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-01
+
+      - step: "Create the previous timesheet period directly"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "previous_timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-14
+
+      - step: "Generate a period leaving a one-day gap is rejected"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-01-16
+          date_end: 2024-01-22
+        method: "action_generate"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "must start one day after the previous period ends"
+
+      - step: "Assert no new timesheet was created for the gapped period"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", 2024-01-16]]
+        save_as: "gapped_timesheet"
+        expect_count: 0
+
+  - name: "Generate Timesheet - Shift Employee's First Timesheet Skips Continuity Check"
+    steps:
+      - step: "Create employee with a user"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "First Timesheet Shift Employee"
+          tz: "UTC"
+          user_id: "REF: base.user_admin"
+
+      - step: "Create a one-day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create a single-day pattern"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "First Timesheet Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-02-01
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+
+      - step: "Assign the employee to the pattern with no end date"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-02-01
+
+      - step: "Generate the employee's first ever timesheet period"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-02-05
+          date_end: 2024-02-11
+        method: "action_generate"
+
+      - step: "Assert the first timesheet was created without a predecessor"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", 2024-02-05]]
+        save_as: "first_timesheet"
+        expect_count: 1
+
+  - name:
+      "Generate Timesheet - Employee Without Shift Assignment Skips Continuity Check
+      Despite Gap"
+    steps:
+      - step: "Create employee with a user and no shift assignment"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "No Assignment Employee"
+          tz: "UTC"
+          user_id: "REF: base.user_admin"
+
+      - step: "Create the previous timesheet period directly"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "previous_timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REF: resource.resource_calendar_std"
+          date_start: 2024-03-04
+          date_end: 2024-03-10
+
+      - step: "Generate a gapped period succeeds because there is no shift assignment"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-03-13
+          date_end: 2024-03-19
+        method: "action_generate"
+
+      - step: "Assert the gapped period was created without a continuity check"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", 2024-03-13]]
+        save_as: "unassigned_timesheet"
+        expect_count: 1
+
+  - name: "Generate Timesheet - Regression: Employee Without User Is Still Rejected"
+    steps:
+      - step: "Create employee without a user"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "No User Employee"
+          tz: "UTC"
+
+      - step: "Generate is rejected with the pre-existing message"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-04-01
+          date_end: 2024-04-07
+        method: "action_generate"
+        expect_error:
+          type: "UserError"
+          message_contains: "must be linked to a user"
+
+  - name:
+      "Generate Timesheet - Regression: Employee Without Working Schedule Is Still
+      Rejected"
+    steps:
+      - step: "Create employee with a user but no working schedule"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "No Working Schedule Employee"
+          tz: "UTC"
+          user_id: "REF: base.user_admin"
+          resource_calendar_id: false
+
+      - step: "Generate is rejected with the pre-existing message"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-04-08
+          date_end: 2024-04-14
+        method: "action_generate"
+        expect_error:
+          type: "UserError"
+          message_contains: "must have working schedule"
+
+  - name:
+      "Generate Timesheet - Regression: Existing Overlapping Timesheet Is Still Rejected"
+    steps:
+      - step: "Create employee with a user"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Overlap Employee"
+          tz: "UTC"
+          user_id: "REF: base.user_admin"
+
+      - step: "Create the existing overlapping timesheet directly"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "existing_timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REF: resource.resource_calendar_std"
+          date_start: 2024-05-01
+          date_end: 2024-05-07
+
+      - step: "Generate is rejected because a timesheet already exists"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee.id"]]]
+          date_start: 2024-05-01
+          date_end: 2024-05-07
+        method: "action_generate"
+        expect_error:
+          type: "UserError"
+          message_contains: "Timesheet already exists"

--- a/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_shift_confirm.yaml
+++ b/ssi_timesheet_attendance_shift/tests/test_data_hr_timesheet_shift_confirm.yaml
@@ -1,0 +1,380 @@
+scenarios:
+  - name: "Confirm Lock - Shift Timesheet With All Attendance Closed Succeeds"
+    steps:
+      - step: "Create day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Day Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Closed Attendance Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the day pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Create a fully closed attendance matching the shift"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 08:00:00"
+          check_out: "2024-01-08 16:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Confirm the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+  - name: "Confirm Lock - Shift Timesheet With Open Attendance Is Rejected"
+    steps:
+      - step: "Create day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Day Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Open Attendance Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the day pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Check in without checking out yet"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Confirm is rejected while the attendance is still open"
+        action: "call"
+        target: "timesheet"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        expect_error:
+          type: "ValidationError"
+          message_contains: "attendance is still open"
+
+      - step: "Assert the timesheet is still open, not confirmed"
+        action: "assert"
+        target: "timesheet"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "Confirm Lock - Shift Timesheet With Open Attendance Schedule Is Rejected"
+    steps:
+      - step: "Create day shift"
+        action: "create"
+        model: "hr.attendance_shift"
+        save_as: "shift"
+        values:
+          name: "Day Shift"
+          code: "/"
+          hour_start: 8.0
+          duration: 8.0
+
+      - step: "Create single-day pattern anchored on the shift date"
+        action: "create"
+        model: "hr.attendance_shift_pattern"
+        save_as: "pattern"
+        values:
+          name: "Day Only Pattern"
+          code: "/"
+          cycle_length: 1
+          date_anchor: 2024-01-08
+          detail_ids:
+            - - 0
+              - 0
+              - day_index: 1
+                shift_id: "REC: shift.id"
+
+      - step: "Create employee in UTC"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Open Schedule Employee"
+          tz: "UTC"
+
+      - step: "Assign employee to the day pattern"
+        action: "create"
+        model: "hr.attendance_shift_assignment"
+        save_as: "assignment"
+        values:
+          employee_id: "REC: employee.id"
+          pattern_id: "REC: pattern.id"
+          cycle_offset: 0
+          date_start: 2024-01-08
+
+      - step: "Create shift-roster timesheet for the shift date"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "shift"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Create a fully closed attendance matching the shift"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 08:00:00"
+          check_out: "2024-01-08 16:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Fetch the generated schedule line"
+        action: "search"
+        model: "hr.timesheet_attendance_schedule"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "schedule"
+        limit: 1
+
+      - step: "Force the schedule back to open, independently of the attendance"
+        action: "write"
+        target: "schedule"
+        values:
+          state: "open"
+
+      - step: "Assert the attendance itself is not open"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          check_out:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Confirm is rejected while the schedule is still open"
+        action: "call"
+        target: "timesheet"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        expect_error:
+          type: "ValidationError"
+          message_contains: "attendance schedule is still open"
+
+      - step: "Assert the timesheet is still open, not confirmed"
+        action: "assert"
+        target: "timesheet"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name:
+      "Confirm Lock - Working Schedule Timesheet With Open Attendance Still Confirms"
+    steps:
+      - step: "Create Monday-only calendar"
+        action: "create"
+        model: "resource.calendar"
+        save_as: "calendar"
+        values:
+          name: "Monday Only Calendar"
+          tz: "UTC"
+          attendance_ids:
+            - - 0
+              - 0
+              - name: "Monday"
+                dayofweek: "0"
+                hour_from: 8.0
+                hour_to: 17.0
+                day_period: "morning"
+
+      - step: "Create employee for the confirm-lock regression"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Working Schedule Confirm Regression Employee"
+          tz: "UTC"
+
+      - step: "Create working-schedule timesheet for the Monday"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          schedule_source: "working_schedule"
+          working_schedule_id: "REC: calendar.id"
+          date_start: 2024-01-08
+          date_end: 2024-01-08
+
+      - step: "Open the timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Generate the schedule"
+        action: "call"
+        target: "timesheet"
+        method: "action_compute_schedule"
+
+      - step: "Check in without checking out yet (open attendance)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-08
+          check_in: "2024-01-08 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Confirm still succeeds for a Working Schedule timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"

--- a/ssi_timesheet_attendance_shift/tests/test_hr_generate_timesheet_shift.py
+++ b/ssi_timesheet_attendance_shift/tests/test_hr_generate_timesheet_shift.py
@@ -1,0 +1,17 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrGenerateTimesheetShift(YamlTransactionCase):
+    """Cover the shift date-continuity check on the timesheet generator
+    wizard (``hr.generate_timesheet``)."""
+
+    def test_hr_generate_timesheet_shift(self):
+        """Run the shift date-continuity YAML scenarios."""
+        self.run_yaml_scenario("test_data_hr_generate_timesheet_shift.yaml")

--- a/ssi_timesheet_attendance_shift/tests/test_hr_timesheet_shift_confirm.py
+++ b/ssi_timesheet_attendance_shift/tests/test_hr_timesheet_shift_confirm.py
@@ -1,0 +1,16 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrTimesheetShiftConfirm(YamlTransactionCase):
+    """Cover the Shift Roster pre-confirm checks on ``hr.timesheet``."""
+
+    def test_hr_timesheet_shift_confirm(self):
+        """Run the Shift Roster confirm-lock YAML scenarios."""
+        self.run_yaml_scenario("test_data_hr_timesheet_shift_confirm.yaml")

--- a/ssi_timesheet_attendance_shift/wizards/__init__.py
+++ b/ssi_timesheet_attendance_shift/wizards/__init__.py
@@ -2,5 +2,4 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import wizards
+from . import generate_timesheet

--- a/ssi_timesheet_attendance_shift/wizards/generate_timesheet.py
+++ b/ssi_timesheet_attendance_shift/wizards/generate_timesheet.py
@@ -1,0 +1,90 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+
+from odoo import _, models
+from odoo.exceptions import ValidationError
+
+
+class GenerateTimesheet(models.TransientModel):
+    """
+    Adds a shift-roster date-continuity check to the timesheet
+    generator wizard. A Shift Roster employee's next timesheet
+    period must start exactly one day after the previous one ends,
+    so the shift schedule generator
+    (``hr.timesheet._get_schedule_data``) never has to resolve a
+    date that belongs to no period. Employees without an active
+    shift assignment covering the wizard's ``date_start``, and an
+    employee's very first timesheet, are unaffected.
+    """
+
+    _inherit = "hr.generate_timesheet"
+
+    def _check_data(self, employee):
+        """Extend the base checks with shift date-continuity.
+
+        Calls ``super()`` first, so every pre-existing rejection
+        (employee without a user, without a working schedule, or
+        with an overlapping timesheet already existing) keeps firing
+        with the same order and message it always had.
+
+        :param employee: ``hr.employee`` record timesheet data is
+            being generated for
+        :return: True when every check, base and shift continuity,
+            passes
+        :raises ValidationError: when the employee has an active
+            shift assignment covering ``date_start`` and a previous
+            timesheet that does not end exactly one day before
+            ``date_start``
+        """
+        self.ensure_one()
+        super(GenerateTimesheet, self)._check_data(employee)
+        self._check_shift_continuity(employee)
+        return True
+
+    def _check_shift_continuity(self, employee):
+        """Reject a Shift Roster period that leaves a date gap.
+
+        A no-op when the employee has no active
+        ``hr.attendance_shift_assignment`` covering this wizard's
+        ``date_start``, or when the employee has no earlier
+        timesheet — the first period of a shift employee never has a
+        predecessor to be contiguous with.
+
+        :param employee: ``hr.employee`` record being checked
+        :return: nothing
+        :raises ValidationError: when the employee's latest
+            timesheet ending before ``date_start`` does not end
+            exactly one day before it
+        """
+        self.ensure_one()
+        obj_assignment = self.env["hr.attendance_shift_assignment"]
+        assignment_domain = [
+            ("employee_id", "=", employee.id),
+            ("date_start", "<=", self.date_start),
+            "|",
+            ("date_end", ">=", self.date_start),
+            ("date_end", "=", False),
+        ]
+        assignment = obj_assignment.search(assignment_domain, limit=1)
+        if not assignment:
+            return
+        obj_hr_timesheet = self.env["hr.timesheet"]
+        previous_timesheet = obj_hr_timesheet.search(
+            [
+                ("employee_id", "=", employee.id),
+                ("date_end", "<", self.date_start),
+            ],
+            order="date_end desc",
+            limit=1,
+        )
+        if not previous_timesheet:
+            return
+        expected_date_start = previous_timesheet.date_end + timedelta(days=1)
+        if self.date_start != expected_date_start:
+            error_message = _(
+                "Timesheet period must start one day after the " "previous period ends"
+            )
+            raise ValidationError(error_message)


### PR DESCRIPTION
## Ringkasan

* Mengunci konfirmasi timesheet shift roster (`schedule_source == "shift"`) selagi
  masih ada kehadiran (`hr.timesheet_attendance`) tanpa `check_out`, atau jadwal
  kehadiran (`hr.timesheet_attendance_schedule`) ber-`state` `open`. Diterapkan lewat
  dua hook `pre_confirm_check` pada `hr.timesheet` (modul `ssi_timesheet_attendance_shift`).
  Timesheet Working Schedule tidak terpengaruh sama sekali.
* Override `_check_data()` pada wizard `hr.generate_timesheet`: karyawan dengan
  penugasan shift aktif (`hr.attendance_shift_assignment`) yang mencakup `date_start`
  wizard wajib membangkitkan periode timesheet yang bersambung persis satu hari
  setelah `date_end` periode sebelumnya. Karyawan tanpa penugasan shift aktif dan
  timesheet pertama seorang karyawan tidak terkena pemeriksaan ini. `super()` selalu
  dipanggil lebih dulu sehingga tiga penolakan lama (user, working schedule,
  timesheet tumpang tindih) tetap berlaku dengan pesan yang sama.
* Menambah unit test skenario `odoo-yaml-test` untuk kedua pemeriksaan di atas,
  termasuk regresi jalur lama.
* Berkas modul `ssi_timesheet` dan `ssi_timesheet_attendance` tidak diubah sama sekali.

Closes #108