### PR TITLE
[UPD] ssi_hr_overtime - Instruksi Kerja hr.overtime & hr.overtime_type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,35 @@ Menu: **Human Resource > Configuration > Timesheets > Timesheet Computation Item
 | `ssi_timesheet/docs/hr_timesheet_computation_item/05-activate.md`   | Activate a timesheet computation item   |
 | `ssi_timesheet/docs/hr_timesheet_computation_item/06-reset-code.md` | Reset the code of one or more items     |
 
+### `ssi_hr_overtime` — Model: `hr.overtime`
+
+Menu: **Human Resource > Timesheets > Overtimes**
+
+| File                                                      | Action                                    |
+| --------------------------------------------------------- | ----------------------------------------- |
+| `ssi_hr_overtime/docs/hr_overtime/01-create.md`           | Create a new overtime                     |
+| `ssi_hr_overtime/docs/hr_overtime/02-edit.md`             | Edit an overtime                          |
+| `ssi_hr_overtime/docs/hr_overtime/03-delete.md`           | Delete an overtime                        |
+| `ssi_hr_overtime/docs/hr_overtime/04-confirm.md`          | Confirm an overtime (submit for approval) |
+| `ssi_hr_overtime/docs/hr_overtime/05-approve.md`          | Approve an overtime                       |
+| `ssi_hr_overtime/docs/hr_overtime/06-reject.md`           | Reject an overtime                        |
+| `ssi_hr_overtime/docs/hr_overtime/10-cancel.md`           | Cancel an overtime                        |
+| `ssi_hr_overtime/docs/hr_overtime/12-restart.md`          | Restart a cancelled/rejected overtime     |
+| `ssi_hr_overtime/docs/hr_overtime/13-reset-number.md`     | Reset an overtime's document number       |
+| `ssi_hr_overtime/docs/hr_overtime/14-restart-approval.md` | Restart an overtime's approval process    |
+
+### `ssi_hr_overtime` — Model: `hr.overtime_type`
+
+Menu: **Human Resource > Configuration > Timesheets > Overtime Types**
+
+| File                                                     | Action                      |
+| -------------------------------------------------------- | --------------------------- |
+| `ssi_hr_overtime/docs/hr_overtime_type/01-create.md`     | Create a new overtime type  |
+| `ssi_hr_overtime/docs/hr_overtime_type/02-edit.md`       | Edit an overtime type       |
+| `ssi_hr_overtime/docs/hr_overtime_type/03-delete.md`     | Delete an overtime type     |
+| `ssi_hr_overtime/docs/hr_overtime_type/04-deactivate.md` | Deactivate an overtime type |
+| `ssi_hr_overtime/docs/hr_overtime_type/05-activate.md`   | Activate an overtime type   |
+
 ### `ssi_hr_holiday` — Model: `hr.leave`
 
 Menu: **Human Resource > Timesheets > Leaves**

--- a/ssi_hr_overtime/README.rst
+++ b/ssi_hr_overtime/README.rst
@@ -7,6 +7,26 @@ Overtime Management
 ===================
 
 
+Work Instruction
+================
+
+* `Create Overtime <docs/hr_overtime/index.html>`_
+* `Edit Overtime <docs/hr_overtime/index.html>`_
+* `Delete Overtime <docs/hr_overtime/index.html>`_
+* `Confirm Overtime <docs/hr_overtime/index.html>`_
+* `Approve Overtime <docs/hr_overtime/index.html>`_
+* `Reject Overtime <docs/hr_overtime/index.html>`_
+* `Cancel Overtime <docs/hr_overtime/index.html>`_
+* `Restart Overtime <docs/hr_overtime/index.html>`_
+* `Reset Document Number — Overtime <docs/hr_overtime/index.html>`_
+* `Restart Approval Process — Overtime <docs/hr_overtime/index.html>`_
+* `Create Overtime Type <docs/hr_overtime_type/index.html>`_
+* `Edit Overtime Type <docs/hr_overtime_type/index.html>`_
+* `Delete Overtime Type <docs/hr_overtime_type/index.html>`_
+* `Deactivate Overtime Type <docs/hr_overtime_type/index.html>`_
+* `Activate Overtime Type <docs/hr_overtime_type/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_hr_overtime/docs/hr_overtime/01-create.md
+++ b/ssi_hr_overtime/docs/hr_overtime/01-create.md
@@ -1,0 +1,71 @@
+# Create Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`), `manual_number_ok` (state `draft`), `restart_approval_ok` (state `confirm`),
+  `cancel_ok` (states `draft`, `confirm`, `done`), and `restart_ok` (states `cancel`,
+  `reject`) to the relevant groups — see the _Standard_ `policy.template` shipped with
+  this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module.
+- **Config:** An active `sequence.template` for this model exists — see the _Standard
+  Overtime_ `sequence.template` shipped with this module.
+- **Data:** The **Employee** to select has an `hr.employee` record, and has an
+  `hr.timesheet` record whose **Date Start**/**Date End** range covers this overtime's
+  **Date** (see `ssi_timesheet/docs/hr_timesheet/01-create.md`) — an overtime cannot be
+  saved without a matching timesheet.
+- **Data:** If **Overtime Type** has **Apply Limit Per Days** checked, the sum of
+  **Planned Hours** across this employee's other (non-cancelled, non-rejected) overtimes
+  on the same **Date** and **Overtime Type** must not exceed **Limit Per Days** —
+  otherwise saving fails (see `Limit Per Days` on
+  `ssi_hr_overtime/docs/hr_overtime_type/01-create.md`).
+- **Access:** User is in group _Overtime — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Employee**: Automatically filled from the current user's linked employee record,
+     if any. Change if needed.
+   - **Department**, **Manager**, **Job Position**: Automatically filled from
+     **Employee**. Read-only.
+   - **Overtime Type** _(required)_: Select the type of overtime being requested.
+     **Apply Limit Per Days** and **Limit Per Days** are displayed read-only, copied
+     from the selected type.
+   - **Date** _(required)_: Enter the date this overtime covers. Defaults to today.
+   - **Date Start** _(required)_: Enter the start date and time of the overtime. Must
+     fall on the same calendar day as **Date**. Defaults to the current date and time;
+     changing **Date** while this field is still empty fills it with midnight of that
+     date.
+   - **Date End** _(required)_: Enter the end date and time of the overtime. Must not be
+     earlier than **Date Start**, and the difference between **Date End** and **Date
+     Start** must not exceed 24 hours. Must not overlap the date/time range of another
+     (non-cancelled, non-rejected) overtime for the same **Employee**.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new overtime record is created in **Draft** status.
+- **# Timesheet** is automatically linked to the `hr.timesheet` whose date range covers
+  this overtime's **Date**; saving fails if no matching timesheet is found.
+- **Planned Hours** is automatically computed as the difference between **Date Start**
+  and **Date End**. **Realized Hours** is computed the same way at this point, since no
+  **Attendances** are linked yet — see `04-confirm` for how **Attendances** get linked
+  and **Realized Hours** subsequently narrows to the overlapping check-in/check-out
+  time.
+- The document number stays **/** until the record transitions to **Done**, which
+  happens automatically once approval completes (see `04-confirm`) — there is no
+  separate Finish/Done button — unless the actor has _Can Input Manual Document Number_
+  access (see `13-reset-number`).

--- a/ssi_hr_overtime/docs/hr_overtime/02-edit.md
+++ b/ssi_hr_overtime/docs/hr_overtime/02-edit.md
@@ -1,0 +1,33 @@
+# Edit Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Overtime — User_, and is the record's **Responsible** or
+  **Employee** (record rule), or holds a broader data-ownership group (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Find and open the record to edit.
+3. Change **Employee**, **Overtime Type**, **Date**, **Date Start**, or **Date End** as
+   needed — the same constraints described in `01-create` apply.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- **# Timesheet**, **Planned Hours**, and **Realized Hours** are recomputed
+  automatically (same effect as described in `01-create`).

--- a/ssi_hr_overtime/docs/hr_overtime/03-delete.md
+++ b/ssi_hr_overtime/docs/hr_overtime/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Overtime — User_, and is the record's **Responsible** or
+  **Employee** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_overtime/docs/hr_overtime/04-confirm.md
+++ b/ssi_hr_overtime/docs/hr_overtime/04-confirm.md
@@ -1,0 +1,48 @@
+# Confirm Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single sequential level approved by group _Overtime — Validator_).
+- **Access:** User is in group _Overtime — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- The **Attendances** tab is populated: every `hr.timesheet_attendance` record for the
+  same **Employee** and **Date** is linked to this overtime, and those attendance
+  records' own **Overtimes** field is recomputed to reference this record in turn (same
+  underlying relation, so it also updates automatically whenever a matching attendance's
+  **Check In**/**Check Out** changes — see `ssi_timesheet_attendance` documentation).
+- **Realized Hours** is recomputed from the newly linked **Attendances**: for each
+  linked attendance, the overlap between **Date Start**/**Date End** and that
+  attendance's **Check In**/**Check Out** is added up.
+- Approval records are created for each approver level defined by the _Standard_
+  `approval.template`.
+- Once every approval level has approved (see `05-approve`), the document transitions to
+  **Done** automatically — there is no separate Finish/Done button, and no dedicated IK
+  for this transition. The document number is also assigned automatically at this point
+  (unless already manually assigned — see `13-reset-number`).

--- a/ssi_hr_overtime/docs/hr_overtime/05-approve.md
+++ b/ssi_hr_overtime/docs/hr_overtime/05-approve.md
@@ -1,0 +1,39 @@
+# Approve Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Overtime — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Finish/Done button. With the shipped _Standard_ `approval.template`
+  (single level), approving always fulfills the approval and the document goes straight
+  to **Done**.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.

--- a/ssi_hr_overtime/docs/hr_overtime/06-reject.md
+++ b/ssi_hr_overtime/docs/hr_overtime/06-reject.md
@@ -1,0 +1,34 @@
+# Reject Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Overtime — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_hr_overtime/docs/hr_overtime/10-cancel.md
+++ b/ssi_hr_overtime/docs/hr_overtime/10-cancel.md
@@ -1,0 +1,35 @@
+# Cancel Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — Validator_
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Overtime — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the overtime.
+- **Attendances** is cleared.

--- a/ssi_hr_overtime/docs/hr_overtime/12-restart.md
+++ b/ssi_hr_overtime/docs/hr_overtime/12-restart.md
@@ -1,0 +1,33 @@
+# Restart Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it for
+  states **Cancelled** and **Rejected**).
+- **Access:** User is in group _Overtime — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- When restarting from **Cancelled**, the **Reason** recorded by `10-cancel` is cleared.

--- a/ssi_hr_overtime/docs/hr_overtime/13-reset-number.md
+++ b/ssi_hr_overtime/docs/hr_overtime/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard
+  Overtime_ `sequence.template`).
+- **Access:** User is in group _Overtime — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** (see
+  `04-confirm`, completed automatically once approved), according to the _Standard
+  Overtime_ `sequence.template` configuration.

--- a/ssi_hr_overtime/docs/hr_overtime/14-restart-approval.md
+++ b/ssi_hr_overtime/docs/hr_overtime/14-restart-approval.md
@@ -1,0 +1,44 @@
+# Restart Approval Process — Overtime
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime`
+>
+> **Menu:** Human Resource > Timesheets > Overtimes
+>
+> **Actor:** user in group _Overtime — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group (see the _Standard_ `policy.template`). As
+  shipped, this policy only evaluates to allowed while the record's **Approval
+  Template** field is still empty — since Confirm (`04-confirm`) already assigns an
+  approval template before the record reaches this state, the button is typically not
+  clickable in practice with the default configuration. See the note below.
+- **Access:** User is in group _Overtime — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtimes** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, this policy is effectively never satisfied under the default configuration.
+> This was found while writing this IK and reported to the module maintainers rather
+> than fixed here, since fixing it is a code change out of scope for this Work
+> Instruction.

--- a/ssi_hr_overtime/docs/hr_overtime_type/01-create.md
+++ b/ssi_hr_overtime/docs/hr_overtime_type/01-create.md
@@ -1,0 +1,31 @@
+# Create Overtime Type
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Overtime Types
+>
+> **Actor:** user in group _Overtime Type_
+
+## Pre-Condition
+
+- **Access:** User is in group _Overtime Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Overtime Types** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Type** _(required)_: Enter a short label for the overtime type (for example
+     "Weekday Overtime").
+   - **Apply Limit Per Days**: Enable to cap the total planned hours employees can
+     request under this type on a single day.
+   - **Limit Per Days**: When **Apply Limit Per Days** is enabled, enter the maximum
+     total **Planned Hours** allowed per employee per day for overtimes of this type
+     (see `ssi_hr_overtime/docs/hr_overtime/01-create.md`).
+4. Click **Save**.
+
+## Post-Condition
+
+- A new overtime type record is created.

--- a/ssi_hr_overtime/docs/hr_overtime_type/02-edit.md
+++ b/ssi_hr_overtime/docs/hr_overtime_type/02-edit.md
@@ -1,0 +1,26 @@
+# Edit Overtime Type
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Overtime Types
+>
+> **Actor:** user in group _Overtime Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Overtime Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Overtime Types** menu.
+2. Find and open the record to edit.
+3. Change the **Type**, **Apply Limit Per Days**, or **Limit Per Days** as needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_hr_overtime/docs/hr_overtime_type/03-delete.md
+++ b/ssi_hr_overtime/docs/hr_overtime_type/03-delete.md
@@ -1,0 +1,26 @@
+# Delete Overtime Type
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Overtime Types
+>
+> **Actor:** user in group _Overtime Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Overtime Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Overtime Types** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_overtime/docs/hr_overtime_type/04-deactivate.md
+++ b/ssi_hr_overtime/docs/hr_overtime_type/04-deactivate.md
@@ -1,0 +1,31 @@
+# Deactivate Overtime Type
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Overtime Types
+>
+> **Actor:** user in group _Overtime Type_
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group _Overtime Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Overtime Types** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as the **Overtime Type** on a new overtime (see
+  `ssi_hr_overtime/docs/hr_overtime/01-create.md`).

--- a/ssi_hr_overtime/docs/hr_overtime_type/05-activate.md
+++ b/ssi_hr_overtime/docs/hr_overtime_type/05-activate.md
@@ -1,0 +1,31 @@
+# Activate Overtime Type
+
+> **Module:** ssi_hr_overtime
+>
+> **Model:** `hr.overtime_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Overtime Types
+>
+> **Actor:** user in group _Overtime Type_
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group _Overtime Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Overtime Types** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again as the **Overtime Type** on a new overtime.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) untuk `ssi_hr_overtime`:

- `docs/hr_overtime/` — create, edit, delete, confirm, approve, reject, cancel, restart,
  reset document number, restart approval process. Setiap aksi diverifikasi dari kode
  (`action_*`), tombol form view, `state`, dan grup akses.
- `docs/hr_overtime_type/` — create, edit, delete, deactivate, activate.
- `README.rst` modul dan `AGENTS.md` root repo diperbarui dengan indeks IK baru.

Field lembur pada `hr.timesheet.overtime_ids` dan
`hr.timesheet_attendance.overtime_ids` bersifat computed/readonly murni (tidak ada
input pengguna), sehingga sesuai Keputusan Desain issue, **tidak** dibuat IK delta untuk
keduanya.

Tour pasangan tiap berkas IK ini **tidak** termasuk dalam PR ini — dikerjakan di item
terpisah open-synergy/opnsynid-hr-timesheet#154, sesuai ruang lingkup issue #125.

Closes #125

## Test plan

- [x] `assets/validate-ik.sh` pada modul `ssi_hr_overtime` — 0 error (peringatan hanya
  soal tour yang memang di luar cakupan item ini)
- [x] Item docs murni — tidak ada perubahan kode Python/XML, unit test tidak relevan
- [ ] CI (pre-commit + test) hijau

🤖 Generated with [Claude Code](https://claude.com/claude-code)