### PR TITLE
[UPD] ssi_timesheet_attendance - perbaiki pesan galat jadwal, kode mati, dan alias impor usang

### DIFF
--- a/ssi_timesheet_attendance/models/hr_timesheet.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet.py
@@ -11,6 +11,15 @@ from odoo.tools import format_datetime
 
 
 class HRTimesheet(models.Model):
+    """
+    Adds attendance tracking to the timesheet document.
+
+    Links recorded ``hr.timesheet_attendance`` entries and their
+    derived ``hr.timesheet_attendance_schedule`` slots to the
+    timesheet, and provides the sign-in/sign-out actions employees use
+    to record their attendance against it.
+    """
+
     _inherit = "hr.timesheet"
 
     @api.depends(
@@ -248,15 +257,6 @@ class HRTimesheet(models.Model):
             "check_out": fields.Datetime.now(),
             "reason_check_out_id": reason and reason.id or False,
         }
-
-    def _prepare_domain_sign_out(self):
-        self.ensure_one()
-        criteria = [
-            ("sheet_id", "=", self.employee_id.active_timesheet_id.id),
-            ("date", "=", fields.Date.today()),
-            ("check_out", "=", False),
-        ]
-        return criteria
 
     def unlink(self):
         _super = super(HRTimesheet, self)

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 from odoo import _, api, fields, models
-from odoo.exceptions import Warning as UserError
+from odoo.exceptions import UserError
 from odoo.tools import format_datetime
 
 

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance_schedule.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance_schedule.py
@@ -4,10 +4,18 @@
 
 
 from odoo import _, api, fields, models
-from odoo.exceptions import Warning as UserError
+from odoo.exceptions import ValidationError
 
 
 class HRTimesheetAttendanceSchedule(models.Model):
+    """
+    Represents a planned attendance schedule slot for an employee.
+
+    Resolves the timesheet that covers its date, aggregates the actual
+    attendance recorded against it, and derives the resulting
+    early/late/finish deviations against the planned schedule window.
+    """
+
     _name = "hr.timesheet_attendance_schedule"
     _inherit = [
         "mixin.datetime_duration",
@@ -33,6 +41,15 @@ class HRTimesheetAttendanceSchedule(models.Model):
         "employee_id",
     )
     def _compute_sheet(self):
+        """Resolve the timesheet that covers this schedule's date.
+
+        Searches ``hr.timesheet`` for a record of the same
+        ``employee_id`` whose ``date_start``/``date_end`` range covers
+        ``date``.
+
+        :raises ValidationError: when no timesheet of ``employee_id``
+            covers ``date`` — the schedule cannot exist without one.
+        """
         obj_sheet = self.env["hr.timesheet"]
         for record in self:
             criteria = [
@@ -44,7 +61,21 @@ class HRTimesheetAttendanceSchedule(models.Model):
             if len(sheet) > 0:
                 record.sheet_id = sheet[0].id
             else:
-                raise UserError(str(record.date))
+                error_message = _(
+                    """
+Context: Determine the timesheet for an attendance schedule
+Database ID: %s
+Problem: No timesheet of employee %s covers the schedule date %s
+Solution: Create a timesheet whose date range includes %s
+"""
+                    % (
+                        record.id,
+                        record.employee_id.name,
+                        record.date,
+                        record.date,
+                    )
+                )
+                raise ValidationError(error_message)
 
     @api.depends(
         "attendance_ids",
@@ -249,14 +280,24 @@ class HRTimesheetAttendanceSchedule(models.Model):
 
     @api.constrains("schedule_work_hour")
     def _check_schedule_work_hour(self):
+        """Ensure the computed schedule duration stays within a day.
+
+        :raises ValidationError: when ``schedule_work_hour`` exceeds
+            23.99 hours.
+        """
         for record in self.sudo():
             if record.schedule_work_hour:
                 strWarning = _("Schedule Hours Cannot Greater Than 24 Hours")
                 if record.schedule_work_hour > 23.99:
-                    raise UserError(strWarning)
+                    raise ValidationError(strWarning)
 
     @api.constrains("date_start")
     def _check_sheet(self):
+        """Ensure the schedule's date stays within its timesheet range.
+
+        :raises ValidationError: when ``date`` falls outside
+            ``sheet_id``'s ``date_start``/``date_end`` range.
+        """
         for record in self.sudo():
             if record.date_start:
                 strWarning = _(
@@ -265,4 +306,4 @@ class HRTimesheetAttendanceSchedule(models.Model):
                 if (record.date < record.sheet_id.date_start) or (
                     record.date > record.sheet_id.date_end
                 ):
-                    raise UserError(strWarning)
+                    raise ValidationError(strWarning)

--- a/ssi_timesheet_attendance/models/res_company.py
+++ b/ssi_timesheet_attendance/models/res_company.py
@@ -5,17 +5,49 @@ from odoo import fields, models
 
 
 class ResCompany(models.Model):
+    """
+    Adds timesheet attendance configuration to the company record.
+
+    Defines the checkout buffer tolerance used to detect anomalous
+    (cross-date) sign-outs, and the default reasons applied when the
+    system auto-creates check-in/check-out entries for them.
+    """
+
     _inherit = "res.company"
 
     checkout_buffer = fields.Float(
         string="Check Out Buffer",
         digits=(2, 2),
+        help=(
+            "Tolerance, in hours, between the scheduled end of the "
+            "attendance and the actual check-out time before a "
+            "check-out recorded on a different date than its "
+            "attendance is treated as an anomaly (a new attendance "
+            "record is created instead of closing the current one). "
+            "A value of 0.0 means every check-out that falls on a "
+            "different date than its attendance is immediately "
+            "treated as an anomaly."
+        ),
     )
     check_out_reason_id = fields.Many2one(
         string="Check Out Reason",
         comodel_name="hr.attendance_reason",
+        help=(
+            "Default reason applied to the check-out of a "
+            "system-generated attendance record created when a "
+            "sign-out is detected as an anomaly (outside the check "
+            "out buffer). Falls back to the module's default check "
+            "out reason when left empty."
+        ),
     )
     check_in_reason_id = fields.Many2one(
         string="Check In Reason",
         comodel_name="hr.attendance_reason",
+        help=(
+            "Default reason applied to the check-in of a "
+            "system-generated attendance record created when a "
+            "sign-out is detected as an anomaly (outside the check "
+            "out buffer). Falls back to the module's default check "
+            "in reason when left empty."
+        ),
     )

--- a/ssi_timesheet_attendance/tests/__init__.py
+++ b/ssi_timesheet_attendance/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_timesheet_attendance
+from . import test_timesheet_attendance_schedule

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance_schedule.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance_schedule.yaml
@@ -1,0 +1,113 @@
+setup:
+  steps:
+    - step: "Get working schedule"
+      action: "search"
+      model: "resource.calendar"
+      domain: []
+      save_as: "working_schedule"
+      limit: 1
+      order: "id asc"
+
+scenarios:
+  - name: "Attendance Schedule - Sheet Resolved For Date Within Timesheet"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Schedule Covered"
+
+      - step: "Create timesheet covering February 2024"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: 2024-02-01
+          date_end: 2024-02-29
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create schedule dated inside timesheet range"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: "2024-02-10 08:00:00"
+          date_end: "2024-02-10 17:00:00"
+
+      - step: "Assert schedule linked to the covering timesheet"
+        action: "assert"
+        target: "schedule"
+        asserts:
+          sheet_id:
+            type: "m2o"
+            expected: "REC: timesheet"
+          date:
+            type: "value"
+            expected: 2024-02-10
+
+  - name: "Attendance Schedule - Rejected For Date Outside Timesheet Range"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Schedule Uncovered"
+
+      - step: "Create timesheet covering March 2024"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: 2024-03-01
+          date_end: 2024-03-31
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Reject schedule dated outside every timesheet range"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Create a timesheet"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: "2024-05-05 08:00:00"
+          date_end: "2024-05-05 17:00:00"
+
+  - name: "Company - Checkout Buffer Default Unchanged"
+    steps:
+      - step: "Create company"
+        action: "create"
+        model: "res.company"
+        save_as: "new_company"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Timesheet Attendance Company"
+
+      - step: "Assert checkout buffer keeps its default value"
+        action: "assert"
+        target: "new_company"
+        asserts:
+          checkout_buffer:
+            type: "value"
+            expected: 0.0

--- a/ssi_timesheet_attendance/tests/test_timesheet_attendance_schedule.py
+++ b/ssi_timesheet_attendance/tests/test_timesheet_attendance_schedule.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTimesheetAttendanceSchedule(YamlTransactionCase):
+    """Scenario tests for ``hr.timesheet_attendance_schedule``.
+
+    Covers sheet resolution against covering/non-covering timesheets
+    and the ``res.company`` checkout buffer default.
+    """
+
+    def test_timesheet_attendance_schedule(self):
+        """Run the schedule sheet-resolution and company scenarios."""
+        self.run_yaml_scenario("test_data_timesheet_attendance_schedule.yaml")


### PR DESCRIPTION
## Ringkasan

- Ganti pesan galat pada `hr.timesheet_attendance_schedule._compute_sheet` dari sekadar `str(tanggal)` menjadi pesan terstruktur (Context/Database ID/Problem/Solution) berbahasa Inggris yang menjelaskan tidak ada timesheet karyawan yang mencakup tanggal jadwal dan menyarankan pembuatan timesheet untuk periode itu, dengan tipe `ValidationError`.
- Hapus `hr.timesheet._prepare_domain_sign_out` yang mati (tidak ada pemanggil) dan menyaring memakai `active_timesheet_id` yang keliru untuk kehadiran lintas periode.
- Ganti seluruh impor alias usang `Warning as UserError` menjadi impor langsung `UserError`/`ValidationError` sesuai makna tiap pemakaian; constraint pelanggaran data pada `hr.timesheet_attendance_schedule` kini memakai `ValidationError` (tetap dalam keluarga `UserError`).
- Lengkapi atribut `help` berbahasa Inggris pada `checkout_buffer`, `check_out_reason_id`, dan `check_in_reason_id` di `res.company`; `checkout_buffer` menyebut satuan jam dan akibat nilai bawaan 0.0.
- Tambah unit test skenario YAML untuk resolusi `sheet_id` jadwal (positif & negatif) dan nilai bawaan `checkout_buffer`.

Tidak ada perubahan nilai bawaan `checkout_buffer`, berkas data perusahaan, maupun kondisi kapan galat dilempar — murni cleanup pesan/tipe/kode mati/impor/help text.

## Test plan

- [x] Unit test YAML baru: sheet resolution positif & negatif, default checkout_buffer — dijalankan via CI
- [x] `assets/verify-module.sh` — sisa kegagalan (naming `HRTimesheetAttendance*`, docstring file lain) adalah tech debt pra-eksisting di luar scope issue ini, tidak boleh diubah tanpa instruksi eksplisit (larangan rename class/field/method)

Closes #109