### PR TITLE
[UPD] ssi_timesheet - Instruksi Kerja hr.timesheet & hr.timesheet_computation_item

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,37 @@ operational documentation for using the feature from the user's perspective.
 
 ## Work Instruction Index
 
+### `ssi_timesheet` — Model: `hr.timesheet`
+
+Menu: **Human Resource > Timesheets > Timesheets**
+
+| File                                                     | Action                                    |
+| -------------------------------------------------------- | ----------------------------------------- |
+| `ssi_timesheet/docs/hr_timesheet/01-create.md`           | Create a new timesheet                    |
+| `ssi_timesheet/docs/hr_timesheet/02-edit.md`             | Edit a timesheet                          |
+| `ssi_timesheet/docs/hr_timesheet/03-delete.md`           | Delete a timesheet                        |
+| `ssi_timesheet/docs/hr_timesheet/04-confirm.md`          | Confirm a timesheet (submit for approval) |
+| `ssi_timesheet/docs/hr_timesheet/05-approve.md`          | Approve a timesheet                       |
+| `ssi_timesheet/docs/hr_timesheet/06-reject.md`           | Reject a timesheet                        |
+| `ssi_timesheet/docs/hr_timesheet/07-start.md`            | Start a timesheet                         |
+| `ssi_timesheet/docs/hr_timesheet/10-cancel.md`           | Cancel a timesheet                        |
+| `ssi_timesheet/docs/hr_timesheet/12-restart.md`          | Restart a cancelled/rejected timesheet    |
+| `ssi_timesheet/docs/hr_timesheet/13-reset-number.md`     | Reset a timesheet's document number       |
+| `ssi_timesheet/docs/hr_timesheet/14-restart-approval.md` | Restart a timesheet's approval process    |
+
+### `ssi_timesheet` — Model: `hr.timesheet_computation_item`
+
+Menu: **Human Resource > Configuration > Timesheets > Timesheet Computation Items**
+
+| File                                                                | Action                                  |
+| ------------------------------------------------------------------- | --------------------------------------- |
+| `ssi_timesheet/docs/hr_timesheet_computation_item/01-create.md`     | Create a new timesheet computation item |
+| `ssi_timesheet/docs/hr_timesheet_computation_item/02-edit.md`       | Edit a timesheet computation item       |
+| `ssi_timesheet/docs/hr_timesheet_computation_item/03-delete.md`     | Delete a timesheet computation item     |
+| `ssi_timesheet/docs/hr_timesheet_computation_item/04-deactivate.md` | Deactivate a timesheet computation item |
+| `ssi_timesheet/docs/hr_timesheet_computation_item/05-activate.md`   | Activate a timesheet computation item   |
+| `ssi_timesheet/docs/hr_timesheet_computation_item/06-reset-code.md` | Reset the code of one or more items     |
+
 ### `ssi_timesheet_attendance_shift` — Model: `hr.attendance_shift`
 
 Menu: **Human Resource > Configurations > Attendance > Attendance Shifts**

--- a/ssi_timesheet/README.rst
+++ b/ssi_timesheet/README.rst
@@ -7,6 +7,28 @@ Timesheets
 ==========
 
 
+Work Instruction
+================
+
+* `Create Timesheet <docs/hr_timesheet/index.html>`_
+* `Edit Timesheet <docs/hr_timesheet/index.html>`_
+* `Delete Timesheet <docs/hr_timesheet/index.html>`_
+* `Confirm Timesheet <docs/hr_timesheet/index.html>`_
+* `Approve Timesheet <docs/hr_timesheet/index.html>`_
+* `Reject Timesheet <docs/hr_timesheet/index.html>`_
+* `Start Timesheet <docs/hr_timesheet/index.html>`_
+* `Cancel Timesheet <docs/hr_timesheet/index.html>`_
+* `Restart Timesheet <docs/hr_timesheet/index.html>`_
+* `Reset Document Number — Timesheet <docs/hr_timesheet/index.html>`_
+* `Restart Approval Process — Timesheet <docs/hr_timesheet/index.html>`_
+* `Create Timesheet Computation Item <docs/hr_timesheet_computation_item/index.html>`_
+* `Edit Timesheet Computation Item <docs/hr_timesheet_computation_item/index.html>`_
+* `Delete Timesheet Computation Item <docs/hr_timesheet_computation_item/index.html>`_
+* `Deactivate Timesheet Computation Item <docs/hr_timesheet_computation_item/index.html>`_
+* `Activate Timesheet Computation Item <docs/hr_timesheet_computation_item/index.html>`_
+* `Reset Code — Timesheet Computation Item <docs/hr_timesheet_computation_item/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_timesheet/docs/hr_timesheet/01-create.md
+++ b/ssi_timesheet/docs/hr_timesheet/01-create.md
@@ -1,0 +1,59 @@
+# Create Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **State:** `—` → `draft`
+>
+> **Inline Actions:** `action_reload_timesheet_computation` (Reload),
+> `action_compute_computation` (Compute)
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `open_ok` (state
+  `draft`), `confirm_ok` (state `open`), `manual_number_ok` (state `draft`), `cancel_ok`
+  (states `draft`, `confirm`, `done`), and `restart_ok` (states `cancel`, `reject`) to
+  the relevant groups — see the _Standard Timesheet_ `policy.template` shipped with this
+  module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard -
+  Timesheet_ `approval.template` shipped with this module.
+- **Config:** An active `sequence.template` for this model exists — see the _Standard
+  Timesheet_ `sequence.template` shipped with this module.
+- **Data:** The **Employee** to select has an `hr.employee` record, and optionally has
+  **Timesheet Computations** registered on it (see the _Timesheet Computation Item_
+  configuration).
+- **Access:** User is in group _Timesheets — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Employee**: Automatically filled from the current user's linked employee record,
+     if any. Change if needed.
+   - **Department**, **Manager**, **Job Position**: Automatically filled from
+     **Employee**. Read-only.
+   - **Date Start** _(required)_: Enter the first date this timesheet covers.
+   - **Date End** _(required)_: Enter the last date this timesheet covers. Must not be
+     earlier than **Date Start**, and must not overlap the date range of another
+     timesheet for the same **Employee**.
+4. On the **Computations** tab, click **Reload** to populate the computation lines from
+   the **Timesheet Computation Items** registered on **Employee**. Existing lines whose
+   item is still registered keep their **Correction Amount**; lines whose item is no
+   longer registered are removed. You may then click **Compute** to re-evaluate each
+   line's **Amount** and **Final Amount**. Both steps also run automatically when the
+   record is **Started** or **Confirmed**, so results still populate even if skipped
+   here — use them to preview or adjust corrections beforehand.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new timesheet record is created in **Draft** status.
+- The document number stays **/** until the record is **Started** (see `07-start`),
+  unless the actor has _Can Input Manual Document Number_ access (see
+  `13-reset-number`).

--- a/ssi_timesheet/docs/hr_timesheet/02-edit.md
+++ b/ssi_timesheet/docs/hr_timesheet/02-edit.md
@@ -1,0 +1,38 @@
+# Edit Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_reload_timesheet_computation` (Reload),
+> `action_compute_computation` (Compute)
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Timesheets — User_, and is the record's **Responsible**
+  or **Employee** (record rule), or holds a broader data-ownership group (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Find and open the record to edit.
+3. Change **Employee**, **Date Start**, or **Date End** as needed.
+4. On the **Computations** tab, click **Reload** to refresh the computation lines after
+   changing **Employee** — items no longer registered on the new employee are removed
+   and newly registered items are added. Click **Compute** afterward to re-evaluate
+   **Amount** and **Final Amount**. Both steps also run automatically when the record is
+   **Started** or **Confirmed**.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_timesheet/docs/hr_timesheet/03-delete.md
+++ b/ssi_timesheet/docs/hr_timesheet/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Timesheets — User_, and is the record's **Responsible**
+  or **Employee** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_timesheet/docs/hr_timesheet/04-confirm.md
+++ b/ssi_timesheet/docs/hr_timesheet/04-confirm.md
@@ -1,0 +1,41 @@
+# Confirm Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **State:** `open` → `confirm`
+>
+> **Requires:** `07-start`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `open` to the actor's group (see the _Standard Timesheet_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard - Timesheet_ `approval.template`, which
+  defines a single sequential level approved by group _Timesheets — Validator_).
+- **Access:** User is in group _Timesheets — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- The **Computations** tab is reloaded and recomputed automatically (same effect as the
+  **Reload** and **Compute** buttons described in `01-create`).
+- Approval records are created for each approver level defined by the _Standard -
+  Timesheet_ `approval.template`.
+- Once every approval level has approved (see `05-approve`), the document transitions to
+  **Done** automatically — there is no separate Finish/Done button, and no dedicated IK
+  for this transition.

--- a/ssi_timesheet/docs/hr_timesheet/05-approve.md
+++ b/ssi_timesheet/docs/hr_timesheet/05-approve.md
@@ -1,0 +1,39 @@
+# Approve Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard Timesheet_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard - Timesheet_ `approval.template` uses sequential approval
+  with a single level, approved by group _Timesheets — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Finish/Done button. With the shipped _Standard - Timesheet_
+  `approval.template` (single level), approving always fulfills the approval and the
+  document goes straight to **Done**.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.

--- a/ssi_timesheet/docs/hr_timesheet/06-reject.md
+++ b/ssi_timesheet/docs/hr_timesheet/06-reject.md
@@ -1,0 +1,34 @@
+# Reject Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard Timesheet_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard - Timesheet_ `approval.template` uses sequential approval with
+  a single level, approved by group _Timesheets — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_timesheet/docs/hr_timesheet/07-start.md
+++ b/ssi_timesheet/docs/hr_timesheet/07-start.md
@@ -1,0 +1,38 @@
+# Start Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **State:** `draft` → `open`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `open_ok` for state
+  `draft` to the actor's group (see the _Standard Timesheet_ `policy.template`).
+- **Config:** An active `sequence.template` for this model exists (see the _Standard
+  Timesheet_ `sequence.template`) — the document number is assigned automatically at
+  this step.
+- **Access:** User is in group _Timesheets — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to start.
+3. Click the **Start** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **On Progress**.
+- The **Computations** tab is reloaded and recomputed automatically (same effect as the
+  **Reload** and **Compute** buttons described in `01-create`).
+- If the document number is still **/**, it is assigned automatically from the sequence
+  configured by the matching `sequence.template`.

--- a/ssi_timesheet/docs/hr_timesheet/10-cancel.md
+++ b/ssi_timesheet/docs/hr_timesheet/10-cancel.md
@@ -1,0 +1,34 @@
+# Cancel Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — Validator_
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard Timesheet_ `policy.template`).
+- **Access:** User is in group _Timesheets — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the timesheet.

--- a/ssi_timesheet/docs/hr_timesheet/12-restart.md
+++ b/ssi_timesheet/docs/hr_timesheet/12-restart.md
@@ -1,0 +1,33 @@
+# Restart Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard Timesheet_ `policy.template`, which
+  grants it for states **Cancelled** and **Rejected**).
+- **Access:** User is in group _Timesheets — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- When restarting from **Cancelled**, the **Reason** recorded by `10-cancel` is cleared.

--- a/ssi_timesheet/docs/hr_timesheet/13-reset-number.md
+++ b/ssi_timesheet/docs/hr_timesheet/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard Timesheet_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard
+  Timesheet_ `sequence.template`).
+- **Access:** User is in group _Timesheets — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **On Progress**
+  (see `07-start`), according to the _Standard Timesheet_ `sequence.template`
+  configuration.

--- a/ssi_timesheet/docs/hr_timesheet/14-restart-approval.md
+++ b/ssi_timesheet/docs/hr_timesheet/14-restart-approval.md
@@ -1,0 +1,45 @@
+# Restart Approval Process — Timesheet
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group (see the _Standard Timesheet_
+  `policy.template`). As shipped, this policy only evaluates to allowed while the
+  record's **Approval Template** field is still empty — since Confirm (`04-confirm`)
+  already assigns an approval template before the record reaches this state, the button
+  is typically not clickable in practice with the default configuration. See the note
+  below.
+- **Access:** User is in group _Timesheets — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped _Standard Timesheet_ `policy.template` grants
+> `restart_approval_ok` only when `approval_template_id` is **not yet** set. Because the
+> `Confirm` action (`04-confirm`) always assigns `approval_template_id` before the
+> record reaches state `confirm`, this policy is effectively never satisfied under the
+> default configuration. This was found while writing this IK and reported to the module
+> maintainers rather than fixed here, since fixing it is a code change out of scope for
+> this Work Instruction.

--- a/ssi_timesheet/docs/hr_timesheet_computation_item/01-create.md
+++ b/ssi_timesheet/docs/hr_timesheet_computation_item/01-create.md
@@ -1,0 +1,39 @@
+# Create Timesheet Computation Item
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet_computation_item`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Timesheet Computation Items
+>
+> **Actor:** user in group _Timesheet Computation Item_
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Timesheet Computation Item_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Timesheet Computation
+   Items** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter a short label for the computation item (for example
+     "Overtime Allowance").
+   - **Code** _(required)_: Enter a unique code, or leave the default **/** to assign
+     one automatically.
+4. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model. Only applies while **Code** is still
+   **/**. If no matching `sequence.template` is configured, the field stays **/** and
+   **Code** must be filled in manually before saving with a non-**/** value.
+5. On the **Computation** tab, edit the **Python Code** field. It starts pre-filled with
+   a comment template describing the available variables (`env`, `document`, `result`).
+   Replace it with the logic that evaluates whether this item applies, assigning a
+   boolean to `result`.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new timesheet computation item record is created.

--- a/ssi_timesheet/docs/hr_timesheet_computation_item/02-edit.md
+++ b/ssi_timesheet/docs/hr_timesheet_computation_item/02-edit.md
@@ -1,0 +1,35 @@
+# Edit Timesheet Computation Item
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet_computation_item`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Timesheet Computation Items
+>
+> **Actor:** user in group _Timesheet Computation Item_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Timesheet Computation Item_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Timesheet Computation
+   Items** menu.
+2. Find and open the record to edit.
+3. Change the **Name**, **Code**, or the **Python Code** on the **Computation** tab as
+   needed.
+4. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model — for example after resetting
+   **Code** back to **/**. Only applies while **Code** is **/**; if no matching
+   `sequence.template` is configured, nothing changes and **Code** must be filled in
+   manually.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_timesheet/docs/hr_timesheet_computation_item/03-delete.md
+++ b/ssi_timesheet/docs/hr_timesheet_computation_item/03-delete.md
@@ -1,0 +1,27 @@
+# Delete Timesheet Computation Item
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet_computation_item`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Timesheet Computation Items
+>
+> **Actor:** user in group _Timesheet Computation Item_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Timesheet Computation Item_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Timesheet Computation
+   Items** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_timesheet/docs/hr_timesheet_computation_item/04-deactivate.md
+++ b/ssi_timesheet/docs/hr_timesheet_computation_item/04-deactivate.md
@@ -1,0 +1,34 @@
+# Deactivate Timesheet Computation Item
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet_computation_item`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Timesheet Computation Items
+>
+> **Actor:** user in group _Timesheet Computation Item_
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group _Timesheet Computation Item_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Timesheet Computation
+   Items** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as a line item on a timesheet.
+- Timesheet computation lines that already reference this item can still be viewed, but
+  will be dropped from `hr.timesheet.computation_ids` the next time **Reload** is used
+  on the timesheet.

--- a/ssi_timesheet/docs/hr_timesheet_computation_item/05-activate.md
+++ b/ssi_timesheet/docs/hr_timesheet_computation_item/05-activate.md
@@ -1,0 +1,33 @@
+# Activate Timesheet Computation Item
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet_computation_item`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Timesheet Computation Items
+>
+> **Actor:** user in group _Timesheet Computation Item_
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group _Timesheet Computation Item_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Timesheet Computation
+   Items** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again as a line item on a timesheet, and will reappear in
+  `hr.timesheet.computation_ids` the next time **Reload** is used on the timesheet.

--- a/ssi_timesheet/docs/hr_timesheet_computation_item/06-reset-code.md
+++ b/ssi_timesheet/docs/hr_timesheet_computation_item/06-reset-code.md
@@ -1,0 +1,31 @@
+# Reset Code — Timesheet Computation Item
+
+> **Module:** ssi_timesheet
+>
+> **Model:** `hr.timesheet_computation_item`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Timesheet Computation Items
+>
+> **Actor:** user in group _Timesheet Computation Item_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** One or more records exist.
+- **Access:** User is in group _Timesheet Computation Item_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Timesheet Computation
+   Items** menu.
+2. Select one or more records whose code will be reset (check the checkbox).
+3. Click the **Reset code** button that appears above the list.
+4. Click **OK** on the confirmation dialog ("Reset code. Are you sure?").
+
+## Post-Condition
+
+- **Code** of the selected records returns to **/**.
+- The records become eligible for automatic code assignment the next time **Generate
+  Code** is used (see `01-create` and `02-edit`), or the field can be filled in
+  manually.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) lengkap untuk `ssi_timesheet`:

- `hr.timesheet` (model transaksional): create, edit, delete, confirm, approve,
  reject, start, cancel, restart, reset document number, restart approval process.
- `hr.timesheet_computation_item` (master data): create, edit, delete, deactivate,
  activate, reset code.

Aksi inline (`action_reload_timesheet_computation` / Reload, `action_compute_computation`
/ Compute, `action_generate_code` / Generate Code) ditempatkan lewat tangga
`action-placement.md` dan didokumentasikan sebagai langkah pada IK create/edit yang
relevan, ditandai dengan metadata `Inline Actions:`.

README.rst modul dan AGENTS.md repo diperbarui dengan indeks IK baru.

**Tidak termasuk** (sesuai cakupan issue): tour pasangan IK — dikerjakan terpisah di
open-synergy/opnsynid-hr-timesheet#151. Tidak ada perubahan kode model/view/security.

## Temuan yang dilaporkan, bukan diperbaiki di PR ini

- Class `HRTimesheet` (`models/hr_timesheet.py`) tidak memiliki docstring sama sekali.
- `policy_template_timesheet_restart_approval` (`data/policy_template_data.xml`)
  mengizinkan `restart_approval_ok` hanya ketika `approval_template_id` **belum**
  terisi — padahal `Confirm` selalu mengisi `approval_template_id` sebelum record
  mencapai state `confirm`, sehingga tombol *Restart Approval Process* praktis tidak
  pernah bisa diklik dengan konfigurasi default.
- `action_restart` (kembali ke Draft dari Cancelled/Rejected) tidak menghapus
  `approval_ids` lama maupun mereset `approval_template_id` — berpotensi menumpuk
  record `approval.approval` lama pada siklus confirm → restart → confirm berikutnya.

Closes #122