### PR TITLE
[UPD] ssi_timesheet_attendance - Instruksi Kerja hr.timesheet_attendance, hr.attendance_reason, dan aksi kehadiran hr.timesheet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,46 @@ Menu: **Human Resource > Configuration > Timesheets > Timesheet Computation Item
 | `ssi_timesheet/docs/hr_timesheet_computation_item/05-activate.md`   | Activate a timesheet computation item   |
 | `ssi_timesheet/docs/hr_timesheet_computation_item/06-reset-code.md` | Reset the code of one or more items     |
 
+### `ssi_timesheet_attendance` — Model: `hr.timesheet` (extends `ssi_timesheet`)
+
+Menu: **Human Resource > Timesheets > Timesheets**
+
+| File                                                                | Action                                                               |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `ssi_timesheet_attendance/docs/hr_timesheet/01-create.md`           | Additional field when creating a timesheet (Working Schedule)        |
+| `ssi_timesheet_attendance/docs/hr_timesheet/02-edit.md`             | Additional field when editing a timesheet (Working Schedule)         |
+| `ssi_timesheet_attendance/docs/hr_timesheet/07-start.md`            | Additional effect when starting a timesheet (attendance tabs unlock) |
+| `ssi_timesheet_attendance/docs/hr_timesheet/15-sign-in.md`          | Sign in (record a check-in attendance)                               |
+| `ssi_timesheet_attendance/docs/hr_timesheet/16-sign-out.md`         | Sign out (record a check-out attendance)                             |
+| `ssi_timesheet_attendance/docs/hr_timesheet/17-compute-schedule.md` | Create Schedules (generate the attendance schedule)                  |
+
+> Read together with `ssi_timesheet/docs/hr_timesheet/*` — these files are deltas
+> (additional fields/effects) or new actions on top of the base `hr.timesheet` IK, only
+> relevant when `ssi_timesheet_attendance` is installed.
+
+### `ssi_timesheet_attendance` — Model: `hr.timesheet_attendance`
+
+Menu: **Human Resource > Timesheets > Attendances**
+
+| File                                                                 | Action                            |
+| -------------------------------------------------------------------- | --------------------------------- |
+| `ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md` | Create a new timesheet attendance |
+| `ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md`   | Edit a timesheet attendance       |
+| `ssi_timesheet_attendance/docs/hr_timesheet_attendance/03-delete.md` | Delete a timesheet attendance     |
+
+### `ssi_timesheet_attendance` — Model: `hr.attendance_reason`
+
+Menu: **Human Resource > Configuration > Attendance > Attendance Reasons**
+
+| File                                                                  | Action                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------ |
+| `ssi_timesheet_attendance/docs/hr_attendance_reason/01-create.md`     | Create a new attendance reason                   |
+| `ssi_timesheet_attendance/docs/hr_attendance_reason/02-edit.md`       | Edit an attendance reason                        |
+| `ssi_timesheet_attendance/docs/hr_attendance_reason/03-delete.md`     | Delete an attendance reason                      |
+| `ssi_timesheet_attendance/docs/hr_attendance_reason/04-deactivate.md` | Deactivate an attendance reason                  |
+| `ssi_timesheet_attendance/docs/hr_attendance_reason/05-activate.md`   | Activate an attendance reason                    |
+| `ssi_timesheet_attendance/docs/hr_attendance_reason/06-reset-code.md` | Reset the code of one or more attendance reasons |
+
 ### `ssi_timesheet_attendance_shift` — Model: `hr.attendance_shift`
 
 Menu: **Human Resource > Configurations > Attendance > Attendance Shifts**

--- a/ssi_timesheet_attendance/README.rst
+++ b/ssi_timesheet_attendance/README.rst
@@ -7,6 +7,26 @@ Timesheet Attendance
 ====================
 
 
+Work Instruction
+================
+
+* `Create Timesheet Attendance <docs/hr_timesheet_attendance/index.html>`_
+* `Edit Timesheet Attendance <docs/hr_timesheet_attendance/index.html>`_
+* `Delete Timesheet Attendance <docs/hr_timesheet_attendance/index.html>`_
+* `Create Attendance Reason <docs/hr_attendance_reason/index.html>`_
+* `Edit Attendance Reason <docs/hr_attendance_reason/index.html>`_
+* `Delete Attendance Reason <docs/hr_attendance_reason/index.html>`_
+* `Deactivate Attendance Reason <docs/hr_attendance_reason/index.html>`_
+* `Activate Attendance Reason <docs/hr_attendance_reason/index.html>`_
+* `Reset Code — Attendance Reason <docs/hr_attendance_reason/index.html>`_
+* `Create Timesheet (additional fields) <docs/hr_timesheet/index.html>`_
+* `Edit Timesheet (additional fields) <docs/hr_timesheet/index.html>`_
+* `Start Timesheet (additional effect) <docs/hr_timesheet/index.html>`_
+* `Sign In — Timesheet <docs/hr_timesheet/index.html>`_
+* `Sign Out — Timesheet <docs/hr_timesheet/index.html>`_
+* `Create Schedules — Timesheet <docs/hr_timesheet/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_timesheet_attendance/docs/hr_attendance_reason/01-create.md
+++ b/ssi_timesheet_attendance/docs/hr_attendance_reason/01-create.md
@@ -1,0 +1,37 @@
+# Create Attendance Reason
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.attendance_reason`
+>
+> **Menu:** Human Resource > Configuration > Attendance > Attendance Reasons
+>
+> **Actor:** user in group _Attendance Reason_
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Reason_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Attendance > Attendance Reasons** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Reason** _(required)_: Enter a short label describing the reason (for example
+     "Business Trip").
+   - **Code** _(required)_: Enter a unique code, or enter **/** to leave it eligible for
+     automatic assignment via **Generate Code**.
+4. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model. Only applies while **Code** is still
+   **/**. If no matching `sequence.template` is configured, nothing changes and **Code**
+   must be filled in manually.
+5. Optionally fill in **Note**.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new attendance reason record is created, active by default.
+- The record becomes selectable as **Reason In** / **Reason Out** on a timesheet
+  attendance record (see `ssi_timesheet_attendance/hr_timesheet_attendance/01-create`).

--- a/ssi_timesheet_attendance/docs/hr_attendance_reason/02-edit.md
+++ b/ssi_timesheet_attendance/docs/hr_attendance_reason/02-edit.md
@@ -1,0 +1,33 @@
+# Edit Attendance Reason
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.attendance_reason`
+>
+> **Menu:** Human Resource > Configuration > Attendance > Attendance Reasons
+>
+> **Actor:** user in group _Attendance Reason_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Attendance Reason_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Attendance > Attendance Reasons** menu.
+2. Find and open the record to edit.
+3. Change **Reason**, **Code**, **Active**, or **Note** as needed.
+4. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model — for example after resetting
+   **Code** back to **/** (see `06-reset-code`). Only applies while **Code** is **/**;
+   if no matching `sequence.template` is configured, nothing changes and **Code** must
+   be filled in manually.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_timesheet_attendance/docs/hr_attendance_reason/03-delete.md
+++ b/ssi_timesheet_attendance/docs/hr_attendance_reason/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Attendance Reason
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.attendance_reason`
+>
+> **Menu:** Human Resource > Configuration > Attendance > Attendance Reasons
+>
+> **Actor:** user in group _Attendance Reason_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** **Created By System** is not set. Records created automatically by the
+  system (the default check-in / check-out reasons shipped with this module) can only be
+  deleted by a user in the _ERP Manager_ (`base.group_erp_manager`) group.
+- **Access:** User is in group _Attendance Reason_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Attendance > Attendance Reasons** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_timesheet_attendance/docs/hr_attendance_reason/04-deactivate.md
+++ b/ssi_timesheet_attendance/docs/hr_attendance_reason/04-deactivate.md
@@ -1,0 +1,32 @@
+# Deactivate Attendance Reason
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.attendance_reason`
+>
+> **Menu:** Human Resource > Configuration > Attendance > Attendance Reasons
+>
+> **Actor:** user in group _Attendance Reason_
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group _Attendance Reason_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Attendance > Attendance Reasons** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as **Reason In** / **Reason Out** on new
+  timesheet attendance records.
+- Timesheet attendance records that already reference this reason can still be viewed.

--- a/ssi_timesheet_attendance/docs/hr_attendance_reason/05-activate.md
+++ b/ssi_timesheet_attendance/docs/hr_attendance_reason/05-activate.md
@@ -1,0 +1,32 @@
+# Activate Attendance Reason
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.attendance_reason`
+>
+> **Menu:** Human Resource > Configuration > Attendance > Attendance Reasons
+>
+> **Actor:** user in group _Attendance Reason_
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group _Attendance Reason_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Attendance > Attendance Reasons** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again as **Reason In** / **Reason Out** on new timesheet
+  attendance records.

--- a/ssi_timesheet_attendance/docs/hr_attendance_reason/06-reset-code.md
+++ b/ssi_timesheet_attendance/docs/hr_attendance_reason/06-reset-code.md
@@ -1,0 +1,30 @@
+# Reset Code — Attendance Reason
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.attendance_reason`
+>
+> **Menu:** Human Resource > Configuration > Attendance > Attendance Reasons
+>
+> **Actor:** user in group _Attendance Reason_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** One or more records exist.
+- **Access:** User is in group _Attendance Reason_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Attendance > Attendance Reasons** menu.
+2. Select one or more records whose code will be reset (check the checkbox).
+3. Click the **Reset code** button that appears above the list.
+4. Click **OK** on the confirmation dialog ("Reset code. Are you sure?").
+
+## Post-Condition
+
+- **Code** of the selected records returns to **/**.
+- The records become eligible for automatic code assignment the next time **Generate
+  Code** is used (see `01-create` and `02-edit`), or the field can be filled in
+  manually.

--- a/ssi_timesheet_attendance/docs/hr_timesheet/01-create.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet/01-create.md
@@ -1,0 +1,15 @@
+# Create Timesheet
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Extends:** ssi_timesheet — model `hr.timesheet`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one required field:
+
+- **Working Schedule** _(required)_: The `resource.calendar` used to compute this
+  timesheet's Attendance Schedule (see
+  `ssi_timesheet_attendance/hr_timesheet/17-compute-schedule`). Automatically filled
+  from **Employee**'s default working calendar, if any — fill in manually if the
+  employee has none configured. Editable only while the record is **Draft**.

--- a/ssi_timesheet_attendance/docs/hr_timesheet/02-edit.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet/02-edit.md
@@ -1,0 +1,12 @@
+# Edit Timesheet
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Extends:** ssi_timesheet — model `hr.timesheet`, aksi `02-edit`
+
+## Additional Fields
+
+- **Working Schedule** _(required)_: Editable only while the record is **Draft** (same
+  restriction as the base **Edit** action). Change it to recompute a different
+  Attendance Schedule the next time
+  `ssi_timesheet_attendance/hr_timesheet/17-compute-schedule` is used.

--- a/ssi_timesheet_attendance/docs/hr_timesheet/07-start.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet/07-start.md
@@ -1,0 +1,13 @@
+# Start Timesheet
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Extends:** ssi_timesheet — model `hr.timesheet`, aksi `07-start`
+
+## Additional Post-Condition
+
+- The **Attendance** and **Attendance Schedules** tabs become usable: **Sign In** /
+  **Sign Out** (see `ssi_timesheet_attendance/hr_timesheet/15-sign-in` and
+  `16-sign-out`) and **Create Schedules** (see
+  `ssi_timesheet_attendance/hr_timesheet/17-compute-schedule`) become available while
+  the record stays **On Progress**.

--- a/ssi_timesheet_attendance/docs/hr_timesheet/15-sign-in.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet/15-sign-in.md
@@ -1,0 +1,38 @@
+# Sign In — Timesheet
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **Requires:** `ssi_timesheet/hr_timesheet/07-start`
+>
+> **Extends:** ssi_timesheet — model `hr.timesheet`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**. The **Sign In** button is only visible while
+  the timesheet is On Progress and the employee's **Attendance Status** is **Sign Out**.
+- **Access:** User is in group _Timesheets — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to sign in for (status **On Progress**).
+3. On the **Attendance** tab, click **Sign In** (`action_sign_in`).
+
+## Post-Condition
+
+- A new `hr.timesheet_attendance` record is created for the employee, with **Check In**
+  set to the current date and time and **Date** set to today (see
+  `ssi_timesheet_attendance/hr_timesheet_attendance/01-create`). No **Reason In** is set
+  by this button — it can be filled in afterward by editing the new row directly on the
+  **Attendance** tab, or via `ssi_timesheet_attendance/hr_timesheet_attendance/02-edit`.
+- **Attendance Status** changes to **Sign In**; the **Sign In** button becomes hidden
+  and **Sign Out** becomes visible.
+- **Latest Attendance** is updated to point to the new record.
+- Sign In is also available without opening this menu, from the attendance widget in the
+  top bar (calls the same action through the employee's active timesheet).

--- a/ssi_timesheet_attendance/docs/hr_timesheet/16-sign-out.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet/16-sign-out.md
@@ -1,0 +1,48 @@
+# Sign Out — Timesheet
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **Requires:** `15-sign-in`
+>
+> **Extends:** ssi_timesheet — model `hr.timesheet`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**. The **Sign Out** button is only visible while
+  the timesheet is On Progress and the employee's **Attendance Status** is **Sign In**
+  (i.e. a Sign In was already done and not yet closed).
+- **Access:** User is in group _Timesheets — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record to sign out from (status **On Progress**, employee currently signed
+   in).
+3. On the **Attendance** tab, click **Sign Out** (`action_sign_out`).
+
+## Post-Condition
+
+- In the usual case, the employee's latest (open) `hr.timesheet_attendance` record is
+  updated: **Check Out** is set to the current date and time, with no **Reason Out**
+  filled by this button.
+- If the check-out date falls on a different date than the attendance's **Date** _and_
+  the gap from the **Working Schedule**'s scheduled end exceeds the company's **Check
+  Out Buffer** (`res.company`, Attendance settings — 0.0 hours if not configured), the
+  sign-out is treated as an anomaly instead: a **new**, already-closed
+  `hr.timesheet_attendance` record is created (**Check In** = **Check Out** = now), with
+  **Reason In** / **Reason Out** defaulted from the company's **Check In Reason** /
+  **Check Out Reason** (falling back to this module's default _[SYSTEM] Automatic check
+  in/out due to inactivity_ reasons when the company fields are empty).
+- Either way, the resulting entry can be corrected afterward by editing it directly on
+  the **Attendance** tab, or via
+  `ssi_timesheet_attendance/hr_timesheet_attendance/02-edit`.
+- **Attendance Status** changes to **Sign Out**; the **Sign Out** button becomes hidden
+  and **Sign In** becomes visible.
+- Sign Out is also available without opening this menu, from the attendance widget in
+  the top bar (calls the same action through the employee's active timesheet).

--- a/ssi_timesheet_attendance/docs/hr_timesheet/17-compute-schedule.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet/17-compute-schedule.md
@@ -1,0 +1,41 @@
+# Create Schedules — Timesheet
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.timesheet`
+>
+> **Menu:** Human Resource > Timesheets > Timesheets
+>
+> **Actor:** user in group _Timesheets — User_
+>
+> **Requires:** `ssi_timesheet/hr_timesheet/01-create`
+>
+> **Extends:** ssi_timesheet — model `hr.timesheet`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft** or **On Progress**. **Working Schedule**, **Date
+  Start**, and **Date End** must be filled — they are required to compute the schedule
+  intervals.
+- **Access:** User is in group _Timesheets — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Timesheets** menu.
+2. Open the record (status **Draft** or **On Progress**).
+3. On the **Attendance Schedules** tab, click **Create Schedules**
+   (`action_compute_schedule`).
+4. Click **OK** on the confirmation dialog ("Compute Schedules. Are you sure?").
+
+## Post-Condition
+
+- Existing `hr.timesheet_attendance_schedule` lines for this timesheet are removed and
+  regenerated from **Working Schedule**'s attendance intervals between **Date Start**
+  and **Date End**, excluding public holidays.
+- Each attendance record already recorded on the **Attendance** tab is re-linked to the
+  matching schedule slot for the same date, and each schedule slot's real
+  attendance/deviation figures (Real Date Start/End, Early Start, Late Start, Finish
+  Early, Finish Late) are recalculated from those attendance records.
+- This step can be repeated at any time while the record is **Draft** or **On
+  Progress**; running it again discards and regenerates all **Attendance Schedules**
+  lines.

--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
@@ -1,0 +1,49 @@
+# Create Timesheet Attendance
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.timesheet_attendance`
+>
+> **Menu:** Human Resource > Timesheets > Attendances
+>
+> **Actor:** user in group _Timesheet Attendance_
+
+## Pre-Condition
+
+- **Record:** An `hr.timesheet` for the current user's employee, covering **Date**,
+  exists with status **On Progress**. The record cannot be saved otherwise — **Sheet**
+  is resolved automatically from **Date** and the employee, and saving fails with an
+  error if no matching open timesheet is found.
+- **Access:** User is in group _Timesheet Attendance_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Attendances** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Date** _(required)_: Enter the calendar date this attendance belongs to. Must
+     fall within the date range of an **On Progress** timesheet for the current user's
+     employee.
+   - **Check In** _(required)_: Automatically filled with the current date and time.
+     Change if needed.
+   - **Reason In**: Select a reason for the check-in. Optional.
+   - **Check Out**: Enter the check-out date and time, if already known. Leave empty to
+     fill in later (see `02-edit`).
+   - **Reason Out**: Select a reason for the check-out. Optional; only meaningful once
+     **Check Out** is filled.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new attendance record is created.
+- **Sheet**, **Attendance Schedule**, **Valid Check In**, **Valid Check Out**, **Total
+  Hour**, and **Total Valid Hour** are computed automatically from **Date**, **Check
+  In**, and **Check Out**.
+- Status becomes **Open** if only one of **Check In** / **Check Out** is filled, or
+  **Present** once both are filled.
+- The matching timesheet's daily summary is recalculated automatically.
+- This record is more commonly created automatically via the **Sign In** / **Sign Out**
+  action on the timesheet (see `ssi_timesheet_attendance/hr_timesheet/15-sign-in.md` and
+  `ssi_timesheet_attendance/hr_timesheet/16-sign-out.md`), or via the attendance widget
+  in the top bar, without opening this menu. This flow is for entering or correcting an
+  attendance record directly.

--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md
@@ -1,0 +1,33 @@
+# Edit Timesheet Attendance
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.timesheet_attendance`
+>
+> **Menu:** Human Resource > Timesheets > Attendances
+>
+> **Actor:** user in group _Timesheet Attendance_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Timesheet Attendance_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Attendances** menu.
+2. Find and open the record to edit.
+3. Change **Date**, **Check In**, **Reason In**, **Check Out**, or **Reason Out** as
+   needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- **Sheet**, **Attendance Schedule**, **Valid Check In**, **Valid Check Out**, **Total
+  Hour**, and **Total Valid Hour** are recomputed automatically.
+- Status is recomputed to **Present** once both **Check In** and **Check Out** are
+  filled, or back to **Open** if one of them is cleared.
+- The matching timesheet's daily summary is recalculated automatically whenever
+  **Date**, **Check In**, or **Check Out** changes.

--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/03-delete.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/03-delete.md
@@ -1,0 +1,28 @@
+# Delete Timesheet Attendance
+
+> **Module:** ssi_timesheet_attendance
+>
+> **Model:** `hr.timesheet_attendance`
+>
+> **Menu:** Human Resource > Timesheets > Attendances
+>
+> **Actor:** user in group _Timesheet Attendance_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Timesheet Attendance_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Attendances** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.
+- Records are also removed automatically, without this flow, when their parent timesheet
+  is deleted.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) untuk `ssi_timesheet_attendance`:

- IK penuh untuk model `hr.timesheet_attendance` (01-create, 02-edit, 03-delete).
- IK master data untuk model `hr.attendance_reason` (01-create, 02-edit, 03-delete,
  04-deactivate, 05-activate, 06-reset-code).
- IK delta pada `hr.timesheet` (field **Working Schedule** di 01-create/02-edit,
  efek tambahan di 07-start) dan IK penuh untuk aksi kehadiran baru yang ditambahkan
  modul ini: **Sign In** (15-sign-in), **Sign Out** (16-sign-out), **Create
  Schedules** (17-compute-schedule) — lolos tangga penempatan aksi sebagai IK
  sendiri (S3: masing-masing membuat/mengubah record `hr.timesheet_attendance` atau
  `hr.timesheet_attendance_schedule`).
- Memperbarui `README.rst` modul dengan bagian Work Instruction.
- Memperbarui indeks `AGENTS.md` di root repo.

**Tour untuk IK ini sengaja tidak termasuk** — item terpisah
open-synergy/opnsynid-hr-timesheet#152 (satu berkas IK = satu tour), sesuai scope
issue #123.

## Kriteria Penerimaan

- [x] `docs/hr_timesheet_attendance/` dan `docs/hr_attendance_reason/` berisi IK untuk
      setiap aksi yang terbukti ada di kode & view
- [x] Aksi kehadiran pada `hr.timesheet` punya tepat satu rumah (berkas IK sendiri,
      dideklarasikan `Extends:`)
- [x] IK delta memuat baris metadata `Extends:` yang menunjuk modul sumbernya
- [x] Tiap berkas IK memuat blok metadata dan bagian Pre-Condition/Flow/Post-Condition
      (delta memuat section perubahan sesuai arketipe)
- [x] Tiap butir Pre-Condition memikul label tipe dari lima tipe tertutup
- [x] `README.rst` modul dan `AGENTS.md` memuat seluruh IK baru
- [x] Seluruh isi IK berbahasa Inggris

Diverifikasi dengan `odoo-development-instruksi-kerja`'s `assets/validate-ik.sh`:
0 error (peringatan yang tersisa hanya "tak ada tour" — diharapkan, lihat #152).

Closes #123