### PR TITLE
[UPD] ssi_hr_leave_request_batch - Work Instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,23 @@ Menu: **Human Resource > Configuration > Timesheets > Leave Type**
 | `ssi_hr_holiday/docs/hr_leave_type/04-deactivate.md` | Deactivate a leave type |
 | `ssi_hr_holiday/docs/hr_leave_type/05-activate.md`   | Activate a leave type   |
 
+### `ssi_hr_leave_request_batch` — Model: `hr.leave_request_batch`
+
+Menu: **Human Resource > Timesheets > Leave Request Batch**
+
+| File                                                                            | Action                                                                    |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/01-create.md`           | Create a new leave request batch                                          |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/02-edit.md`             | Edit a leave request batch                                                |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/03-delete.md`           | Delete a leave request batch                                              |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/04-confirm.md`          | Confirm a leave request batch (creates & confirms the derived leaves)     |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/05-approve.md`          | Approve a leave request batch (approves the derived leaves too)           |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/06-reject.md`           | Reject a leave request batch (rejects the derived leaves too)             |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/10-cancel.md`           | Cancel a leave request batch (cancels the derived leaves too)             |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/12-restart.md`          | Restart a cancelled leave request batch (restarts the derived leaves too) |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/13-reset-number.md`     | Reset a leave request batch's document number                             |
+| `ssi_hr_leave_request_batch/docs/hr_leave_request_batch/14-restart-approval.md` | Restart a leave request batch's approval process                          |
+
 ### `ssi_timesheet_attendance` — Model: `hr.timesheet` (extends `ssi_timesheet`)
 
 Menu: **Human Resource > Timesheets > Timesheets**

--- a/ssi_hr_leave_request_batch/README.rst
+++ b/ssi_hr_leave_request_batch/README.rst
@@ -7,6 +7,21 @@ Leave Request Batch
 ====================
 
 
+Work Instruction
+================
+
+* `Create Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Edit Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Delete Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Confirm Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Approve Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Reject Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Cancel Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Restart Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Reset Document Number — Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+* `Restart Approval Process — Leave Request Batch <docs/hr_leave_request_batch/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/01-create.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/01-create.md
@@ -1,0 +1,56 @@
+# Create Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`), `manual_number_ok` (state `draft`), `restart_approval_ok` (states `confirm`,
+  `reject`), `cancel_ok` (states `draft`, `confirm`, `done`, `reject`), and `restart_ok`
+  (state `cancel`) to the relevant groups — see the _Standard_ `policy.template` shipped
+  with this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module (single sequential level, approved by
+  group _Leave Request Batch — Validator_).
+- **Config:** An active `sequence.template` for this model exists — see the _Standard_
+  `sequence.template` shipped with this module.
+- **Data:** Each employee to select in **Employee(s)** has an `hr.employee` record.
+  Confirming this batch (`04-confirm`) creates one `hr.leave` document per selected
+  employee, so the same data prerequisites documented for a single leave apply per
+  employee — see `ssi_hr_holiday/docs/hr_leave/01-create.md` (e.g., a matching
+  `hr.timesheet` covering the batch's date range, and, if the selected **Type** has
+  **Need Allocation** checked, an available `hr.leave_allocation` for that employee).
+- **Access:** User is in group _Leave Request Batch — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Type** _(required)_: Select the type of leave that will be applied to every
+     `hr.leave` document created for this batch.
+   - **Employee(s)**: Select the employees to include in this batch. Leaving it empty
+     means confirming the batch creates no `hr.leave` documents (see `04-confirm`).
+   - **Date Start** _(required)_: Enter the start date shared by every `hr.leave`
+     document created for this batch.
+   - **Date End** _(required)_: Enter the end date shared by every `hr.leave` document
+     created for this batch.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new leave request batch record is created in **Draft** status.
+- The **Leave Request** tab stays empty — the individual `hr.leave` documents are only
+  created once the batch is confirmed (see `04-confirm`).
+- The document number stays **/** until the record transitions to **Done**, which
+  happens automatically once approval completes (see `04-confirm`) — there is no
+  separate Finish/Done button — unless the actor has _Can Input Manual Document Number_
+  access (see `13-reset-number`).

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/02-edit.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/02-edit.md
@@ -1,0 +1,32 @@
+# Edit Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Leave Request Batch — User_, and is the record's
+  **Responsible** (record rule), or holds a broader data-ownership group (_Company_,
+  _Company and All Child Companies_, or _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Find and open the record to edit.
+3. Change **Type**, **Employee(s)**, **Date Start**, or **Date End** as needed — the
+   same constraints described in `01-create` apply.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- The **Leave Request** tab remains unaffected by this edit — it is only populated when
+  the batch is confirmed (see `04-confirm`).

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/03-delete.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Leave Request Batch — User_, and is the record's
+  **Responsible** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/04-confirm.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/04-confirm.md
@@ -1,0 +1,63 @@
+# Confirm Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single sequential level approved by group _Leave Request Batch — Validator_).
+- **Data:** See `01-create` for the per-employee prerequisites (matching timesheet, and
+  leave allocation if the **Type** needs one) that the batch's employees must satisfy —
+  a failure for any one of them fails confirming the whole batch.
+- **Access:** User is in group _Leave Request Batch — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- For each employee listed in **Employee(s)** that does not already have a linked
+  `hr.leave` document in this batch, a new `hr.leave` document is created (**Date
+  Start**/**Date End** = this batch's **Date Start**/**Date End**, **Type** = this
+  batch's **Type**, **Batch** = this record) and appears in the **Leave Request** tab.
+  Creating each of these documents is subject to `hr.leave`'s own creation prerequisites
+  — see `ssi_hr_holiday/docs/hr_leave/01-create.md` — and fails the whole batch confirm
+  if not met for any employee (e.g., no matching `hr.timesheet`, or insufficient leave
+  allocation).
+- Each newly created `hr.leave` document has its **Number of Days**, **Department**,
+  **Manager**, and **Job Position** computed automatically — the same effect as the
+  onchange triggered when creating an `hr.leave` document manually (see
+  `ssi_hr_holiday/docs/hr_leave/01-create.md`).
+- Every `hr.leave` document listed in the **Leave Request** tab (whether newly created
+  by this confirm, or already linked from an earlier confirm on this same batch) is
+  immediately confirmed as well — it transitions to **Waiting for Approval** on its own,
+  with the same effects described in `ssi_hr_holiday/docs/hr_leave/04-confirm.md` (its
+  own approval records created from the `hr.leave` _Standard_ `approval.template`).
+- If **Employee(s)** is empty, the batch still transitions to **Waiting for Approval**,
+  but no `hr.leave` documents are created.
+- Approval records are created for the batch itself, for each approver level defined by
+  the _Standard_ `approval.template` (single level, group _Leave Request Batch —
+  Validator_).
+- Once every approval level has approved (see `05-approve`), the batch transitions to
+  **Done** automatically — there is no separate Finish/Done button. The document number
+  is also assigned automatically at this point (unless already manually assigned — see
+  `13-reset-number`).

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/05-approve.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/05-approve.md
@@ -1,0 +1,44 @@
+# Approve Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Finish/Done button. With the shipped _Standard_ `approval.template`
+  (single level), approving always fulfills the approval and the batch goes straight to
+  **Done**.
+- Every `hr.leave` document listed in the **Leave Request** tab (see `04-confirm`) is
+  approved as well — each one is transitioned via its own **Approve** action, following
+  the effect described in `ssi_hr_holiday/docs/hr_leave/05-approve.md` (with the
+  `hr.leave` _Standard_ `approval.template` also being single level, each child leave
+  goes straight to **Done** too).
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/06-reject.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/06-reject.md
@@ -1,0 +1,37 @@
+# Reject Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.
+- Every `hr.leave` document listed in the **Leave Request** tab (see `04-confirm`) is
+  rejected as well — each one is transitioned via its own **Reject** action, following
+  the effect described in `ssi_hr_holiday/docs/hr_leave/06-reject.md`.

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/10-cancel.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/10-cancel.md
@@ -1,0 +1,39 @@
+# Cancel Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — Validator_
+>
+> **State:** `draft` | `confirm` | `done` | `reject` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, **Done**, or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Leave Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the batch.
+- If any `hr.leave` documents were already created for this batch (see `04-confirm`,
+  listed in the **Leave Request** tab), each one is cancelled as well, following the
+  effect described in `ssi_hr_holiday/docs/hr_leave/10-cancel.md`. Cancelling straight
+  from **Draft** has no such effect, since the **Leave Request** tab is still empty at
+  that point.

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/12-restart.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/12-restart.md
@@ -1,0 +1,45 @@
+# Restart Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — Validator_
+>
+> **State:** `cancel` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it only
+  for status **Cancelled**).
+- **Access:** User is in group _Leave Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- The **Reason** recorded by `10-cancel` is cleared.
+- All approval records for the batch are removed and the **Approval Template** is
+  cleared. A later Confirm (`04-confirm`) starts the approval process from the
+  beginning.
+- If any `hr.leave` documents exist for this batch (see `04-confirm`, listed in the
+  **Leave Request** tab), each one is restarted as well, following the effect described
+  in `ssi_hr_holiday/docs/hr_leave/12-restart.md`.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_ok` only for status
+> **Cancelled** — not **Rejected**. Unlike some other modules in this repository, a
+> record in status **Rejected** has no button to return directly to **Draft**; it must
+> first be cancelled (see `10-cancel`, which allows cancelling from status **Rejected**)
+> before **Restart** becomes available.

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/13-reset-number.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard_
+  `sequence.template`).
+- **Access:** User is in group _Leave Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** (see
+  `04-confirm`, completed automatically once approved), according to the _Standard_
+  `sequence.template` configuration.

--- a/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/14-restart-approval.md
+++ b/ssi_hr_leave_request_batch/docs/hr_leave_request_batch/14-restart-approval.md
@@ -1,0 +1,46 @@
+# Restart Approval Process — Leave Request Batch
+
+> **Module:** ssi_hr_leave_request_batch
+>
+> **Model:** `hr.leave_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Request Batch
+>
+> **Actor:** user in group _Leave Request Batch — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for states `confirm` and `reject` to the actor's group (see the _Standard_
+  `policy.template`). As shipped, this policy only evaluates to allowed while the
+  record's **Approval Template** field is still empty — since Confirm (`04-confirm`)
+  already assigns an approval template before the record reaches state `confirm` (and
+  rejecting does not clear it), the button is typically not clickable in practice with
+  the default configuration. See the note below.
+- **Access:** User is in group _Leave Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Request Batch** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status is unchanged (remains **Waiting for Approval** or **Rejected**, whichever it
+  was before this action).
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, and neither approving, rejecting, nor entering state `reject` clears it,
+> this policy is effectively never satisfied under the default configuration. This was
+> found while writing this IK and reported to the module maintainers rather than fixed
+> here, since fixing it is a code change out of scope for this Work Instruction.


### PR DESCRIPTION
## Summary

Adds Work Instructions (IK) for `hr.leave_request_batch` (module
`ssi_hr_leave_request_batch`), covering every button-backed action verified from the
model and view code: Create, Edit, Delete, Confirm, Approve, Reject, Cancel, Restart,
Reset Document Number, and Restart Approval Process.

- `docs/hr_leave_request_batch/` — 10 IK files, each with the metadata block and
  Pre-Condition/Flow/Post-Condition structure.
- Post-Condition of Confirm/Approve/Reject/Cancel/Restart documents the cascading
  effect on the derived `hr.leave` documents created by the batch.
- `README.rst` — new *Work Instruction* section linking all 10 IK files.
- `AGENTS.md` (repo root) — new Work Instruction Index section for
  `ssi_hr_leave_request_batch` / `hr.leave_request_batch`.

Two behavior findings surfaced while verifying the code (not fixed here, out of scope
per the tracking issue — documented in the IK instead):

- `restart_ok` is only granted by the shipped `policy.template` for status
  **Cancelled**, not **Rejected** (see `12-restart.md`).
- `restart_approval_ok` is practically never satisfied under the default
  configuration, since `Confirm` always assigns `approval_template_id` before the
  record reaches state `confirm`, and neither approving, rejecting, nor state `reject`
  clears it (see `14-restart-approval.md`).

Docs-only change: no model/view/security code touched, no existing test/tour modified.
The paired tour for these IK files is tracked separately in #156.

Closes #127

## Test plan

- [x] `odoo-development-instruksi-kerja/assets/validate-ik.sh` run against the module:
      0 errors (only expected "no paired tour yet" warnings, out of scope for this
      issue).
- [x] Verified every documented action against the model (`hr_leave_request_batch.py`)
      and the inherited `mixin.transaction*` base views — no undocumented
      button-backed `action_*` remains.
- [x] `git diff` reviewed: additive only, no test/tour files touched.