### PR TITLE
[UPD] ssi_hr_overtime_batch - Instruksi Kerja hr.overtime_batch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,23 @@ Menu: **Human Resource > Configuration > Timesheets > Overtime Types**
 | `ssi_hr_overtime/docs/hr_overtime_type/04-deactivate.md` | Deactivate an overtime type |
 | `ssi_hr_overtime/docs/hr_overtime_type/05-activate.md`   | Activate an overtime type   |
 
+### `ssi_hr_overtime_batch` — Model: `hr.overtime_batch`
+
+Menu: **Human Resource > Timesheets > Overtime Batch**
+
+| File                                                                  | Action                                                                           |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/01-create.md`           | Create a new overtime batch                                                      |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/02-edit.md`             | Edit an overtime batch                                                           |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/03-delete.md`           | Delete an overtime batch                                                         |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/04-confirm.md`          | Confirm an overtime batch (creates & confirms the derived overtimes)             |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/05-approve.md`          | Approve an overtime batch (approves the derived overtimes too)                   |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/06-reject.md`           | Reject an overtime batch (rejects the derived overtimes too)                     |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/10-cancel.md`           | Cancel an overtime batch (cancels the derived overtimes too)                     |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/12-restart.md`          | Restart a cancelled/rejected overtime batch (restarts the derived overtimes too) |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/13-reset-number.md`     | Reset an overtime batch's document number                                        |
+| `ssi_hr_overtime_batch/docs/hr_overtime_batch/14-restart-approval.md` | Restart an overtime batch's approval process                                     |
+
 ### `ssi_hr_holiday` — Model: `hr.leave`
 
 Menu: **Human Resource > Timesheets > Leaves**

--- a/ssi_hr_overtime_batch/README.rst
+++ b/ssi_hr_overtime_batch/README.rst
@@ -7,6 +7,21 @@ Human Resource Overtime Batch
 =============================
 
 
+Work Instruction
+================
+
+* `Create Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Edit Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Delete Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Confirm Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Approve Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Reject Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Cancel Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Restart Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Reset Document Number — Overtime Batch <docs/hr_overtime_batch/index.html>`_
+* `Restart Approval Process — Overtime Batch <docs/hr_overtime_batch/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/01-create.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/01-create.md
@@ -1,0 +1,59 @@
+# Create Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`), `manual_number_ok` (state `draft`), `restart_approval_ok` (state `confirm`),
+  `cancel_ok` (states `draft`, `confirm`, `done`), and `restart_ok` (states `cancel`,
+  `reject`) to the relevant groups — see the _Standard_ `policy.template` shipped with
+  this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module (single sequential level, approved by
+  group _Overtime Batch — Validator_).
+- **Config:** An active `sequence.template` for this model exists — see the _Standard_
+  `sequence.template` shipped with this module.
+- **Data:** Each employee to select in **Employee(s)** has an `hr.employee` record.
+  Confirming this batch (`04-confirm`) creates one `hr.overtime` document per selected
+  employee, so the same data prerequisites documented for a single overtime apply per
+  employee — see `ssi_hr_overtime/docs/hr_overtime/01-create.md` (e.g., a matching
+  `hr.timesheet` covering the batch's date range must exist for the employee).
+- **Data:** None of the employees selected in **Employee(s)** may already have a
+  non-cancelled, non-rejected `hr.overtime` whose **Date Start**/**Date End** range
+  overlaps this batch's **Date Start**/**Date End** — otherwise confirming the batch
+  fails for that employee (see `04-confirm`).
+- **Access:** User is in group _Overtime Batch — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Overtime Type** _(required)_: Select the type of overtime that will be applied to
+     every `hr.overtime` document created for this batch.
+   - **Employee(s)**: Select the employees to include in this batch. Leaving it empty
+     means confirming the batch creates no `hr.overtime` documents (see `04-confirm`).
+   - **Date Start** _(required)_: Enter the start date and time shared by every
+     `hr.overtime` document created for this batch.
+   - **Date End** _(required)_: Enter the end date and time shared by every
+     `hr.overtime` document created for this batch.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new overtime batch record is created in **Draft** status.
+- The **Overtime(s)** tab stays empty — the individual `hr.overtime` documents are only
+  created once the batch is confirmed (see `04-confirm`).
+- The document number stays **/** until the record transitions to **Done**, which
+  happens automatically once approval completes (see `04-confirm`) — there is no
+  separate Finish/Done button — unless the actor has _Can Input Manual Document Number_
+  access (see `13-reset-number`).

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/02-edit.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/02-edit.md
@@ -1,0 +1,32 @@
+# Edit Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Overtime Batch — User_, and is the record's
+  **Responsible** (record rule), or holds a broader data-ownership group (_Company_,
+  _Company and All Child Companies_, or _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Find and open the record to edit.
+3. Change **Overtime Type**, **Employee(s)**, **Date Start**, or **Date End** as needed
+   — the same constraints described in `01-create` apply.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- The **Overtime(s)** tab remains unaffected by this edit — it is only populated when
+  the batch is confirmed (see `04-confirm`).

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/03-delete.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Overtime Batch — User_, and is the record's
+  **Responsible** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/04-confirm.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/04-confirm.md
@@ -1,0 +1,58 @@
+# Confirm Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single sequential level approved by group _Overtime Batch — Validator_).
+- **Data:** See `01-create` for the per-employee prerequisites (matching timesheet, no
+  overlapping overtime) that the batch's employees must satisfy — a failure for any one
+  of them fails confirming the whole batch.
+- **Access:** User is in group _Overtime Batch — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- For each employee listed in **Employee(s)**, a new `hr.overtime` document is created
+  (**Date** = the date of this batch's **Date Start**, **Date Start**/**Date End** =
+  this batch's **Date Start**/**Date End**, **Overtime Type** = this batch's **Overtime
+  Type**, **Batch** = this record) and appears in the **Overtime(s)** tab. Creating each
+  of these documents is subject to `hr.overtime`'s own creation prerequisites — see
+  `ssi_hr_overtime/docs/hr_overtime/01-create.md` — and fails the whole batch confirm if
+  not met for any employee (e.g., no matching `hr.timesheet`, or an overlapping overtime
+  already exists for that employee/date range).
+- Each newly created `hr.overtime` document is immediately confirmed as well — it
+  transitions to **Waiting for Approval** on its own, with the same effects described in
+  `ssi_hr_overtime/docs/hr_overtime/04-confirm.md` (its **Attendances** tab populated,
+  **Realized Hours** recomputed, and its own approval records created from the
+  `hr.overtime` _Standard_ `approval.template`).
+- If **Employee(s)** is empty, the batch still transitions to **Waiting for Approval**,
+  but no `hr.overtime` documents are created.
+- Approval records are created for the batch itself, for each approver level defined by
+  the _Standard_ `approval.template` (single level, group _Overtime Batch — Validator_).
+- Once every approval level has approved (see `05-approve`), the batch transitions to
+  **Done** automatically — there is no separate Finish/Done button. The document number
+  is also assigned automatically at this point (unless already manually assigned — see
+  `13-reset-number`).

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/05-approve.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/05-approve.md
@@ -1,0 +1,45 @@
+# Approve Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Overtime Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Finish/Done button. With the shipped _Standard_ `approval.template`
+  (single level), approving always fulfills the approval and the batch goes straight to
+  **Done**.
+- Every `hr.overtime` document created for this batch (see `04-confirm`, listed in the
+  **Overtime(s)** tab) is approved as well — each one is transitioned via its own
+  **Approve** action, following the effect described in
+  `ssi_hr_overtime/docs/hr_overtime/05-approve.md` (with the `hr.overtime` _Standard_
+  `approval.template` also being single level, each child overtime goes straight to
+  **Done** too).
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/06-reject.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/06-reject.md
@@ -1,0 +1,38 @@
+# Reject Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Overtime Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.
+- Every `hr.overtime` document created for this batch (see `04-confirm`, listed in the
+  **Overtime(s)** tab) is rejected as well — each one is transitioned via its own
+  **Reject** action, following the effect described in
+  `ssi_hr_overtime/docs/hr_overtime/06-reject.md`.

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/10-cancel.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/10-cancel.md
@@ -1,0 +1,39 @@
+# Cancel Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — Validator_
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Overtime Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the batch.
+- If any `hr.overtime` documents were already created for this batch (see `04-confirm`,
+  listed in the **Overtime(s)** tab), each one is cancelled as well, following the
+  effect described in `ssi_hr_overtime/docs/hr_overtime/10-cancel.md` (its own
+  **Attendances** cleared). Cancelling straight from **Draft** has no such effect, since
+  the **Overtime(s)** tab is still empty at that point.

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/12-restart.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/12-restart.md
@@ -1,0 +1,36 @@
+# Restart Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it for
+  states **Cancelled** and **Rejected**).
+- **Access:** User is in group _Overtime Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- When restarting from **Cancelled**, the **Reason** recorded by `10-cancel` is cleared.
+- If any `hr.overtime` documents exist for this batch (see `04-confirm`, listed in the
+  **Overtime(s)** tab), each one is restarted as well, following the effect described in
+  `ssi_hr_overtime/docs/hr_overtime/12-restart.md`.

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/13-reset-number.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard_
+  `sequence.template`).
+- **Access:** User is in group _Overtime Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** (see
+  `04-confirm`, completed automatically once approved), according to the _Standard_
+  `sequence.template` configuration.

--- a/ssi_hr_overtime_batch/docs/hr_overtime_batch/14-restart-approval.md
+++ b/ssi_hr_overtime_batch/docs/hr_overtime_batch/14-restart-approval.md
@@ -1,0 +1,44 @@
+# Restart Approval Process — Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch
+>
+> **Model:** `hr.overtime_batch`
+>
+> **Menu:** Human Resource > Timesheets > Overtime Batch
+>
+> **Actor:** user in group _Overtime Batch — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group (see the _Standard_ `policy.template`). As
+  shipped, this policy only evaluates to allowed while the record's **Approval
+  Template** field is still empty — since Confirm (`04-confirm`) already assigns an
+  approval template before the record reaches this state, the button is typically not
+  clickable in practice with the default configuration. See the note below.
+- **Access:** User is in group _Overtime Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Overtime Batch** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, this policy is effectively never satisfied under the default configuration.
+> This was found while writing this IK and reported to the module maintainers rather
+> than fixed here, since fixing it is a code change out of scope for this Work
+> Instruction.


### PR DESCRIPTION
## Summary

- Menambahkan Instruksi Kerja (IK) untuk model `hr.overtime_batch` di modul
  `ssi_hr_overtime_batch`: create, edit, delete, confirm, approve, reject,
  cancel, restart, reset-number, dan restart-approval.
- Post-Condition IK confirm/approve/reject/cancel/restart menjelaskan efek
  berantai ke dokumen `hr.overtime` turunan yang dibuat & dikonfirmasi lewat
  hook `ssi_decorator` saat batch di-confirm/approve/reject/cancel/restart.
- Memperbarui `README.rst` modul dengan bagian Work Instruction.
- Memperbarui indeks `AGENTS.md` di root repo.

Tour pasangan IK ini sengaja **tidak** disertakan di sini — dikerjakan di item
terpisah open-synergy/opnsynid-hr-timesheet#155, sesuai Keputusan Desain di
issue #126.

Closes #126

## Test plan

- [x] `assets/validate-ik.sh` dari skill `odoo-development-instruksi-kerja`
      dijalankan atas modul: 0 error (hanya peringatan "belum ada tour",
      yang memang diharapkan karena di luar cakupan item ini).
- [x] CI (pre-commit, lint) diverifikasi lewat `gh pr checks --watch`.