### PR TITLE
[UPD] ssi_hr_leave_allocation_request_batch - Instruksi Kerja model transaksional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,23 @@ Menu: **Human Resource > Configuration > Timesheets > Leave Type**
 | `ssi_hr_holiday/docs/hr_leave_type/04-deactivate.md` | Deactivate a leave type |
 | `ssi_hr_holiday/docs/hr_leave_type/05-activate.md`   | Activate a leave type   |
 
+### `ssi_hr_leave_allocation_request_batch` — Model: `hr.leave_allocation_request_batch`
+
+Menu: **Human Resource > Timesheets > Leave Allocation Request Batch**
+
+| File                                                                                                  | Action                                                                                             |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/01-create.md`           | Create a new leave allocation request batch                                                        |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/02-edit.md`             | Edit a leave allocation request batch                                                              |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/03-delete.md`           | Delete a leave allocation request batch                                                            |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/04-confirm.md`          | Confirm a leave allocation request batch (submit for approval)                                     |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/05-approve.md`          | Approve a leave allocation request batch (creates & leaves the derived leave allocations in Draft) |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/06-reject.md`           | Reject a leave allocation request batch                                                            |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/10-cancel.md`           | Cancel a leave allocation request batch (deletes the derived leave allocations, if any)            |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/12-restart.md`          | Restart a cancelled leave allocation request batch                                                 |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/13-reset-number.md`     | Reset a leave allocation request batch's document number                                           |
+| `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/14-restart-approval.md` | Restart a leave allocation request batch's approval process                                        |
+
 ### `ssi_hr_leave_request_batch` — Model: `hr.leave_request_batch`
 
 Menu: **Human Resource > Timesheets > Leave Request Batch**

--- a/ssi_hr_leave_allocation_request_batch/README.rst
+++ b/ssi_hr_leave_allocation_request_batch/README.rst
@@ -7,6 +7,21 @@ Leave Allocation Request Batch
 ==============================
 
 
+Work Instruction
+================
+
+* `Create Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Edit Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Delete Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Confirm Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Approve Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Reject Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Cancel Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Restart Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Reset Document Number — Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+* `Restart Approval Process — Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/01-create.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/01-create.md
@@ -1,0 +1,67 @@
+# Create Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`), `manual_number_ok` (state `draft`), `restart_approval_ok` (states `confirm`,
+  `reject`), `cancel_ok` (states `draft`, `confirm`, `done`, `reject`), and `restart_ok`
+  (state `cancel`) to the relevant groups — see the _Standard_ `policy.template` shipped
+  with this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module (single sequential level, approved by
+  group _Leave Allocation Request Batch — Validator_).
+- **Config:** An active `sequence.template` for this model exists — see the _Standard_
+  `sequence.template` shipped with this module.
+- **Data:** Each employee to select in **Employee(s)** has an `hr.employee` record.
+  Approving this batch to **Done** (`05-approve`) creates one `hr.leave_allocation`
+  document per selected employee that does not already have a clashing allocation, so
+  the same data prerequisites documented for a single leave allocation apply per
+  employee — see `ssi_hr_holiday/docs/hr_leave_allocation/01-create.md` (e.g., the
+  selected **Type** must have **Need Allocation** checked, and the employee must not
+  already have an active `hr.leave_allocation` whose date range overlaps this batch's
+  **Date Start**/**Date End**).
+- **Access:** User is in group _Leave Allocation Request Batch — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Type** _(required)_: Select the leave type that will be applied to every
+     `hr.leave_allocation` document created for this batch. Only leave types with **Need
+     Allocation** checked can be selected.
+   - **Number Of Days** _(required)_: Enter the number of leave days granted by every
+     `hr.leave_allocation` document created for this batch.
+   - **Employee(s)** _(required)_: Select the employees to include in this batch.
+   - **Date Start** _(required)_: Enter the start date shared by every
+     `hr.leave_allocation` document created for this batch.
+   - **Date End** _(required)_: Enter the end date shared by every `hr.leave_allocation`
+     document created for this batch.
+   - **Can be Extended**: Check to allow **Date Extended** to be set later than **Date
+     End**. Leave unchecked to keep **Date Extended** equal to **Date End**.
+   - **Date Extended**: Automatically filled from **Date End**. If **Can be Extended**
+     is checked, change it to a later date; entering a date earlier than **Date End**
+     triggers a warning and it is reset back to **Date End**.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new leave allocation request batch record is created in **Draft** status.
+- The **Leave Allocation Request** tab stays empty — the individual
+  `hr.leave_allocation` documents are only created once the batch's approval completes
+  and it reaches **Done** (see `05-approve`), not when it is confirmed (see
+  `04-confirm`).
+- The document number stays **/** until the record transitions to **Done**, which
+  happens automatically once approval completes — there is no separate Finish/Done
+  button — unless the actor has _Can Input Manual Document Number_ access (see
+  `13-reset-number`).

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/02-edit.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/02-edit.md
@@ -1,0 +1,34 @@
+# Edit Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Leave Allocation Request Batch — User_, and is the
+  record's **Responsible** (record rule), or holds a broader data-ownership group
+  (_Company_, _Company and All Child Companies_, or _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Find and open the record to edit.
+3. Change **Type**, **Number Of Days**, **Employee(s)**, **Date Start**, **Date End**,
+   **Can be Extended**, or **Date Extended** as needed — the same constraints described
+   in `01-create` apply.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- The **Leave Allocation Request** tab remains unaffected by this edit — it is only
+  populated once the batch's approval completes and it reaches **Done** (see
+  `05-approve`).

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/03-delete.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Leave Allocation Request Batch — User_, and is the
+  record's **Responsible** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/04-confirm.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/04-confirm.md
@@ -1,0 +1,46 @@
+# Confirm Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single sequential level approved by group _Leave Allocation Request Batch —
+  Validator_).
+- **Access:** User is in group _Leave Allocation Request Batch — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for the batch, one for each approver level defined by the
+  _Standard_ `approval.template` (single level, group _Leave Allocation Request Batch —
+  Validator_).
+- The **Leave Allocation Request** tab still stays empty — confirming the batch does
+  **not** create any `hr.leave_allocation` document yet. The derived documents are only
+  created once every approval level has approved and the batch reaches **Done** (see
+  `05-approve`).
+- Once every approval level has approved, the batch transitions to **Done**
+  automatically — there is no separate Finish/Done button. The document number is also
+  assigned automatically at this point (unless already manually assigned — see
+  `13-reset-number`).

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/05-approve.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/05-approve.md
@@ -1,0 +1,67 @@
+# Approve Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Data:** For every employee listed in **Employee(s)** that does not already have a
+  linked `hr.leave_allocation` document in this batch, the employee must not already
+  have another active `hr.leave_allocation` (status other than
+  **Cancelled**/**Rejected**) whose date range overlaps this batch's **Date
+  Start**/**Date End** — see `ssi_hr_holiday/docs/hr_leave_allocation/01-create.md`. If
+  this condition is not met for even one employee, approving fails for the whole batch
+  (see Post-Condition below).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave Allocation Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending; the rest of this section does not apply yet.
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Finish/Done button. With the shipped _Standard_ `approval.template`
+  (single level), approving always fulfills the approval and the batch goes straight to
+  **Done**. Reaching **Done** triggers the derived-document creation described below.
+- For each employee listed in **Employee(s)** that does not already have a linked
+  `hr.leave_allocation` document in this batch (**Leave Allocation Request** tab), a new
+  `hr.leave_allocation` document is created (**Date Start**/**Date End** = this batch's
+  **Date Start**/**Date End**, **Type** = this batch's **Type**, **Number of Days** =
+  this batch's **Number Of Days**, **Can be Extended**/**Date Extended** = this batch's
+  own values, **Batch** = this record) and appears in the **Leave Allocation Request**
+  tab. Its **Department**, **Manager**, and **Job Position** are computed automatically
+  — the same effect as the onchange triggered when creating an `hr.leave_allocation`
+  document manually (see `ssi_hr_holiday/docs/hr_leave_allocation/01-create.md`).
+- Unlike the batch itself, each newly created `hr.leave_allocation` document is **not**
+  automatically confirmed or approved — it is left in its own **Draft** status.
+  Advancing it through its own workflow (see
+  `ssi_hr_holiday/docs/hr_leave_allocation/04-confirm.md` onward) is a separate, manual
+  step outside this batch.
+- If any employee in **Employee(s)** already has another active `hr.leave_allocation`
+  overlapping this batch's date range (see Pre-Condition), approving raises an error and
+  the whole action fails — the batch does not reach **Done** and no
+  `hr.leave_allocation` document is created for any employee in this approval attempt.
+
+> **Note:** **Employee(s)** is a required field on this model (see `01-create`), so a
+> batch can never reach this step with an empty employee list.

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/06-reject.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/06-reject.md
@@ -1,0 +1,38 @@
+# Reject Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses sequential approval with a single
+  level, approved by group _Leave Allocation Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.
+- No `hr.leave_allocation` document is created or affected by this rejection — since
+  derived documents are only created once the batch reaches **Done** (see `05-approve`),
+  and a rejected batch never reaches **Done**, the **Leave Allocation Request** tab
+  stays empty.

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/10-cancel.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/10-cancel.md
@@ -1,0 +1,48 @@
+# Cancel Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — Validator_
+>
+> **State:** `draft` | `confirm` | `done` | `reject` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, **Done**, or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Leave Allocation Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the batch.
+- If any `hr.leave_allocation` documents were already created for this batch (see
+  `05-approve`, listed in the **Leave Allocation Request** tab), each one is **deleted**
+  (not cancelled) as part of cancelling the batch. Cancelling from **Draft**, **Waiting
+  for Approval**, or **Rejected** has no such effect, since the **Leave Allocation
+  Request** tab is still empty at that point (documents are only created once the batch
+  reaches **Done** — see `05-approve`).
+
+> **Note:** deleting each linked `hr.leave_allocation` document only succeeds while that
+> document is still in its own **Draft** status with document number **/** (its state
+> right after being created by `05-approve`, since this batch does not advance it any
+> further — see the note there). If a linked `hr.leave_allocation` document was manually
+> confirmed, approved, or otherwise advanced after being created, cancelling this batch
+> fails instead of deleting it, and the batch stays in its state from before this Cancel
+> attempt.

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/12-restart.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/12-restart.md
@@ -1,0 +1,44 @@
+# Restart Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — Validator_
+>
+> **State:** `cancel` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it only
+  for status **Cancelled**).
+- **Access:** User is in group _Leave Allocation Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- The **Reason** recorded by `10-cancel` is cleared.
+- All approval records for the batch are removed and the **Approval Template** is
+  cleared. A later Confirm (`04-confirm`) starts the approval process from the
+  beginning.
+- The **Leave Allocation Request** tab stays empty — any `hr.leave_allocation` documents
+  that existed for this batch were already removed when it was cancelled (see
+  `10-cancel`).
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_ok` only for status
+> **Cancelled** — not **Rejected**. A record in status **Rejected** has no button to
+> return directly to **Draft**; it must first be cancelled (see `10-cancel`, which
+> allows cancelling from status **Rejected**) before **Restart** becomes available.

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/13-reset-number.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/13-reset-number.md
@@ -1,0 +1,35 @@
+# Reset Document Number — Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard_
+  `sequence.template`).
+- **Access:** User is in group _Leave Allocation Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** (see
+  `05-approve`, completed automatically once approved), according to the _Standard_
+  `sequence.template` configuration.

--- a/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/14-restart-approval.md
+++ b/ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/14-restart-approval.md
@@ -1,0 +1,46 @@
+# Restart Approval Process — Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch
+>
+> **Model:** `hr.leave_allocation_request_batch`
+>
+> **Menu:** Human Resource > Timesheets > Leave Allocation Request Batch
+>
+> **Actor:** user in group _Leave Allocation Request Batch — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for states `confirm` and `reject` to the actor's group (see the _Standard_
+  `policy.template`). As shipped, this policy only evaluates to allowed while the
+  record's **Approval Template** field is still empty — since Confirm (`04-confirm`)
+  already assigns an approval template before the record reaches state `confirm` (and
+  rejecting does not clear it), the button is typically not clickable in practice with
+  the default configuration. See the note below.
+- **Access:** User is in group _Leave Allocation Request Batch — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Leave Allocation Request Batch** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status is unchanged (remains **Waiting for Approval** or **Rejected**, whichever it
+  was before this action).
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, and neither approving, rejecting, nor entering state `reject` clears it,
+> this policy is effectively never satisfied under the default configuration. This was
+> found while writing this IK and reported to the module maintainers rather than fixed
+> here, since fixing it is a code change out of scope for this Work Instruction.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) untuk model transaksional
`hr.leave_allocation_request_batch` (modul `ssi_hr_leave_allocation_request_batch`),
lengkap dengan indeksnya di `README.rst` modul dan `AGENTS.md` repo.

* IK dibuat untuk setiap aksi yang terbukti ada di kode & form view (bukan disalin dari
  modul batch lain): create, edit, delete, confirm, approve, reject, cancel, restart,
  reset document number, restart approval process.
* Post-Condition `05-approve` mendokumentasikan pembentukan dokumen `hr.leave_allocation`
  turunan (dibuat lewat hook privat `post_done_action`, bukan tombol tersendiri) —
  termasuk kekhususan model ini dibanding modul batch sejenis: dokumen turunan baru
  terbentuk saat batch mencapai status **Done** (bukan saat Confirm, karena hook
  propagasi confirm/approve/reject ke dokumen anak sengaja dinonaktifkan di kode), dan
  dokumen turunan itu tidak otomatis ikut ter-confirm/approve. `10-cancel`
  mendokumentasikan bahwa membatalkan batch dari status Done **menghapus** (bukan
  membatalkan) dokumen turunannya.
* Sesuai ruang lingkup issue: tour pasangan tiap berkas IK ini **sengaja belum dibuat**
  pada PR ini — dikerjakan di item terpisah open-synergy/opnsynid-hr-timesheet#157.

## Test plan

- [x] `assets/validate-ik.sh` dijalankan atas modul: 0 error (peringatan hanya soal tour
      yang memang di luar ruang lingkup issue ini).
- [x] CI (pre-commit + unit test) dipantau hijau di PR ini.

Closes #128