### PR TITLE
[UPD] ssi_hr_holiday: Instruksi Kerja hr.leave, hr.leave_allocation, hr.leave_type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,54 @@ Menu: **Human Resource > Configuration > Timesheets > Timesheet Computation Item
 | `ssi_timesheet/docs/hr_timesheet_computation_item/05-activate.md`   | Activate a timesheet computation item   |
 | `ssi_timesheet/docs/hr_timesheet_computation_item/06-reset-code.md` | Reset the code of one or more items     |
 
+### `ssi_hr_holiday` — Model: `hr.leave`
+
+Menu: **Human Resource > Timesheets > Leaves**
+
+| File                                                  | Action                                |
+| ----------------------------------------------------- | ------------------------------------- |
+| `ssi_hr_holiday/docs/hr_leave/01-create.md`           | Create a new leave                    |
+| `ssi_hr_holiday/docs/hr_leave/02-edit.md`             | Edit a leave                          |
+| `ssi_hr_holiday/docs/hr_leave/03-delete.md`           | Delete a leave                        |
+| `ssi_hr_holiday/docs/hr_leave/04-confirm.md`          | Confirm a leave (submit for approval) |
+| `ssi_hr_holiday/docs/hr_leave/05-approve.md`          | Approve a leave                       |
+| `ssi_hr_holiday/docs/hr_leave/06-reject.md`           | Reject a leave                        |
+| `ssi_hr_holiday/docs/hr_leave/10-cancel.md`           | Cancel a leave                        |
+| `ssi_hr_holiday/docs/hr_leave/12-restart.md`          | Restart a cancelled/rejected leave    |
+| `ssi_hr_holiday/docs/hr_leave/13-reset-number.md`     | Reset a leave's document number       |
+| `ssi_hr_holiday/docs/hr_leave/14-restart-approval.md` | Restart a leave's approval process    |
+
+### `ssi_hr_holiday` — Model: `hr.leave_allocation`
+
+Menu: **Human Resource > Timesheets > Leave Allocations**
+
+| File                                                             | Action                                           |
+| ---------------------------------------------------------------- | ------------------------------------------------ |
+| `ssi_hr_holiday/docs/hr_leave_allocation/01-create.md`           | Create a new leave allocation                    |
+| `ssi_hr_holiday/docs/hr_leave_allocation/02-edit.md`             | Edit a leave allocation                          |
+| `ssi_hr_holiday/docs/hr_leave_allocation/03-delete.md`           | Delete a leave allocation                        |
+| `ssi_hr_holiday/docs/hr_leave_allocation/04-confirm.md`          | Confirm a leave allocation (submit for approval) |
+| `ssi_hr_holiday/docs/hr_leave_allocation/05-approve.md`          | Approve a leave allocation                       |
+| `ssi_hr_holiday/docs/hr_leave_allocation/06-reject.md`           | Reject a leave allocation                        |
+| `ssi_hr_holiday/docs/hr_leave_allocation/09-auto-done.md`        | Automatic transition to Done when days run out   |
+| `ssi_hr_holiday/docs/hr_leave_allocation/10-cancel.md`           | Cancel a leave allocation                        |
+| `ssi_hr_holiday/docs/hr_leave_allocation/11-terminate.md`        | Terminate a leave allocation                     |
+| `ssi_hr_holiday/docs/hr_leave_allocation/12-restart.md`          | Restart a cancelled leave allocation             |
+| `ssi_hr_holiday/docs/hr_leave_allocation/13-reset-number.md`     | Reset a leave allocation's document number       |
+| `ssi_hr_holiday/docs/hr_leave_allocation/14-restart-approval.md` | Restart a leave allocation's approval process    |
+
+### `ssi_hr_holiday` — Model: `hr.leave_type`
+
+Menu: **Human Resource > Configuration > Timesheets > Leave Type**
+
+| File                                                 | Action                  |
+| ---------------------------------------------------- | ----------------------- |
+| `ssi_hr_holiday/docs/hr_leave_type/01-create.md`     | Create a new leave type |
+| `ssi_hr_holiday/docs/hr_leave_type/02-edit.md`       | Edit a leave type       |
+| `ssi_hr_holiday/docs/hr_leave_type/03-delete.md`     | Delete a leave type     |
+| `ssi_hr_holiday/docs/hr_leave_type/04-deactivate.md` | Deactivate a leave type |
+| `ssi_hr_holiday/docs/hr_leave_type/05-activate.md`   | Activate a leave type   |
+
 ### `ssi_timesheet_attendance` — Model: `hr.timesheet` (extends `ssi_timesheet`)
 
 Menu: **Human Resource > Timesheets > Timesheets**

--- a/ssi_hr_holiday/README.rst
+++ b/ssi_hr_holiday/README.rst
@@ -7,6 +7,38 @@ Leave Management
 ================
 
 
+Work Instruction
+================
+
+* `Create Leave <docs/hr_leave/index.html>`_
+* `Edit Leave <docs/hr_leave/index.html>`_
+* `Delete Leave <docs/hr_leave/index.html>`_
+* `Confirm Leave <docs/hr_leave/index.html>`_
+* `Approve Leave <docs/hr_leave/index.html>`_
+* `Reject Leave <docs/hr_leave/index.html>`_
+* `Cancel Leave <docs/hr_leave/index.html>`_
+* `Restart Leave <docs/hr_leave/index.html>`_
+* `Reset Document Number — Leave <docs/hr_leave/index.html>`_
+* `Restart Approval Process — Leave <docs/hr_leave/index.html>`_
+* `Create Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Edit Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Delete Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Confirm Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Approve Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Reject Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Auto Transition to Done — Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Cancel Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Terminate Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Restart Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Reset Document Number — Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Restart Approval Process — Leave Allocation <docs/hr_leave_allocation/index.html>`_
+* `Create Leave Type <docs/hr_leave_type/index.html>`_
+* `Edit Leave Type <docs/hr_leave_type/index.html>`_
+* `Delete Leave Type <docs/hr_leave_type/index.html>`_
+* `Deactivate Leave Type <docs/hr_leave_type/index.html>`_
+* `Activate Leave Type <docs/hr_leave_type/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_hr_holiday/docs/hr_leave/01-create.md
+++ b/ssi_hr_holiday/docs/hr_leave/01-create.md
@@ -1,0 +1,68 @@
+# Create Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`), `manual_number_ok` (state `draft`), and `cancel_ok` (states `draft`,
+  `confirm`, `done`) to the relevant groups — see the _Standard_ `policy.template`
+  shipped with this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module.
+- **Config:** An active `sequence.template` for this model exists — see the _Standard
+  Leave_ `sequence.template` shipped with this module.
+- **Data:** The **Employee** to select has an `hr.employee` record, and has an
+  `hr.timesheet` record whose **Date Start**/**Date End** range covers this leave's
+  **Date Start**/**Date End** (see `ssi_timesheet/docs/hr_timesheet/01-create.md`) — a
+  leave cannot be saved without a matching timesheet.
+- **Data:** If the selected **Leave Type** has **Need Allocation** checked, an
+  `hr.leave_allocation` record in status **In Progress** must exist for the same
+  **Employee** and **Leave Type**, covering this leave's date range, with enough
+  **Available Days** (see `ssi_hr_holiday/docs/hr_leave_allocation/01-create.md`) —
+  otherwise confirming this leave will fail (see `04-confirm`).
+- **Access:** User is in group _Leave — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Employee**: Automatically filled from the current user's linked employee record,
+     if any. Change if needed.
+   - **Department**, **Manager**, **Job Position**: Automatically filled from
+     **Employee**. Read-only.
+   - **Leave Type** _(required)_: Select the type of leave being requested.
+   - **Date Start** _(required)_: Enter the first date of the leave. Must not overlap
+     the date range of another (non-cancelled, non-rejected) leave for the same
+     **Employee**.
+   - **Date End** _(required)_: Enter the last date of the leave. Must not be earlier
+     than **Date Start**.
+   - **Number of Days** _(required)_: Automatically filled from **Duration** once **Date
+     Start**/**Date End** are set. Change if a different value is needed (for example a
+     half-day leave).
+4. Click **Save**.
+
+## Post-Condition
+
+- A new leave record is created in **Draft** status.
+- **# Timesheet** is automatically linked to the `hr.timesheet` whose date range covers
+  this leave; saving fails if no matching timesheet is found.
+- **Duration** is automatically computed from the **Schedules** tab, which lists the
+  attendance schedules matching **Employee**/**Date Start**/**Date End** — public
+  holidays within that range are excluded from **Duration** (see the note on
+  `ssi_hr_holiday/docs/hr_leave_type/01-create.md`).
+- **# Leave Allocation** is automatically linked to a matching, available leave
+  allocation for **Employee**/**Leave Type**, if one exists.
+- The document number stays **/** until the record transitions to **Done**, which
+  happens automatically once approval completes (see `04-confirm`) — there is no
+  separate Finish/Done button — unless the actor has _Can Input Manual Document Number_
+  access (see `13-reset-number`).

--- a/ssi_hr_holiday/docs/hr_leave/02-edit.md
+++ b/ssi_hr_holiday/docs/hr_leave/02-edit.md
@@ -1,0 +1,33 @@
+# Edit Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Leave — User_, and is the record's **Responsible** or
+  **Employee** (record rule), or holds a broader data-ownership group (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Find and open the record to edit.
+3. Change **Employee**, **Leave Type**, **Date Start**, **Date End**, or **Number of
+   Days** as needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- **# Timesheet**, **Duration**, and **# Leave Allocation** are recomputed the same way
+  as described in `01-create`.

--- a/ssi_hr_holiday/docs/hr_leave/03-delete.md
+++ b/ssi_hr_holiday/docs/hr_leave/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Leave — User_, and is the record's **Responsible** or
+  **Employee** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_holiday/docs/hr_leave/04-confirm.md
+++ b/ssi_hr_holiday/docs/hr_leave/04-confirm.md
@@ -1,0 +1,49 @@
+# Confirm Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single sequential level approved by group _Leave — Validator_).
+- **Data:** If **Leave Type** has **Need Allocation** checked, an available **# Leave
+  Allocation** with enough **Available Days** must be linked (see `01-create`) —
+  otherwise this step fails with a validation error.
+- **Access:** User is in group _Leave — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- **# Timesheet**, **Duration**, and **# Leave Allocation** are recomputed automatically
+  (same effect as described in `01-create`).
+- Approval records are created for each approver level defined by the _Standard_
+  `approval.template`.
+- Once every approval level has approved (see `05-approve`), the document transitions to
+  **Done** automatically — there is no separate Finish/Done button, and no dedicated IK
+  for this transition. The document number is also assigned automatically at this point
+  (unless already manually assigned — see `13-reset-number`).
+- If the leave was linked to a **# Leave Allocation**, that allocation's **Used Days**
+  and **Available Days** are recomputed, and may reach **0**, triggering the
+  allocation's automatic transition to **Done** (see
+  `ssi_hr_holiday/docs/hr_leave_allocation/09-auto-done.md`).

--- a/ssi_hr_holiday/docs/hr_leave/05-approve.md
+++ b/ssi_hr_holiday/docs/hr_leave/05-approve.md
@@ -1,0 +1,43 @@
+# Approve Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Finish/Done button. With the shipped _Standard_ `approval.template`
+  (single level), approving always fulfills the approval and the document goes straight
+  to **Done**.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- Once **Done**, the linked **# Leave Allocation** (if any) has its **Used Days** and
+  **Available Days** recomputed, which may trigger that allocation's automatic
+  transition to **Done** (see
+  `ssi_hr_holiday/docs/hr_leave_allocation/09-auto-done.md`).

--- a/ssi_hr_holiday/docs/hr_leave/06-reject.md
+++ b/ssi_hr_holiday/docs/hr_leave/06-reject.md
@@ -1,0 +1,34 @@
+# Reject Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_hr_holiday/docs/hr_leave/10-cancel.md
+++ b/ssi_hr_holiday/docs/hr_leave/10-cancel.md
@@ -1,0 +1,45 @@
+# Cancel Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — Validator_
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Leave — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the leave.
+- The code attempts to also reopen a linked **# Leave Allocation** that is in status
+  **Done** back to **In Progress** as part of this step. See the note below.
+
+> **Note:** as implemented, this reopen attempt calls the allocation's `action_open()`
+> directly, without bypassing the `open_ok` policy check. The shipped `policy.template`
+> named "Standard" never grants `open_ok` on `hr.leave_allocation` (see the note on
+> `ssi_hr_holiday/docs/hr_leave_allocation/04-confirm.md`), so this appears to make
+> cancelling a **Done** leave whose allocation is also **Done** fail with a policy error
+> instead of completing the cancellation. This was found while writing this IK and
+> reported to the module maintainers rather than fixed here, since fixing it is a code
+> change out of scope for this Work Instruction.

--- a/ssi_hr_holiday/docs/hr_leave/12-restart.md
+++ b/ssi_hr_holiday/docs/hr_leave/12-restart.md
@@ -1,0 +1,33 @@
+# Restart Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it for
+  states **Cancelled** and **Rejected**).
+- **Access:** User is in group _Leave — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- When restarting from **Cancelled**, the **Reason** recorded by `10-cancel` is cleared.

--- a/ssi_hr_holiday/docs/hr_leave/13-reset-number.md
+++ b/ssi_hr_holiday/docs/hr_leave/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard
+  Leave_ `sequence.template`).
+- **Access:** User is in group _Leave — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** (see
+  `04-confirm`, completed automatically once approved), according to the _Standard
+  Leave_ `sequence.template` configuration.

--- a/ssi_hr_holiday/docs/hr_leave/14-restart-approval.md
+++ b/ssi_hr_holiday/docs/hr_leave/14-restart-approval.md
@@ -1,0 +1,44 @@
+# Restart Approval Process — Leave
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave`
+>
+> **Menu:** Human Resource > Timesheets > Leaves
+>
+> **Actor:** user in group _Leave — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group (see the _Standard_ `policy.template`). As
+  shipped, this policy only evaluates to allowed while the record's **Approval
+  Template** field is still empty — since Confirm (`04-confirm`) already assigns an
+  approval template before the record reaches this state, the button is typically not
+  clickable in practice with the default configuration. See the note below.
+- **Access:** User is in group _Leave — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leaves** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, this policy is effectively never satisfied under the default configuration.
+> This was found while writing this IK and reported to the module maintainers rather
+> than fixed here, since fixing it is a code change out of scope for this Work
+> Instruction.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/01-create.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/01-create.md
@@ -1,0 +1,62 @@
+# Create Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`), `manual_number_ok` (state `draft`), `cancel_ok` (states `draft`, `confirm`,
+  `open`, `done`, `reject`), `restart_ok` (state `cancel`), and `terminate_ok` (state
+  `done`) to the relevant groups — see the _Standard_ `policy.template` shipped with
+  this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module.
+- **Config:** An active `sequence.template` for this model exists — see the _Standard
+  Leave Allocation_ `sequence.template` shipped with this module.
+- **Data:** The **Employee** to select has an `hr.employee` record.
+- **Data:** A **Leave Type** exists with **Need Allocation** checked (see
+  `ssi_hr_holiday/docs/hr_leave_type/01-create.md`) — only leave types with **Need
+  Allocation** checked can be selected as **Leave Type** here.
+- **Access:** User is in group _Leave Allocation — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Leave Type** _(required)_: Select a leave type that has **Need Allocation**
+     checked.
+   - **Employee**: Automatically filled from the current user's linked employee record,
+     if any. Change if needed.
+   - **Department**, **Manager**, **Job Position**: Automatically filled from
+     **Employee**. Read-only.
+   - **Date Start** _(required)_: Enter the first date this allocation is valid from.
+   - **Date End** _(required)_: Enter the last date this allocation is valid until. Must
+     not be earlier than **Date Start**, and must not overlap the date range of another
+     leave allocation for the same **Employee**.
+   - **Number of Days** _(required)_: Enter the number of leave days granted by this
+     allocation.
+   - **Can be Extended**: Check to allow **Date Extended** to be set later than **Date
+     End**. Leave unchecked to keep **Date Extended** equal to **Date End**.
+   - **Date Extended** _(required)_: Defaults to **Date End**. If **Can be Extended** is
+     checked, enter a later date until which leaves may still be taken from this
+     allocation.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new leave allocation record is created in **Draft** status.
+- The document number stays **/** until the record transitions to **In Progress**, which
+  happens automatically once approval completes (see `04-confirm`) — there is no
+  separate Open/Start button — unless the actor has _Can Input Manual Document Number_
+  access (see `13-reset-number`).
+- **Used Days**, **Plannned Days**, and **Available Days** are computed from the linked
+  **Leaves** tab and initially show **0** and the full **Number of Days**, respectively.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/02-edit.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/02-edit.md
@@ -1,0 +1,31 @@
+# Edit Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Leave Allocation — User_, and is the record's
+  **Responsible** or **Employee** (record rule), or holds a broader data-ownership group
+  (_Direct Subordinate_, _All Subordinate_, _Company_, _Company and All Child
+  Companies_, or _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Find and open the record to edit.
+3. Change **Leave Type**, **Employee**, **Date Start**, **Date End**, **Number of
+   Days**, **Can be Extended**, or **Date Extended** as needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/03-delete.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/03-delete.md
@@ -1,0 +1,30 @@
+# Delete Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Leave Allocation — User_, and is the record's
+  **Responsible** or **Employee** (record rule), or holds a broader data-ownership
+  group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/04-confirm.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/04-confirm.md
@@ -1,0 +1,45 @@
+# Confirm Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single sequential level approved by group _Leave Allocation — Validator_).
+- **Access:** User is in group _Leave Allocation — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the _Standard_
+  `approval.template`.
+- Once every approval level has approved (see `05-approve`), the document transitions to
+  **In Progress** automatically — there is no separate Open/Start button, and no
+  dedicated IK for this transition. The document number is also assigned automatically
+  at this point (unless already manually assigned — see `13-reset-number`).
+
+> **Note:** the shipped _Standard_ `policy.template` does not define an `open_ok` detail
+> for this model, so even though the underlying framework can render an Open/Start
+> button, it always stays hidden. This confirms the confirm → open transition is only
+> ever reached automatically, once approval is complete.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/05-approve.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/05-approve.md
@@ -1,0 +1,39 @@
+# Approve Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `open`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **In Progress** automatically
+  — there is no separate Open/Start button. With the shipped _Standard_
+  `approval.template` (single level), approving always fulfills the approval and the
+  document goes straight to **In Progress**.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/06-reject.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/06-reject.md
@@ -1,0 +1,37 @@
+# Reject Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.
+- There is no policy path back to **Draft** from **Rejected** for this model — the
+  shipped _Standard_ `policy.template` only grants `restart_ok` for state **Cancelled**
+  (see `12-restart`).

--- a/ssi_hr_holiday/docs/hr_leave_allocation/09-auto-done.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/09-auto-done.md
@@ -1,0 +1,39 @@
+# Auto Transition to Done — Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** system (`base.automation`, no user action)
+>
+> **State:** `open` → `done`
+>
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **In Progress**.
+- **Record:** **Available Days** (`num_of_days_available`) is greater than **0** just
+  before the triggering write (the automation's `filter_pre_domain`).
+
+## Flow
+
+This transition is **not** triggered by a user action — there is no button for it. It
+runs automatically via the `base.automation` record `leave_allocation_done` whenever a
+write on the allocation causes **Available Days** to become exactly **0** (the
+automation's `filter_domain`). In practice this happens when the linked **Leaves**
+(`leave_ids`) change in a way that recomputes **Used Days**, **Plannned Days**, or
+**Available Days** — most commonly, a **Leave** that draws from this allocation reaches
+status **Done** (see `ssi_hr_holiday/docs/hr_leave/04-confirm.md`, whose approval
+completion sets the leave to **Done** automatically) and fully consumes the remaining
+**Available Days**.
+
+## Post-Condition
+
+- Status changes to **Done**.
+- No approval, policy, or sequence configuration is required for this transition — the
+  server action it triggers (`leave_allocation_action_done`) calls `action_done()`
+  directly, and the model's `done_ok` policy check is bypassed because
+  `_automatically_insert_done_button` is set to `False` for this model.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/10-cancel.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/10-cancel.md
@@ -1,0 +1,37 @@
+# Cancel Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — Validator_
+>
+> **State:** `draft` | `confirm` | `open` | `done` | `reject` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, **In Progress**, **Done**,
+  or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the allocation.
+- If any **Leaves** referencing this allocation are not already **Cancelled** or
+  **Rejected**, cancellation fails — cancel or reject those leaves first.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/11-terminate.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/11-terminate.md
@@ -1,0 +1,48 @@
+# Terminate Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — Validator_
+>
+> **State:** `done` → `terminate`
+>
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **Done**.
+- **Config:** An active `policy.template` for this model grants `terminate_ok` for state
+  `done` to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to terminate.
+3. Click the **Terminate** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Terminated**.
+- The selected **Reason** is recorded on the allocation.
+- There is no policy path back to **Draft** from **Terminated** for this model — the
+  shipped _Standard_ `policy.template` only grants `restart_ok` for state **Cancelled**
+  (see `12-restart`).
+
+> **Note:** a daily scheduled action (`ir_cron_terminate_allocation`) attempts the same
+> effect automatically, without any user action, for any **In Progress** (`open`)
+> allocation whose **Date Extended** has passed. As implemented, this scheduled job
+> calls the same `action_terminate()` used by the button above, which re-checks the
+> `terminate_ok` policy — and the shipped _Standard_ `policy.template` only grants
+> `terminate_ok` for state **Done**, not **In Progress**. This appears to make the
+> scheduled job fail with a policy error for its actual target records instead of
+> terminating them. This was found while writing this IK and reported to the module
+> maintainers rather than fixed here, since fixing it is a code change out of scope for
+> this Work Instruction.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/12-restart.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/12-restart.md
@@ -1,0 +1,38 @@
+# Restart Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — Validator_
+>
+> **State:** `cancel` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for state
+  `cancel` to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- The **Reason** recorded by `10-cancel` is cleared.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_ok` **only** for
+> state **Cancelled** — there is no policy path back to **Draft** from **Rejected**
+> (`06-reject`) or **Terminated** (`11-terminate`) for this model, even though the
+> **Restart** button itself is rendered for any state (visibility is controlled entirely
+> by `restart_ok`).

--- a/ssi_hr_holiday/docs/hr_leave_allocation/13-reset-number.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard
+  Leave Allocation_ `sequence.template`).
+- **Access:** User is in group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **In Progress**
+  (see `04-confirm`, completed automatically once approved), according to the _Standard
+  Leave Allocation_ `sequence.template` configuration.

--- a/ssi_hr_holiday/docs/hr_leave_allocation/14-restart-approval.md
+++ b/ssi_hr_holiday/docs/hr_leave_allocation/14-restart-approval.md
@@ -1,0 +1,45 @@
+# Restart Approval Process — Leave Allocation
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_allocation`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocations
+>
+> **Actor:** user in group _Leave Allocation — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for states `confirm` and `reject` to the actor's group (see the _Standard_
+  `policy.template`). As shipped, this policy only evaluates to allowed while the
+  record's **Approval Template** field is still empty — since Confirm (`04-confirm`)
+  already assigns an approval template before the record reaches state `confirm`, the
+  button is typically not clickable in practice with the default configuration. See the
+  note below.
+- **Access:** User is in group _Leave Allocation — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocations** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains unchanged.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, this policy is effectively never satisfied under the default configuration.
+> This was found while writing this IK and reported to the module maintainers rather
+> than fixed here, since fixing it is a code change out of scope for this Work
+> Instruction.

--- a/ssi_hr_holiday/docs/hr_leave_type/01-create.md
+++ b/ssi_hr_holiday/docs/hr_leave_type/01-create.md
@@ -1,0 +1,47 @@
+# Create Leave Type
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Leave Type
+>
+> **Actor:** user in group _Leave Type_
+
+## Pre-Condition
+
+- **Access:** User is in group _Leave Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Leave Type** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Leave Type** _(required)_: Enter a short label for the leave type (for example
+     "Annual Leave" or "Sick Leave").
+   - **Need Allocation**: Check if a leave request of this type must be covered by an
+     available leave allocation (see
+     `ssi_hr_holiday/docs/hr_leave_allocation/01-create.md`) before it can be confirmed.
+     Leave unchecked if this type does not require an allocation.
+   - **Apply Limit Per Request**: Check to cap the number of days that can be requested
+     in a single leave request of this type.
+   - **Limit Per Request**: Enter the maximum number of days allowed per request. Only
+     enforced when **Apply Limit Per Request** is checked.
+   - **Exclude Public Holiday**: A configuration toggle stored on the leave type. See
+     the note below.
+   - **Exclude Rest Day**: A configuration toggle stored on the leave type. See the note
+     below.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new leave type record is created and available for selection on **Leaves** and
+  **Leave Allocations**.
+
+> **Note:** as implemented in this module, **Exclude Public Holiday** and **Exclude Rest
+> Day** are stored but not read by `hr.leave`'s duration computation
+> (`_compute_leave_duration`) — public holidays are always excluded from **Duration**
+> regardless of this flag, and rest days are excluded only as a side effect of
+> **Schedules** already containing working days only, not because of this flag. This was
+> found while writing this IK and reported to the module maintainers rather than fixed
+> here, since fixing it is a code change out of scope for this Work Instruction.

--- a/ssi_hr_holiday/docs/hr_leave_type/02-edit.md
+++ b/ssi_hr_holiday/docs/hr_leave_type/02-edit.md
@@ -1,0 +1,27 @@
+# Edit Leave Type
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Leave Type
+>
+> **Actor:** user in group _Leave Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Leave Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Leave Type** menu.
+2. Find and open the record to edit.
+3. Change **Leave Type**, **Need Allocation**, **Apply Limit Per Request**, **Limit Per
+   Request**, **Exclude Public Holiday**, or **Exclude Rest Day** as needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_hr_holiday/docs/hr_leave_type/03-delete.md
+++ b/ssi_hr_holiday/docs/hr_leave_type/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Leave Type
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Leave Type
+>
+> **Actor:** user in group _Leave Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Leave Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Leave Type** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system. Deletion fails with a
+  database integrity error if the leave type is already referenced by an existing
+  **Leave** or **Leave Allocation** record (both reference `hr.leave_type` with
+  `ondelete="restrict"`) — deactivate the record instead (see `04-deactivate`).

--- a/ssi_hr_holiday/docs/hr_leave_type/04-deactivate.md
+++ b/ssi_hr_holiday/docs/hr_leave_type/04-deactivate.md
@@ -1,0 +1,33 @@
+# Deactivate Leave Type
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Leave Type
+>
+> **Actor:** user in group _Leave Type_
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group _Leave Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Leave Type** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected on new **Leave** or **Leave Allocation**
+  records.
+- **Leave** and **Leave Allocation** records that already reference this leave type can
+  still be viewed.

--- a/ssi_hr_holiday/docs/hr_leave_type/05-activate.md
+++ b/ssi_hr_holiday/docs/hr_leave_type/05-activate.md
@@ -1,0 +1,31 @@
+# Activate Leave Type
+
+> **Module:** ssi_hr_holiday
+>
+> **Model:** `hr.leave_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Leave Type
+>
+> **Actor:** user in group _Leave Type_
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group _Leave Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Leave Type** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again on new **Leave** or **Leave Allocation** records.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) untuk ketiga model asli `ssi_hr_holiday`:

- `hr.leave` — IK penuh model transaksional (create, edit, delete, confirm, approve,
  reject, cancel, restart, reset document number, restart approval process). Transisi
  `confirm → done` yang dijalankan `_after_approved_method` tidak dibuatkan IK sendiri,
  hanya disebut di Post-Condition `04-confirm`.
- `hr.leave_allocation` — IK penuh model transaksional, termasuk IK khusus untuk transisi
  otomatis `leave_allocation_done` (`base.automation`, `09-auto-done.md`) yang
  memindahkan alokasi ke Done saat `num_of_days_available` habis. Transisi
  `confirm → open` yang dijalankan `_after_approved_method` tidak dibuatkan IK sendiri.
- `hr.leave_type` — IK master data lengkap (create, edit, delete, deactivate, activate).

`README.rst` modul dan `AGENTS.md` indeks root repo diperbarui agar mencantumkan seluruh
IK baru.

Delta yang modul ini pasang pada `hr.timesheet`/`hr.timesheet_attendance_schedule`
(`leave_ids`) diverifikasi dari kode: keduanya `readonly`/tanpa view input pengguna,
murni informasional — sehingga tidak dibuatkan IK delta, sesuai ruang lingkup issue.

Beberapa ketidakcocokan kode ditemukan saat menulis IK ini dan dicatat sebagai catatan di
berkas IK terkait, bukan diperbaiki di sini (di luar ruang lingkup dokumentasi):

- Kebijakan `restart_approval_ok` pada `hr.leave` dan `hr.leave_allocation` efektif tak
  pernah terpenuhi di bawah konfigurasi default (pola yang sama seperti sudah dicatat di
  `ssi_timesheet/docs/hr_timesheet/14-restart-approval.md`).
- Kebijakan `open_ok` pada `hr.leave_allocation` tak pernah di-grant oleh
  `policy.template` "Standard", sehingga `_reopen_leave_allocation` (dipanggil saat
  membatalkan leave Done) berpotensi gagal dengan galat kebijakan.
- `ir_cron_terminate_allocation` menyasar state `open`, padahal `terminate_ok` hanya
  digrant untuk state `done` — berpotensi membuat cron gagal untuk target sebenarnya.
- Field `Exclude Public Holiday`/`Exclude Rest Day` pada `hr.leave_type` tersimpan tapi
  tidak dibaca oleh `_compute_leave_duration`.

## Ruang lingkup

Sesuai issue: **tour TIDAK termasuk** item ini — dipisah ke
open-synergy/opnsynid-hr-timesheet#153 (satu berkas IK = satu tour).

Tidak ada file Python yang ditulis/diubah — item dokumentasi murni.

Closes #124