### PR TITLE
[UPD] ssi_timesheet - Tambah UI test (Odoo Tour) dari Instruksi Kerja

### DIFF
--- a/ssi_timesheet/__manifest__.py
+++ b/ssi_timesheet/__manifest__.py
@@ -20,6 +20,7 @@
         "ssi_employee_document_mixin",
         "ssi_decorator",
         "report_xlsx",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -34,6 +35,7 @@
         "views/hr_timesheet_computation_item_views.xml",
         "views/hr_timesheet_views.xml",
         "views/hr_employee_views.xml",
+        "views/ssi_timesheet_assets.xml",
         "wizards/generate_timesheet.xml",
         "wizards/timesheet_summary_report.xml",
         "reports/hr_timesheet_computation_analysis.xml",

--- a/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js
+++ b/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js
@@ -1,0 +1,453 @@
+odoo.define("ssi_timesheet.hr_timesheet_computation_item_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Configuration > Timesheets >
+    // Timesheet Computation Items. "Timesheets" (level 3, under
+    // Configuration) has one child of its own — the "Timesheet Computation
+    // Items" leaf — so it is rendered as a non-clickable dropdown header
+    // and is skipped here, exactly like the "Payroll Agreement" example in
+    // the odoo-development-ui-test skill (patterns.md §A).
+    function openComputationItemMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr.menu_human_resource_configuration"]',
+            },
+            {
+                content: "Open the Timesheet Computation Items menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.hr_timesheet_computation_item_menu"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action ("Employees") is also a
+                // .o_list_view.
+                content: "Timesheet Computation Items list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(Timesheet Computation Items)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_computation_item/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_computation_item_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openComputationItemMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Name; leave Code as the default "/".
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-COMP-CREATE-UI",
+            },
+            // ── Flow 4 — Click Generate Code.
+            {
+                content: "Click Generate Code",
+                trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+            },
+            {
+                content: "UI is no longer blocked",
+                trigger: "body:not(.o_ui_blocked)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 5 — On the Computation tab, the Python Code field is
+            // shown pre-filled with the default comment template.
+            {
+                content: "Open the Computation tab",
+                trigger: ".o_notebook .nav-link:contains(Computation)",
+            },
+            {
+                content: "Python Code editor is displayed",
+                trigger: ".o_field_widget[name='python_code'] .ace_editor",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new record is created.
+            {
+                content: "Back to the Timesheet Computation Items list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a" +
+                    ":contains(Timesheet Computation Items)",
+            },
+            {
+                content: "New record appears in the list",
+                trigger: ".o_data_row:contains(TOUR-COMP-CREATE-UI)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_computation_item/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_computation_item_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openComputationItemMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-COMP-EDIT-UI) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Reset Code back to "/".
+            {
+                content: "Reset the Code field to /",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+            // ── Flow 4 — Click Generate Code.
+            {
+                content: "Click Generate Code",
+                trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+            },
+            {
+                content: "UI is no longer blocked",
+                trigger: "body:not(.o_ui_blocked)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_computation_item/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_computation_item_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openComputationItemMenuSteps(), [
+            // ── Flow 2-3 — select the record and delete it. Deletion is
+            // driven from the record's own Action menu rather than the
+            // list checkbox: the 14.0 list-selector checkbox is flaky
+            // (odoo-development-ui-test skill, patterns.md §I), and this
+            // reaches the same Post-Condition.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-COMP-DELETE-UI) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the Timesheet Computation Items list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a" +
+                    ":contains(Timesheet Computation Items)",
+            },
+            // ── Post-Condition — records permanently removed.
+            {
+                content: "Deleted item no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-COMP-DELETE-UI)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_computation_item/04-deactivate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_computation_item_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openComputationItemMenuSteps(), [
+            // ── Flow 2-3 — select the record and archive it, from the
+            // record's own form (same substitution as Delete above).
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-COMP-DEACTIVATE-UI) " +
+                    ".o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Uncheck Active",
+                trigger: ".o_field_widget[name='active'] input",
+                run: "click",
+            },
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — record is archived.
+            {
+                content: "Archived ribbon is displayed",
+                trigger: ".o_form_view .ribbon:visible:contains(Archived)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_computation_item/05-activate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_computation_item_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openComputationItemMenuSteps(), [
+            // ── Flow 2 — Enable the Archived filter.
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+                run: function () {
+                    // Owl dropdowns in 14.0 are not always opened by a
+                    // synthetic click — use a native click instead.
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .o_menu_item a:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Archived item is displayed in the list",
+                trigger: ".o_data_row:contains(TOUR-COMP-ACTIVATE-UI)",
+                extra_trigger: ".o_list_view",
+            },
+            // ── Flow 3-4 — select the record and unarchive it, from the
+            // record's own form (same substitution as Delete above).
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-COMP-ACTIVATE-UI) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+            // ── Post-Condition — record is restored. Unarchive executes
+            // immediately without a confirmation dialog.
+            {
+                content: "Archived ribbon is no longer displayed",
+                trigger: ".o_form_view:not(:has(.ribbon:visible:contains(Archived)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_computation_item/06-reset-code.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_computation_item_reset_code",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openComputationItemMenuSteps(), [
+            // ── Flow 2 — Select the record whose code will be reset. This
+            // button only exists in the list header, so (unlike Delete/
+            // Archive) it must be exercised via the list checkbox.
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-COMP-RESETCODE-UI) " +
+                    ".o_list_record_selector input",
+                run: "click",
+            },
+            // ── Flow 3 — Click the Reset code button.
+            {
+                content: "Click the Reset code button",
+                trigger: ".o_control_panel button[name='action_reset_code']",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            // ── Post-Condition — Code returns to "/"; the dialog closing
+            // without error is the visible evidence.
+            {
+                content: "Dialog is closed",
+                trigger: "body:not(:has(.modal))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js
+++ b/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js
@@ -69,11 +69,23 @@ odoo.define("ssi_timesheet.hr_timesheet_computation_item_tour", function (requir
                 },
             },
             // ── Flow 3 — Fill in Name; leave Code as the default "/".
+            // ``code`` carries no field-level default (unlike
+            // ``hr.timesheet.name``), so it starts genuinely empty on a
+            // new record — set it to "/" explicitly (matching what the
+            // IK calls "the default") so the implicit save behind the
+            // Generate Code click below does not race client-side
+            // required-field validation on a still-blank Code.
             {
                 content: "Fill in Name",
                 trigger: ".o_field_widget[name='name']",
                 extra_trigger: ".o_form_view.o_form_editable",
                 run: "text TOUR-COMP-CREATE-UI",
+            },
+            {
+                content: "Ensure Code is /",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur /",
             },
             // ── Flow 4 — Click Generate Code. No sequence.template is
             // configured for this model in this repo (see the IK's own
@@ -180,7 +192,7 @@ odoo.define("ssi_timesheet.hr_timesheet_computation_item_tour", function (requir
                 content: "Reset the Code field to /",
                 trigger: ".o_field_widget[name='code']",
                 extra_trigger: ".o_form_view.o_form_editable",
-                run: "text /",
+                run: "text_blur /",
             },
             // ── Flow 4 — Click Generate Code. No sequence.template is
             // configured for this model in this repo (see the IK's own

--- a/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js
+++ b/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js
@@ -75,18 +75,25 @@ odoo.define("ssi_timesheet.hr_timesheet_computation_item_tour", function (requir
                 extra_trigger: ".o_form_view.o_form_editable",
                 run: "text TOUR-COMP-CREATE-UI",
             },
-            // ── Flow 4 — Click Generate Code.
+            // ── Flow 4 — Click Generate Code. No sequence.template is
+            // configured for this model in this repo (see the IK's own
+            // caveat), so this always raises "No sequence template
+            // found" — dismiss that dialog, then fill Code manually
+            // with a non-"/" value as the IK instructs for that case.
             {
                 content: "Click Generate Code",
                 trigger: ".o_statusbar_buttons button[name='action_generate_code']",
             },
             {
-                content: "UI is no longer blocked",
-                trigger: "body:not(.o_ui_blocked)",
-                run: function () {
-                    // Assertion only; do not trigger the default click
-                    // action.
-                },
+                content: 'Dismiss the "No sequence template found" dialog',
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Fill in Code manually",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-CREATE-01",
             },
             // ── Flow 5 — On the Computation tab, the Python Code field is
             // shown pre-filled with the default comment template.
@@ -175,18 +182,25 @@ odoo.define("ssi_timesheet.hr_timesheet_computation_item_tour", function (requir
                 extra_trigger: ".o_form_view.o_form_editable",
                 run: "text /",
             },
-            // ── Flow 4 — Click Generate Code.
+            // ── Flow 4 — Click Generate Code. No sequence.template is
+            // configured for this model in this repo (see the IK's own
+            // caveat), so this always raises "No sequence template
+            // found" — dismiss that dialog, then fill Code manually
+            // with a non-"/" value as the IK instructs for that case.
             {
                 content: "Click Generate Code",
                 trigger: ".o_statusbar_buttons button[name='action_generate_code']",
             },
             {
-                content: "UI is no longer blocked",
-                trigger: "body:not(.o_ui_blocked)",
-                run: function () {
-                    // Assertion only; do not trigger the default click
-                    // action.
-                },
+                content: 'Dismiss the "No sequence template found" dialog',
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Fill in Code manually",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-EDIT-02",
             },
             // ── Flow 5 — Click Save.
             {
@@ -427,22 +441,22 @@ odoo.define("ssi_timesheet.hr_timesheet_computation_item_tour", function (requir
                     ".o_list_record_selector input",
                 run: "click",
             },
-            // ── Flow 3 — Click the Reset code button.
+            // ── Flow 3 — Click the Reset code button. Unlike form-view
+            // buttons, list-view <header> buttons in 14.0 never honor
+            // `confirm=` (web/static/src/js/views/list/list_controller.js
+            // `_onHeaderButtonClicked` calls `_executeButtonAction`
+            // directly and never reads `node.attrs.confirm`), so no
+            // dialog appears here despite the IK's Flow step 4 — the
+            // action runs immediately.
             {
                 content: "Click the Reset code button",
                 trigger: ".o_control_panel button[name='action_reset_code']",
             },
-            // ── Flow 4 — Click OK on the confirmation dialog.
+            // ── Post-Condition — Code returns to "/": the list reloads
+            // after the action and the row no longer shows the old code.
             {
-                content: "Confirm the dialog",
-                trigger: ".modal-footer button.btn-primary",
-                in_modal: true,
-            },
-            // ── Post-Condition — Code returns to "/"; the dialog closing
-            // without error is the visible evidence.
-            {
-                content: "Dialog is closed",
-                trigger: "body:not(:has(.modal))",
+                content: "Row no longer shows the old code",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(TCI-RESET)))",
                 run: function () {
                     // Assertion only; do not trigger the default click
                     // action.

--- a/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js
+++ b/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js
@@ -1,0 +1,747 @@
+odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Timesheets.
+    // "Timesheets" (level 2, section) has one child ("Timesheets" leaf,
+    // level 3) so both levels are clickable — matches the three menu
+    // segments written in every hr_timesheet IK ("Menu: Human Resource >
+    // Timesheets > Timesheets").
+    function openTimesheetMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Timesheets menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.menu_hr_timesheet"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action ("Employees") is also a
+                // .o_list_view.
+                content: "Timesheets list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Timesheets)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Click a statusbar/header button by its exact visible label. Several
+    // buttons on this form share a `name` attribute that is a numeric
+    // action id (the Cancel button) rather than a method name, so matching
+    // by trimmed text is the only selector that is deterministic across
+    // all of them.
+    function clickHeaderButtonByLabel(label) {
+        return {
+            content: "Click the " + label + " button",
+            trigger: ".o_statusbar_buttons button",
+            run: function () {
+                var $button = $(".o_statusbar_buttons button").filter(function () {
+                    return $(this).text().trim() === label;
+                });
+                $button[0].click();
+            },
+        };
+    }
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Employee, Date Start, Date End.
+            {
+                content: "Select the Employee",
+                trigger: ".o_field_many2one[name='employee_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-EMP-CREATE",
+            },
+            {
+                content: "Pick the Employee from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-EMP-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 01/01/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 01/31/2026",
+            },
+            // ── Flow 4 — On the Computations tab, click Reload, then
+            // Compute.
+            {
+                content: "Open the Computations tab",
+                trigger: ".o_notebook .nav-link:contains(Computations)",
+            },
+            {
+                content: "Click Reload",
+                trigger:
+                    ".o_form_view button[name='action_reload_timesheet_computation']",
+            },
+            {
+                // Gate: TCC01 only becomes reachable through
+                // employee_id.timesheet_computation_ids, and computation_ids
+                // starts empty on a brand-new record — this cannot match
+                // before Reload actually ran.
+                content: "Computation line is loaded from the Employee",
+                trigger:
+                    ".o_field_x2many[name='computation_ids'] " +
+                    ".o_data_row:contains(TCC01)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click Compute",
+                trigger: ".o_form_view button[name='action_compute_computation']",
+            },
+            {
+                content: "UI is no longer blocked",
+                trigger: "body:not(.o_ui_blocked)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — new record created in Draft status.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Date End.
+            {
+                content: "Change Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 01/20/2026",
+            },
+            // ── Flow 4 — On the Computations tab, click Reload, then
+            // Compute.
+            {
+                content: "Open the Computations tab",
+                trigger: ".o_notebook .nav-link:contains(Computations)",
+            },
+            {
+                content: "Click Reload",
+                trigger:
+                    ".o_form_view button[name='action_reload_timesheet_computation']",
+            },
+            {
+                // Gate: TCE01 is registered on TOUR-EMP-EDIT but the record
+                // was created without any computation_ids row, so this
+                // cannot match before Reload actually ran.
+                content: "Computation line is loaded from the Employee",
+                trigger:
+                    ".o_field_x2many[name='computation_ids'] " +
+                    ".o_data_row:contains(TCE01)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click Compute",
+                trigger: ".o_form_view button[name='action_compute_computation']",
+            },
+            {
+                content: "UI is no longer blocked",
+                trigger: "body:not(.o_ui_blocked)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2-3 — select the record and delete it. Deletion is
+            // driven from the record's own Action menu rather than the
+            // list checkbox: the 14.0 list-selector checkbox is flaky
+            // (odoo-development-ui-test skill, patterns.md §I), and this
+            // reaches the same Post-Condition.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the Timesheets list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Timesheets)",
+            },
+            // ── Post-Condition — records permanently removed.
+            {
+                content: "Deleted timesheet no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-EMP-DELETE)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to confirm.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Waiting for Approval,
+            // and the Approve button (evidence that approval records were
+            // created for the pending level) becomes available.
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Approve button becomes available",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_approve_approval']:visible",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/05-approve.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — single-level approval template fulfilled
+            // immediately, so status changes to Done.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/06-reject.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to reject.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/07-start.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_start",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to start.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-START) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Start button.
+            {
+                content: "Click the Start button",
+                trigger: ".o_statusbar_buttons button[name='action_open']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to On Progress.
+            {
+                content: "Status is On Progress",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/10-cancel.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to cancel.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Cancel button. `name` is a numeric
+            // action id on this button, so match its label instead.
+            clickHeaderButtonByLabel("Cancel"),
+            // ── Flow 4 — In the wizard, select the Reason.
+            {
+                // 14.0: do NOT prefix with `.modal` — the trigger is
+                // searched INSIDE the modal already (see
+                // odoo-development-ui-test skill, patterns.md §H).
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Select the cancellation reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] " +
+                    ".o_radio_item:contains(TOUR-CANCEL-REASON) input",
+            },
+            // ── Flow 5 — Click Confirm.
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+            // ── Flow 6 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Cancelled, and the
+            // selected Reason is recorded on the timesheet.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Cancellation reason is displayed",
+                trigger: "h2:visible:contains(Cancellation reason)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/12-restart.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to restart.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/13-reset-number.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record whose document number will be
+            // reset.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-RESETNUM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Reset Document Number button.
+            {
+                content: "Click the Reset Document Number button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reset_document_number']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — document number returns to "/"; the
+            // dialog closing without error is the visible evidence.
+            {
+                content: "Dialog is closed",
+                trigger: "body:not(:has(.modal))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/14-restart-approval.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_hr_timesheet_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to restart the approval process
+            // for.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-EMP-RESTARTAPPROVAL) " +
+                    ".o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Restart Approval Process button.
+            {
+                content: "Click the Restart Approval Process button",
+                trigger:
+                    ".o_statusbar_buttons " +
+                    "button[name='action_reload_approval_template']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status remains Waiting for Approval.
+            {
+                content: "Status remains Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js
+++ b/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js
@@ -114,8 +114,19 @@ odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
                 extra_trigger: ".o_form_view.o_form_editable",
                 run: "text_blur 01/31/2026",
             },
-            // ── Flow 4 — On the Computations tab, click Reload, then
-            // Compute.
+            // ── Flow 4 — On the Computations tab, click Reload. Compute
+            // is deliberately NOT clicked here: it neither writes any
+            // stored value (action_compute_computation only evaluates
+            // Python Code into a discarded local dict — see
+            // hr_timesheet.py _compute_computation) nor produces any
+            // other kasatmata change, so there is no data-driven gate
+            // that is guaranteed false before the click and true after
+            // (odoo-development-ui-test skill, patterns.md §P table:
+            // "aksi boleh menghasilkan nol data... jangan klik tombolnya
+            // di tour"). The IK itself frames it as optional ("You may
+            // then click Compute"), and both Reload and Compute already
+            // run automatically on Start/Confirm (docs/hr_timesheet/
+            // 07-start.md, 04-confirm.md).
             {
                 content: "Open the Computations tab",
                 trigger: ".o_notebook .nav-link:contains(Computations)",
@@ -134,18 +145,6 @@ odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
                 trigger:
                     ".o_field_x2many[name='computation_ids'] " +
                     ".o_data_row:contains(TCC01)",
-                run: function () {
-                    // Assertion only; do not trigger the default click
-                    // action.
-                },
-            },
-            {
-                content: "Click Compute",
-                trigger: ".o_form_view button[name='action_compute_computation']",
-            },
-            {
-                content: "UI is no longer blocked",
-                trigger: "body:not(.o_ui_blocked)",
                 run: function () {
                     // Assertion only; do not trigger the default click
                     // action.
@@ -220,8 +219,19 @@ odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
                 extra_trigger: ".o_form_view.o_form_editable",
                 run: "text_blur 01/20/2026",
             },
-            // ── Flow 4 — On the Computations tab, click Reload, then
-            // Compute.
+            // ── Flow 4 — On the Computations tab, click Reload. Compute
+            // is deliberately NOT clicked here: it neither writes any
+            // stored value (action_compute_computation only evaluates
+            // Python Code into a discarded local dict — see
+            // hr_timesheet.py _compute_computation) nor produces any
+            // other kasatmata change, so there is no data-driven gate
+            // that is guaranteed false before the click and true after
+            // (odoo-development-ui-test skill, patterns.md §P table:
+            // "aksi boleh menghasilkan nol data... jangan klik tombolnya
+            // di tour"). The IK itself frames it as optional ("You may
+            // then click Compute"), and both Reload and Compute already
+            // run automatically on Start/Confirm (docs/hr_timesheet/
+            // 07-start.md, 04-confirm.md).
             {
                 content: "Open the Computations tab",
                 trigger: ".o_notebook .nav-link:contains(Computations)",
@@ -239,18 +249,6 @@ odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
                 trigger:
                     ".o_field_x2many[name='computation_ids'] " +
                     ".o_data_row:contains(TCE01)",
-                run: function () {
-                    // Assertion only; do not trigger the default click
-                    // action.
-                },
-            },
-            {
-                content: "Click Compute",
-                trigger: ".o_form_view button[name='action_compute_computation']",
-            },
-            {
-                content: "UI is no longer blocked",
-                trigger: "body:not(.o_ui_blocked)",
                 run: function () {
                     // Assertion only; do not trigger the default click
                     // action.

--- a/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js
+++ b/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js
@@ -106,13 +106,13 @@ odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
                 content: "Fill in Date Start",
                 trigger: ".o_field_widget[name='date_start'] input",
                 extra_trigger: ".o_form_view.o_form_editable",
-                run: "text 01/01/2026",
+                run: "text_blur 01/01/2026",
             },
             {
                 content: "Fill in Date End",
                 trigger: ".o_field_widget[name='date_end'] input",
                 extra_trigger: ".o_form_view.o_form_editable",
-                run: "text 01/31/2026",
+                run: "text_blur 01/31/2026",
             },
             // ── Flow 4 — On the Computations tab, click Reload, then
             // Compute.
@@ -218,7 +218,7 @@ odoo.define("ssi_timesheet.hr_timesheet_tour", function (require) {
                 content: "Change Date End",
                 trigger: ".o_field_widget[name='date_end'] input",
                 extra_trigger: ".o_form_view.o_form_editable",
-                run: "text 01/20/2026",
+                run: "text_blur 01/20/2026",
             },
             // ── Flow 4 — On the Computations tab, click Reload, then
             // Compute.

--- a/ssi_timesheet/tests/__init__.py
+++ b/ssi_timesheet/tests/__init__.py
@@ -5,3 +5,5 @@
 from . import test_timesheet
 from . import test_timesheet_computation
 from . import test_timesheet_summary_report
+from . import test_ui_hr_timesheet
+from . import test_ui_hr_timesheet_computation_item

--- a/ssi_timesheet/tests/test_ui_hr_timesheet.py
+++ b/ssi_timesheet/tests/test_ui_hr_timesheet.py
@@ -32,6 +32,13 @@ class TestUiHrTimesheet(HttpSavepointCase):
         requires; those are built here by calling the transition
         methods directly with ``bypass_policy_check``, mirroring how
         ``tests/test_data_timesheet.yaml`` prepares the same states.
+
+        When ``ssi_timesheet_attendance_shift`` is installed alongside
+        this module (as it is in this repo's CI, which tests every
+        addon together), ``hr.timesheet`` gains a required
+        ``working_schedule_id`` whenever ``schedule_source`` is its
+        default ``working_schedule`` — see
+        :meth:`_timesheet_values` for how that is satisfied.
         """
         super().setUpClass()
         cls.env.ref("ssi_timesheet.hr_timesheet_validator_group").sudo().write(
@@ -41,6 +48,10 @@ class TestUiHrTimesheet(HttpSavepointCase):
         employee_model = cls.env["hr.employee"]
         item_model = cls.env["hr.timesheet_computation_item"]
         timesheet_model = cls.env["hr.timesheet"]
+        cls.timesheet_model = timesheet_model
+        cls.working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
 
         # --- 01-create.md: employee with a registered computation item,
         # so the tour's Reload button click has a deterministic row to
@@ -67,31 +78,19 @@ class TestUiHrTimesheet(HttpSavepointCase):
         )
         cls.employee_edit.timesheet_computation_ids = [(6, 0, [item_edit.id])]
         cls.timesheet_edit = timesheet_model.create(
-            {
-                "employee_id": cls.employee_edit.id,
-                "date_start": "2026-01-01",
-                "date_end": "2026-01-31",
-            }
+            cls._timesheet_values(cls.employee_edit, "2026-01-01", "2026-01-31")
         )
 
         # --- 03-delete.md: draft timesheet, document number still "/".
         cls.employee_delete = employee_model.create({"name": "TOUR-EMP-DELETE"})
         cls.timesheet_delete = timesheet_model.create(
-            {
-                "employee_id": cls.employee_delete.id,
-                "date_start": "2026-02-01",
-                "date_end": "2026-02-28",
-            }
+            cls._timesheet_values(cls.employee_delete, "2026-02-01", "2026-02-28")
         )
 
         # --- 04-confirm.md: On Progress (state=open).
         cls.employee_confirm = employee_model.create({"name": "TOUR-EMP-CONFIRM"})
         cls.timesheet_confirm = timesheet_model.create(
-            {
-                "employee_id": cls.employee_confirm.id,
-                "date_start": "2026-03-01",
-                "date_end": "2026-03-31",
-            }
+            cls._timesheet_values(cls.employee_confirm, "2026-03-01", "2026-03-31")
         )
         cls.timesheet_confirm.with_context(bypass_policy_check=True).action_open()
 
@@ -100,11 +99,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # "Standard - Timesheet" approval.template.
         cls.employee_approve = employee_model.create({"name": "TOUR-EMP-APPROVE"})
         cls.timesheet_approve = timesheet_model.create(
-            {
-                "employee_id": cls.employee_approve.id,
-                "date_start": "2026-04-01",
-                "date_end": "2026-04-30",
-            }
+            cls._timesheet_values(cls.employee_approve, "2026-04-01", "2026-04-30")
         )
         cls.timesheet_approve.with_context(bypass_policy_check=True).action_open()
         cls.timesheet_approve.with_context(bypass_policy_check=True).action_confirm()
@@ -113,11 +108,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # the approve fixture above.
         cls.employee_reject = employee_model.create({"name": "TOUR-EMP-REJECT"})
         cls.timesheet_reject = timesheet_model.create(
-            {
-                "employee_id": cls.employee_reject.id,
-                "date_start": "2026-05-01",
-                "date_end": "2026-05-31",
-            }
+            cls._timesheet_values(cls.employee_reject, "2026-05-01", "2026-05-31")
         )
         cls.timesheet_reject.with_context(bypass_policy_check=True).action_open()
         cls.timesheet_reject.with_context(bypass_policy_check=True).action_confirm()
@@ -125,11 +116,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # --- 07-start.md: Draft, ready to Start.
         cls.employee_start = employee_model.create({"name": "TOUR-EMP-START"})
         cls.timesheet_start = timesheet_model.create(
-            {
-                "employee_id": cls.employee_start.id,
-                "date_start": "2026-06-01",
-                "date_end": "2026-06-30",
-            }
+            cls._timesheet_values(cls.employee_start, "2026-06-01", "2026-06-30")
         )
 
         # --- 10-cancel.md: Draft (cancel_ok also applies to draft,
@@ -137,11 +124,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # wizard.
         cls.employee_cancel = employee_model.create({"name": "TOUR-EMP-CANCEL"})
         cls.timesheet_cancel = timesheet_model.create(
-            {
-                "employee_id": cls.employee_cancel.id,
-                "date_start": "2026-07-01",
-                "date_end": "2026-07-31",
-            }
+            cls._timesheet_values(cls.employee_cancel, "2026-07-01", "2026-07-31")
         )
         cls.cancel_reason = cls.env["base.cancel_reason"].create(
             {
@@ -154,11 +137,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # --- 12-restart.md: Cancelled (state=cancel).
         cls.employee_restart = employee_model.create({"name": "TOUR-EMP-RESTART"})
         cls.timesheet_restart = timesheet_model.create(
-            {
-                "employee_id": cls.employee_restart.id,
-                "date_start": "2026-08-01",
-                "date_end": "2026-08-31",
-            }
+            cls._timesheet_values(cls.employee_restart, "2026-08-01", "2026-08-31")
         )
         restart_reason = cls.env["base.cancel_reason"].create(
             {
@@ -176,11 +155,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # Document Number button has a visible effect.
         cls.employee_resetnum = employee_model.create({"name": "TOUR-EMP-RESETNUM"})
         cls.timesheet_resetnum = timesheet_model.create(
-            {
-                "employee_id": cls.employee_resetnum.id,
-                "date_start": "2026-09-01",
-                "date_end": "2026-09-30",
-            }
+            cls._timesheet_values(cls.employee_resetnum, "2026-09-01", "2026-09-30")
         )
         cls.timesheet_resetnum.sudo().write({"name": "TOUR-RESETNUM-999"})
 
@@ -192,11 +167,9 @@ class TestUiHrTimesheet(HttpSavepointCase):
             {"name": "TOUR-EMP-RESTARTAPPROVAL"}
         )
         cls.timesheet_restart_approval = timesheet_model.create(
-            {
-                "employee_id": cls.employee_restart_approval.id,
-                "date_start": "2026-10-01",
-                "date_end": "2026-10-31",
-            }
+            cls._timesheet_values(
+                cls.employee_restart_approval, "2026-10-01", "2026-10-31"
+            )
         )
         cls.timesheet_restart_approval.with_context(
             bypass_policy_check=True
@@ -205,6 +178,31 @@ class TestUiHrTimesheet(HttpSavepointCase):
             bypass_policy_check=True
         ).action_confirm()
         cls.timesheet_restart_approval.sudo().write({"approval_template_id": False})
+
+    @classmethod
+    def _timesheet_values(cls, employee, date_start, date_end):
+        """Build ``hr.timesheet.create()`` values for a fixture record.
+
+        Includes ``working_schedule_id`` only when the field exists —
+        it is added by the sibling ``ssi_timesheet_attendance_shift``
+        module (installed alongside this one in this repo's CI), which
+        requires it whenever ``schedule_source`` keeps its default
+        ``working_schedule`` value.
+
+        :param employee: ``hr.employee`` record the timesheet is for
+        :param str date_start: ISO date string
+        :param str date_end: ISO date string
+        :return: values ready for ``hr.timesheet.create()``
+        :rtype: dict
+        """
+        values = {
+            "employee_id": employee.id,
+            "date_start": date_start,
+            "date_end": date_end,
+        }
+        if "working_schedule_id" in cls.timesheet_model._fields:
+            values["working_schedule_id"] = cls.working_schedule.id
+        return values
 
     def test_create(self):
         """Run the create tour for ``hr.timesheet``.

--- a/ssi_timesheet/tests/test_ui_hr_timesheet.py
+++ b/ssi_timesheet/tests/test_ui_hr_timesheet.py
@@ -1,0 +1,288 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrTimesheet(HttpSavepointCase):
+    """Tour tests for the ``hr.timesheet`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed employees and timesheets visible to the browser session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the Validator group and seed one fixture per tour.
+
+        Pre-Condition common to every ``hr_timesheet`` IK: the actor is
+        in group *Timesheets — User* (or a state-specific action
+        requires *Timesheets — Validator*). Granting *Validator* to
+        ``admin`` covers both, since it implies *User* which implies
+        *Viewer* (menu access).
+
+        Each state-transition tour needs its own employee/timesheet
+        pair already sitting in the state the IK's Pre-Condition
+        requires; those are built here by calling the transition
+        methods directly with ``bypass_policy_check``, mirroring how
+        ``tests/test_data_timesheet.yaml`` prepares the same states.
+        """
+        super().setUpClass()
+        cls.env.ref("ssi_timesheet.hr_timesheet_validator_group").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+        employee_model = cls.env["hr.employee"]
+        item_model = cls.env["hr.timesheet_computation_item"]
+        timesheet_model = cls.env["hr.timesheet"]
+
+        # --- 01-create.md: employee with a registered computation item,
+        # so the tour's Reload button click has a deterministic row to
+        # wait for.
+        cls.employee_create = employee_model.create({"name": "TOUR-EMP-CREATE"})
+        item_create = item_model.create(
+            {
+                "name": "TOUR-COMP-CREATE",
+                "code": "TCC01",
+                "python_code": "result = True",
+            }
+        )
+        cls.employee_create.timesheet_computation_ids = [(6, 0, [item_create.id])]
+
+        # --- 02-edit.md: draft timesheet, employee also carries a
+        # registered computation item for the same Reload gate.
+        cls.employee_edit = employee_model.create({"name": "TOUR-EMP-EDIT"})
+        item_edit = item_model.create(
+            {
+                "name": "TOUR-COMP-EDIT",
+                "code": "TCE01",
+                "python_code": "result = True",
+            }
+        )
+        cls.employee_edit.timesheet_computation_ids = [(6, 0, [item_edit.id])]
+        cls.timesheet_edit = timesheet_model.create(
+            {
+                "employee_id": cls.employee_edit.id,
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+            }
+        )
+
+        # --- 03-delete.md: draft timesheet, document number still "/".
+        cls.employee_delete = employee_model.create({"name": "TOUR-EMP-DELETE"})
+        cls.timesheet_delete = timesheet_model.create(
+            {
+                "employee_id": cls.employee_delete.id,
+                "date_start": "2026-02-01",
+                "date_end": "2026-02-28",
+            }
+        )
+
+        # --- 04-confirm.md: On Progress (state=open).
+        cls.employee_confirm = employee_model.create({"name": "TOUR-EMP-CONFIRM"})
+        cls.timesheet_confirm = timesheet_model.create(
+            {
+                "employee_id": cls.employee_confirm.id,
+                "date_start": "2026-03-01",
+                "date_end": "2026-03-31",
+            }
+        )
+        cls.timesheet_confirm.with_context(bypass_policy_check=True).action_open()
+
+        # --- 05-approve.md: Waiting for Approval (state=confirm); admin
+        # (Validator) is the pending approver for the single-level
+        # "Standard - Timesheet" approval.template.
+        cls.employee_approve = employee_model.create({"name": "TOUR-EMP-APPROVE"})
+        cls.timesheet_approve = timesheet_model.create(
+            {
+                "employee_id": cls.employee_approve.id,
+                "date_start": "2026-04-01",
+                "date_end": "2026-04-30",
+            }
+        )
+        cls.timesheet_approve.with_context(bypass_policy_check=True).action_open()
+        cls.timesheet_approve.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 06-reject.md: Waiting for Approval, independent record from
+        # the approve fixture above.
+        cls.employee_reject = employee_model.create({"name": "TOUR-EMP-REJECT"})
+        cls.timesheet_reject = timesheet_model.create(
+            {
+                "employee_id": cls.employee_reject.id,
+                "date_start": "2026-05-01",
+                "date_end": "2026-05-31",
+            }
+        )
+        cls.timesheet_reject.with_context(bypass_policy_check=True).action_open()
+        cls.timesheet_reject.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 07-start.md: Draft, ready to Start.
+        cls.employee_start = employee_model.create({"name": "TOUR-EMP-START"})
+        cls.timesheet_start = timesheet_model.create(
+            {
+                "employee_id": cls.employee_start.id,
+                "date_start": "2026-06-01",
+                "date_end": "2026-06-30",
+            }
+        )
+
+        # --- 10-cancel.md: Draft (cancel_ok also applies to draft,
+        # confirm and done). A global cancel reason is required by the
+        # wizard.
+        cls.employee_cancel = employee_model.create({"name": "TOUR-EMP-CANCEL"})
+        cls.timesheet_cancel = timesheet_model.create(
+            {
+                "employee_id": cls.employee_cancel.id,
+                "date_start": "2026-07-01",
+                "date_end": "2026-07-31",
+            }
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-CANCEL-REASON",
+                "code": "TOUR-CR",
+                "global_use": True,
+            }
+        )
+
+        # --- 12-restart.md: Cancelled (state=cancel).
+        cls.employee_restart = employee_model.create({"name": "TOUR-EMP-RESTART"})
+        cls.timesheet_restart = timesheet_model.create(
+            {
+                "employee_id": cls.employee_restart.id,
+                "date_start": "2026-08-01",
+                "date_end": "2026-08-31",
+            }
+        )
+        restart_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-RESTART-REASON",
+                "code": "TOUR-RR",
+                "global_use": True,
+            }
+        )
+        cls.timesheet_restart.with_context(bypass_policy_check=True).action_cancel(
+            restart_reason
+        )
+
+        # --- 13-reset-number.md: Draft, with a document number already
+        # assigned (simulating a manually-numbered record) so the Reset
+        # Document Number button has a visible effect.
+        cls.employee_resetnum = employee_model.create({"name": "TOUR-EMP-RESETNUM"})
+        cls.timesheet_resetnum = timesheet_model.create(
+            {
+                "employee_id": cls.employee_resetnum.id,
+                "date_start": "2026-09-01",
+                "date_end": "2026-09-30",
+            }
+        )
+        cls.timesheet_resetnum.sudo().write({"name": "TOUR-RESETNUM-999"})
+
+        # --- 14-restart-approval.md: Waiting for Approval, with
+        # approval_template_id cleared so the shipped policy.template
+        # (which only grants restart_approval_ok while that field is
+        # empty) evaluates to allowed — see the note in the IK itself.
+        cls.employee_restart_approval = employee_model.create(
+            {"name": "TOUR-EMP-RESTARTAPPROVAL"}
+        )
+        cls.timesheet_restart_approval = timesheet_model.create(
+            {
+                "employee_id": cls.employee_restart_approval.id,
+                "date_start": "2026-10-01",
+                "date_end": "2026-10-31",
+            }
+        )
+        cls.timesheet_restart_approval.with_context(
+            bypass_policy_check=True
+        ).action_open()
+        cls.timesheet_restart_approval.with_context(
+            bypass_policy_check=True
+        ).action_confirm()
+        cls.timesheet_restart_approval.sudo().write({"approval_template_id": False})
+
+    def test_create(self):
+        """Run the create tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/01-create.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/02-edit.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/03-delete.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_delete", login="admin")
+
+    def test_confirm(self):
+        """Run the confirm tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/04-confirm.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_confirm", login="admin")
+
+    def test_approve(self):
+        """Run the approve tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/05-approve.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_approve", login="admin")
+
+    def test_reject(self):
+        """Run the reject tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/06-reject.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_reject", login="admin")
+
+    def test_start(self):
+        """Run the start tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/07-start.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_start", login="admin")
+
+    def test_cancel(self):
+        """Run the cancel tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/10-cancel.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_cancel", login="admin")
+
+    def test_restart(self):
+        """Run the restart tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/12-restart.md
+        """
+        self.start_tour("/web", "ssi_timesheet_hr_timesheet_restart", login="admin")
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/13-reset-number.md
+        """
+        self.start_tour(
+            "/web", "ssi_timesheet_hr_timesheet_reset_number", login="admin"
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web", "ssi_timesheet_hr_timesheet_restart_approval", login="admin"
+        )

--- a/ssi_timesheet/tests/test_ui_hr_timesheet_computation_item.py
+++ b/ssi_timesheet/tests/test_ui_hr_timesheet_computation_item.py
@@ -1,0 +1,135 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrTimesheetComputationItem(HttpSavepointCase):
+    """Tour tests for the ``hr.timesheet_computation_item`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed computation items visible to the browser session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group and seed one item per tour.
+
+        Pre-Condition common to every IK in this model: the actor is in
+        group *Timesheet Computation Item* — without it the
+        Configuration menu is never rendered for "admin" and every tour
+        dies on its first step.
+        """
+        super().setUpClass()
+        cls.env.ref("ssi_timesheet.hr_timesheet_computation_item_group").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+        item_model = cls.env["hr.timesheet_computation_item"]
+
+        cls.item_edit = item_model.create(
+            {
+                "name": "TOUR-COMP-EDIT-UI",
+                "code": "TCI-EDIT",
+                "python_code": "result = True",
+            }
+        )
+        cls.item_delete = item_model.create(
+            {
+                "name": "TOUR-COMP-DELETE-UI",
+                "code": "TCI-DELETE",
+                "python_code": "result = True",
+            }
+        )
+        cls.item_deactivate = item_model.create(
+            {
+                "name": "TOUR-COMP-DEACTIVATE-UI",
+                "code": "TCI-DEACTIVATE",
+                "python_code": "result = True",
+            }
+        )
+        cls.item_activate = item_model.create(
+            {
+                "name": "TOUR-COMP-ACTIVATE-UI",
+                "code": "TCI-ACTIVATE",
+                "python_code": "result = True",
+                "active": False,
+            }
+        )
+        cls.item_reset_code = item_model.create(
+            {
+                "name": "TOUR-COMP-RESETCODE-UI",
+                "code": "TCI-RESET",
+                "python_code": "result = True",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.timesheet_computation_item``.
+
+        IK: docs/hr_timesheet_computation_item/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_hr_timesheet_computation_item_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.timesheet_computation_item``.
+
+        IK: docs/hr_timesheet_computation_item/02-edit.md
+        """
+        self.start_tour(
+            "/web", "ssi_timesheet_hr_timesheet_computation_item_edit", login="admin"
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.timesheet_computation_item``.
+
+        IK: docs/hr_timesheet_computation_item/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_hr_timesheet_computation_item_delete",
+            login="admin",
+        )
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``hr.timesheet_computation_item``.
+
+        IK: docs/hr_timesheet_computation_item/04-deactivate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_hr_timesheet_computation_item_deactivate",
+            login="admin",
+        )
+
+    def test_activate(self):
+        """Run the activate tour for ``hr.timesheet_computation_item``.
+
+        IK: docs/hr_timesheet_computation_item/05-activate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_hr_timesheet_computation_item_activate",
+            login="admin",
+        )
+
+    def test_reset_code(self):
+        """Run the reset code tour for ``hr.timesheet_computation_item``.
+
+        IK: docs/hr_timesheet_computation_item/06-reset-code.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_hr_timesheet_computation_item_reset_code",
+            login="admin",
+        )

--- a/ssi_timesheet/views/ssi_timesheet_assets.xml
+++ b/ssi_timesheet/views/ssi_timesheet_assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_timesheet assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet/static/tests/tours/hr_timesheet_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet/static/tests/tours/hr_timesheet_computation_item_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan Odoo Tour untuk setiap berkas Instruksi Kerja `ssi_timesheet` yang punya
langkah UI — satu tour per berkas IK, langkah Flow dipetakan 1:1 jadi step tour, sesuai
`docs/hr_timesheet/` (11 tour) dan `docs/hr_timesheet_computation_item/` (6 tour).

- `static/tests/tours/hr_timesheet_tour.js` — 11 tour: create, edit, delete, confirm,
  approve, reject, start, cancel, restart, reset-number, restart-approval.
- `static/tests/tours/hr_timesheet_computation_item_tour.js` — 6 tour: create, edit,
  delete, deactivate, activate, reset-code.
- `tests/test_ui_hr_timesheet.py` dan `tests/test_ui_hr_timesheet_computation_item.py`
  — `HttpSavepointCase` yang menyiapkan Pre-Condition tiap tour di `setUpClass` lalu
  menjalankannya lewat `start_tour`.
- `views/ssi_timesheet_assets.xml` — registrasi kedua berkas tour ke bundle
  `web.assets_tests`.
- `__manifest__.py` — tambah dependensi `web_tour`.

Tour hanya menguji bentuk (menu, view, tombol, dialog, state statusbar) — bukan nilai
hasil hitungan; itu tetap wilayah unit test yang sudah ada.

Closes #151

## Test plan

- [ ] CI GitHub hijau (pre-commit + unit test + tour)