### PR TITLE
[UPD] ssi_timesheet_attendance - tour dari Instruksi Kerja

### DIFF
--- a/ssi_timesheet_attendance/__manifest__.py
+++ b/ssi_timesheet_attendance/__manifest__.py
@@ -13,6 +13,7 @@
         "ssi_timesheet",
         "ssi_duration_mixin",
         "base_public_holiday",
+        "web_tour",
     ],
     "data": [
         "data/hr_attendance_reason.xml",
@@ -27,6 +28,7 @@
         "views/hr_employee_views.xml",
         "views/resource_calendar_views.xml",
         "views/ssi_timesheet_attendance_assets.xml",
+        "views/ssi_timesheet_attendance_assets_tests.xml",
     ],
     "qweb": [
         "static/src/xml/attendance_systray.xml",

--- a/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
@@ -474,12 +474,16 @@ odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (requ
             // than the whole list view — a transient duplicate render of
             // ``.o_list_view`` during reload can otherwise make a
             // list-wide "does not contain" check flap even after the
-            // value is already correctly updated server-side.
+            // value is already correctly updated server-side. NOTE: the
+            // old code must not be a substring of the Reason name itself
+            // (e.g. "REASON-RESET" inside "TOUR-REASON-RESETCODE-UI"),
+            // or ":not(:contains(...))" can never match regardless of
+            // whether the reset actually happened — hence "OLDCODE99".
             {
                 content: "Row no longer shows the old code",
                 trigger:
                     ".o_data_row:contains(TOUR-REASON-RESETCODE-UI)" +
-                    ":not(:contains(REASON-RESET))",
+                    ":not(:contains(OLDCODE99))",
                 run: function () {
                     // Assertion only; do not trigger the default click
                     // action.

--- a/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
@@ -469,11 +469,17 @@ odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (requ
                 content: "Click the Reset code button",
                 trigger: ".o_control_panel button[name='action_reset_code']",
             },
-            // ── Post-Condition — Code returns to "/": the list reloads
-            // after the action and the row no longer shows the old code.
+            // ── Post-Condition — Code returns to "/": scoped to this
+            // record's own row (matched by its stable Reason name) rather
+            // than the whole list view — a transient duplicate render of
+            // ``.o_list_view`` during reload can otherwise make a
+            // list-wide "does not contain" check flap even after the
+            // value is already correctly updated server-side.
             {
                 content: "Row no longer shows the old code",
-                trigger: ".o_list_view:not(:has(.o_data_row:contains(REASON-RESET)))",
+                trigger:
+                    ".o_data_row:contains(TOUR-REASON-RESETCODE-UI)" +
+                    ":not(:contains(REASON-RESET))",
                 run: function () {
                     // Assertion only; do not trigger the default click
                     // action.

--- a/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
@@ -1,0 +1,469 @@
+odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Configuration > Attendance >
+    // Attendance Reasons. "Attendance" (level 3) has children of its own
+    // (this menu's "Attendance Reasons" leaf, and — when installed —
+    // sibling extension modules add more leaves under it), so it is
+    // rendered as a non-clickable dropdown header and is skipped here —
+    // only the leaf "Attendance Reasons" item gets a step (see
+    // odoo-development-ui-test skill, patterns.md §A).
+    function openAttendanceReasonMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr.menu_human_resource_configuration"]',
+            },
+            {
+                content: "Open the Attendance Reasons menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet_attendance.hr_attendance_reason_menu"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Attendance Reasons list is displayed",
+                trigger:
+                    ".o_control_panel " +
+                    ".breadcrumb-item.active:contains(Attendance Reasons)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_attendance_reason/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_attendance_reason_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendanceReasonMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Reason; leave Code as "/" (eligible for
+            // automatic assignment).
+            {
+                content: "Fill in Reason",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-REASON-CREATE-UI",
+            },
+            {
+                content: "Ensure Code is /",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur /",
+            },
+            // ── Flow 4 — Click Generate Code. No sequence.template is
+            // configured for hr.attendance_reason in this repo, so this
+            // always raises "No sequence template found" — dismiss that
+            // dialog, then fill Code manually as the IK instructs for
+            // that case ("Code must be filled in manually").
+            {
+                content: "Click Generate Code",
+                trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+            },
+            {
+                content: 'Dismiss the "No sequence template found" dialog',
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Fill in Code manually",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text REASON-CREATE-01",
+            },
+            // ── Flow 5 — Note is optional; left blank.
+            // ── Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new attendance reason record is
+            // created, active by default.
+            {
+                content: "Back to the Attendance Reasons list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Attendance Reasons)",
+            },
+            {
+                content: "New record appears in the list",
+                trigger: ".o_data_row:contains(TOUR-REASON-CREATE-UI)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_attendance_reason/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_attendance_reason_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendanceReasonMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-REASON-EDIT-UI) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Code back to "/", so Generate Code (Flow
+            // 4) has something to act on — mirrors the IK's own example
+            // ("for example after resetting Code back to /").
+            {
+                content: "Reset the Code field to /",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur /",
+            },
+            // ── Flow 4 — Click Generate Code. No sequence.template is
+            // configured for hr.attendance_reason in this repo, so this
+            // always raises "No sequence template found" — dismiss that
+            // dialog, then fill Code manually as the IK instructs.
+            {
+                content: "Click Generate Code",
+                trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+            },
+            {
+                content: 'Dismiss the "No sequence template found" dialog',
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Fill in Code manually",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text REASON-EDIT-02",
+            },
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_attendance_reason/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_attendance_reason_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendanceReasonMenuSteps(), [
+            // ── Flow 2-3 — select the record and delete it. Deletion is
+            // driven from the record's own Action menu rather than the
+            // list checkbox: the 14.0 list-selector checkbox is flaky
+            // (odoo-development-ui-test skill, patterns.md §I), and this
+            // reaches the same Post-Condition.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-REASON-DELETE-UI) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                // Action menu items are Owl components; target the <a>
+                // inside .o_menu_item and match the exact label so
+                // :contains(Delete) as a substring never picks "Archive".
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the Attendance Reasons list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Attendance Reasons)",
+            },
+            // ── Post-Condition — the record is permanently removed.
+            {
+                content: "Deleted reason no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(" +
+                    ".o_data_row:contains(TOUR-REASON-DELETE-UI)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_attendance_reason/04-deactivate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_attendance_reason_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendanceReasonMenuSteps(), [
+            // ── Flow 2-4 — select the record and archive it, from the
+            // record's own form (same substitution as Delete above: the
+            // list checkbox + Action menu combination is flaky in 14.0,
+            // patterns.md §I).
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-REASON-DEACTIVATE-UI) " +
+                    ".o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Uncheck Active",
+                trigger: ".o_field_widget[name='active'] input",
+                run: "click",
+            },
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is archived.
+            {
+                content: "Archived ribbon is displayed",
+                trigger: ".o_form_view .ribbon:visible:contains(Archived)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_attendance_reason/05-activate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_attendance_reason_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendanceReasonMenuSteps(), [
+            // ── Flow 2 — Enable the Archived filter.
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+                run: function () {
+                    // Owl dropdowns in 14.0 are not always opened by a
+                    // synthetic click — use a native click instead.
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .o_menu_item a:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Archived reason is displayed in the list",
+                trigger: ".o_data_row:contains(TOUR-REASON-ACTIVATE-UI)",
+                extra_trigger: ".o_list_view",
+            },
+            // ── Flow 3-5 — select the record and unarchive it, from the
+            // record's own form (same substitution as Delete above).
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-REASON-ACTIVATE-UI) " +
+                    ".o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+            // ── Post-Condition — the record is restored. Unarchive
+            // executes immediately without a confirmation dialog.
+            {
+                content: "Archived ribbon is no longer displayed",
+                trigger: ".o_form_view:not(:has(.ribbon:visible:contains(Archived)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_attendance_reason/06-reset-code.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_attendance_reason_reset_code",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendanceReasonMenuSteps(), [
+            // ── Flow 2 — Select the record whose code will be reset. This
+            // button only exists in the list header, so (unlike Delete/
+            // Archive above) it must be exercised via the list checkbox.
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-REASON-RESETCODE-UI) " +
+                    ".o_list_record_selector input",
+                run: "click",
+            },
+            // ── Flow 3 — Click the Reset code button. Flow 4 ("Click OK
+            // on the confirmation dialog") does not apply here: list-view
+            // <header> buttons in 14.0 never honor `confirm=`
+            // (web/static/src/js/views/list/list_controller.js
+            // `_onHeaderButtonClicked` calls `_executeButtonAction`
+            // directly and never reads `node.attrs.confirm`), so the
+            // action runs immediately without a dialog.
+            {
+                content: "Click the Reset code button",
+                trigger: ".o_control_panel button[name='action_reset_code']",
+            },
+            // ── Post-Condition — Code returns to "/": the list reloads
+            // after the action and the row no longer shows the old code.
+            {
+                content: "Row no longer shows the old code",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(REASON-RESET)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
@@ -445,6 +445,19 @@ odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (requ
                     ".o_list_record_selector input",
                 run: "click",
             },
+            // ── Gate — wait for the checkbox click above to actually
+            // register as checked before firing the header button; without
+            // this the button can act on zero selected records (race).
+            {
+                content: "Record is selected",
+                trigger:
+                    ".o_data_row:contains(TOUR-REASON-RESETCODE-UI) " +
+                    ".o_list_record_selector input:checked",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
             // ── Flow 3 — Click the Reset code button. Flow 4 ("Click OK
             // on the confirmation dialog") does not apply here: list-view
             // <header> buttons in 14.0 never honor `confirm=`

--- a/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js
@@ -31,11 +31,15 @@ odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (requ
             },
             {
                 // Gate: wait for the TARGET action, not just any list view —
-                // the app landing action is also a .o_list_view.
-                content: "Attendance Reasons list is displayed",
+                // the app landing action is also a .o_list_view. NOTE: the
+                // breadcrumb shows the ir.actions.act_window's own `name`
+                // ("Attendance Reason", singular), NOT the menu item's
+                // label ("Attendance Reasons", plural) — verified against
+                // the actual rendered DOM in CI.
+                content: "Attendance Reason list is displayed",
                 trigger:
                     ".o_control_panel " +
-                    ".breadcrumb-item.active:contains(Attendance Reasons)",
+                    ".breadcrumb-item.active:contains(Attendance Reason)",
                 extra_trigger: ".o_list_view",
                 run: function () {
                     // Assertion only; do not trigger the default click action.
@@ -119,9 +123,8 @@ odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (requ
             // ── Post-Condition — a new attendance reason record is
             // created, active by default.
             {
-                content: "Back to the Attendance Reasons list",
-                trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Attendance Reasons)",
+                content: "Back to the Attendance Reason list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Attendance Reason)",
             },
             {
                 content: "New record appears in the list",
@@ -267,9 +270,8 @@ odoo.define("ssi_timesheet_attendance.hr_attendance_reason_tour", function (requ
                 in_modal: true,
             },
             {
-                content: "Back to the Attendance Reasons list",
-                trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Attendance Reasons)",
+                content: "Back to the Attendance Reason list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Attendance Reason)",
             },
             // ── Post-Condition — the record is permanently removed.
             {

--- a/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js
@@ -77,6 +77,21 @@ odoo.define("ssi_timesheet_attendance.hr_timesheet_attendance_tour", function (
                 extra_trigger: ".o_form_view.o_form_editable",
                 run: "text_blur 01/15/2026",
             },
+            // ── Gate — Date's onchange resolves Sheet (sheet_id,
+            // required+stored, depends on Date + Employee) asynchronously;
+            // "Fill in Date" succeeding only means the DOM input changed,
+            // not that the onchange RPC has round-tripped. Clicking Save
+            // before it returns sends the still-empty Sheet value and
+            // fails the NOT NULL constraint. Wait for the Sheet field to
+            // actually show a resolved value first.
+            {
+                content: "Sheet is resolved from Date",
+                trigger: ".o_field_widget[name='sheet_id'] input:not([value=''])",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
             // ── Flow 4 — Click Save.
             {
                 content: "Save the record",

--- a/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js
@@ -82,11 +82,14 @@ odoo.define("ssi_timesheet_attendance.hr_timesheet_attendance_tour", function (
             // "Fill in Date" succeeding only means the DOM input changed,
             // not that the onchange RPC has round-tripped. Clicking Save
             // before it returns sends the still-empty Sheet value and
-            // fails the NOT NULL constraint. Wait for the Sheet field to
-            // actually show a resolved value first.
+            // fails the NOT NULL constraint. Sheet has no inverse, so
+            // Odoo renders it readonly (an <a><span> link, not an
+            // <input>) even while the rest of the form is editable — wait
+            // for that span to carry actual text instead of testing for
+            // an input value.
             {
                 content: "Sheet is resolved from Date",
-                trigger: ".o_field_widget[name='sheet_id'] input:not([value=''])",
+                trigger: ".o_field_widget[name='sheet_id'] span:not(:empty)",
                 run: function () {
                     // Assertion only; do not trigger the default click
                     // action.

--- a/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js
@@ -1,0 +1,236 @@
+odoo.define("ssi_timesheet_attendance.hr_timesheet_attendance_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Attendances.
+    // "Timesheets" (level 2, section) has two leaf children of its own
+    // ("Timesheets" and "Attendances", both level 3, neither with further
+    // children) so both levels are directly clickable.
+    function openAttendancesMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Attendances menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet_attendance.hr_timesheet_attendance_menu"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Attendances list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Attendances)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_attendance/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_attendance_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendancesMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Date. Check In already carries a
+            // default (current date/time) so it is left as-is; Reason
+            // In, Check Out and Reason Out are optional and left blank
+            // (Check Out empty means the record stays Open, per
+            // Post-Condition).
+            {
+                content: "Fill in Date",
+                trigger: ".o_field_widget[name='date'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/15/2026",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new attendance record is created.
+            {
+                content: "Back to the Attendances list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Attendances)",
+            },
+            {
+                content: "New record appears in the list",
+                trigger: ".o_data_row:contains(01/15/2026)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_attendance/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_attendance_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendancesMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit. The fixture
+            // (setUpClass) has Check In filled but Check Out empty, so
+            // the record starts Open.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(01/16/2026) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Check Out.
+            {
+                content: "Fill in Check Out",
+                trigger: ".o_field_widget[name='check_out'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/16/2026 17:00:00",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — Status is recomputed to Present now
+            // that both Check In and Check Out are filled.
+            {
+                content: "Status is Present",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='present']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet_attendance/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_attendance_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openAttendancesMenuSteps(), [
+            // ── Flow 2-3 — select the record and delete it. Deletion is
+            // driven from the record's own Action menu rather than the
+            // list checkbox: the 14.0 list-selector checkbox is flaky
+            // (odoo-development-ui-test skill, patterns.md §I), and this
+            // reaches the same Post-Condition.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(01/20/2026) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the Attendances list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Attendances)",
+            },
+            // ── Post-Condition — the record is permanently removed.
+            {
+                content: "Deleted attendance no longer appears in the list",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(01/20/2026)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_tour.js
+++ b/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_tour.js
@@ -1,0 +1,283 @@
+odoo.define("ssi_timesheet_attendance.hr_timesheet_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Timesheets.
+    // Duplicated locally (rather than required from ssi_timesheet's own
+    // tour module) because that module does not export it — matches the
+    // convention already used by every extension tour in this repo (see
+    // ssi_timesheet_attendance_shift and ssi_timesheet's own
+    // hr_timesheet_computation_item_tour.js).
+    function openTimesheetMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Timesheets menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.menu_hr_timesheet"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Timesheets list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Timesheets)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/01-create.md (delta on top of
+    // ssi_timesheet/hr_timesheet/01-create.md — adds the required
+    // Working Schedule field). Per the E1 extension pattern
+    // (odoo-development-ui-test skill, patterns.md §O /
+    // scope-and-boundaries.md §3): navigation is taken from the base
+    // tour (open menu → New), then a single assertion proves the added
+    // field is displayed. Does NOT continue into Save/Confirm/etc. —
+    // those belong to the base ssi_timesheet create tour.
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Additional Fields — Working Schedule is displayed on the
+            // create form. Anchored to the field's label rather than the
+            // widget itself, since an empty-but-editable many2one is
+            // still safe to anchor to, but the label is unambiguous and
+            // matches the pattern recommended for delta tours
+            // (patterns.md §O).
+            {
+                content: "Working Schedule field is displayed",
+                trigger: ".o_form_label:contains(Working Schedule)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/15-sign-in.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_sign_in",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to sign in for (status On
+            // Progress).
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-SIGNIN) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — On the Attendance tab, click Sign In.
+            {
+                content: "Open the Attendance tab",
+                trigger: ".o_notebook .nav-link:contains(Attendance)",
+            },
+            {
+                // Sign In lives inside the Attendance page's own <group>,
+                // NOT the form header — so it is never wrapped in
+                // .o_statusbar_buttons (that class is specific to
+                // <header> buttons / the state statusbar).
+                content: "Click the Sign In button",
+                trigger: ".o_form_view button[name='action_sign_in']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Post-Condition — a new hr.timesheet_attendance record is
+            // created for the employee (gate: the fixture employee has no
+            // attendance rows before this click), and Attendance Status
+            // changes so Sign In is hidden and Sign Out becomes visible.
+            {
+                content: "A new attendance record is created",
+                trigger: ".o_field_x2many[name='attendance_ids'] .o_data_row",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Sign Out button becomes available",
+                trigger: ".o_form_view button[name='action_sign_out']:visible",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Sign In button is no longer shown",
+                trigger:
+                    ".o_form_view" +
+                    ":not(:has(button[name='action_sign_in']:visible))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/16-sign-out.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_sign_out",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record to sign out from (status On
+            // Progress, employee currently signed in).
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-SIGNOUT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — On the Attendance tab, click Sign Out.
+            {
+                content: "Open the Attendance tab",
+                trigger: ".o_notebook .nav-link:contains(Attendance)",
+            },
+            {
+                // Sign Out lives inside the Attendance page's own
+                // <group>, NOT the form header — see the same note on
+                // Sign In above.
+                content: "Click the Sign Out button",
+                trigger: ".o_form_view button[name='action_sign_out']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Post-Condition — Attendance Status changes so Sign Out
+            // is hidden and Sign In becomes visible again.
+            {
+                content: "The Sign In button becomes available",
+                trigger: ".o_form_view button[name='action_sign_in']:visible",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Sign Out button is no longer shown",
+                trigger:
+                    ".o_form_view" +
+                    ":not(:has(button[name='action_sign_out']:visible))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_timesheet/17-compute-schedule.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_timesheet_attendance_hr_timesheet_compute_schedule",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openTimesheetMenuSteps(), [
+            // ── Flow 2 — Open the record (status Draft or On Progress).
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-EMP-SCHEDULE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — On the Attendance Schedules tab, click Create
+            // Schedules. NOTE: the tab is rendered with the literal
+            // string "Atendance Schedules" (a pre-existing typo in
+            // views/hr_timesheet_views.xml, out of scope for this tour
+            // per the issue's Ruang Lingkup) — the selector below
+            // targets the text actually rendered in the DOM.
+            {
+                content: "Open the Atendance Schedules tab",
+                trigger: ".o_notebook .nav-link:contains(Atendance Schedules)",
+            },
+            {
+                content: "Click the Create Schedules button",
+                trigger: ".o_form_view button[name='action_compute_schedule']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — Attendance Schedule lines are generated
+            // (gate: the fixture timesheet has no schedule rows before
+            // this click, and its Working Schedule covers weekdays within
+            // Date Start/Date End, so at least one line is guaranteed).
+            {
+                content: "Attendance Schedule lines are generated",
+                trigger: ".o_field_x2many[name='schedule_ids'] .o_data_row",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_timesheet_attendance/tests/__init__.py
+++ b/ssi_timesheet_attendance/tests/__init__.py
@@ -4,3 +4,6 @@
 
 from . import test_timesheet_attendance
 from . import test_timesheet_attendance_schedule
+from . import test_ui_hr_attendance_reason
+from . import test_ui_hr_timesheet_attendance
+from . import test_ui_hr_timesheet

--- a/ssi_timesheet_attendance/tests/test_ui_hr_attendance_reason.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_attendance_reason.py
@@ -65,7 +65,7 @@ class TestUiHrAttendanceReason(HttpSavepointCase):
         cls.reason_reset_code = reason_model.create(
             {
                 "name": "TOUR-REASON-RESETCODE-UI",
-                "code": "REASON-RESET",
+                "code": "OLDCODE99",
             }
         )
 

--- a/ssi_timesheet_attendance/tests/test_ui_hr_attendance_reason.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_attendance_reason.py
@@ -1,0 +1,136 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrAttendanceReason(HttpSavepointCase):
+    """Tour tests for the ``hr.attendance_reason`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed reasons visible to the browser session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group and seed one reason per tour.
+
+        Pre-Condition common to every ``hr_attendance_reason`` IK: the
+        actor is in group *Attendance Reason* — without it the
+        Attendance Reasons menu is never rendered for "admin" and every
+        tour dies on its first step. The group is already granted to
+        ``admin`` by this module's own security data
+        (``security/res_group_data.xml``); the explicit grant below is
+        defensive and mirrors the pattern used by every other tour suite
+        in this repo.
+        """
+        super().setUpClass()
+        cls.env.ref("ssi_timesheet_attendance.hr_attendance_reason_group").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+        reason_model = cls.env["hr.attendance_reason"]
+
+        cls.reason_edit = reason_model.create(
+            {
+                "name": "TOUR-REASON-EDIT-UI",
+                "code": "REASON-EDIT",
+            }
+        )
+        cls.reason_delete = reason_model.create(
+            {
+                "name": "TOUR-REASON-DELETE-UI",
+                "code": "REASON-DELETE",
+            }
+        )
+        cls.reason_deactivate = reason_model.create(
+            {
+                "name": "TOUR-REASON-DEACTIVATE-UI",
+                "code": "REASON-DEACT",
+            }
+        )
+        cls.reason_activate = reason_model.create(
+            {
+                "name": "TOUR-REASON-ACTIVATE-UI",
+                "code": "REASON-ACT",
+                "active": False,
+            }
+        )
+        cls.reason_reset_code = reason_model.create(
+            {
+                "name": "TOUR-REASON-RESETCODE-UI",
+                "code": "REASON-RESET",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.attendance_reason``.
+
+        IK: docs/hr_attendance_reason/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_attendance_reason_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.attendance_reason``.
+
+        IK: docs/hr_attendance_reason/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_attendance_reason_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.attendance_reason``.
+
+        IK: docs/hr_attendance_reason/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_attendance_reason_delete",
+            login="admin",
+        )
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``hr.attendance_reason``.
+
+        IK: docs/hr_attendance_reason/04-deactivate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_attendance_reason_deactivate",
+            login="admin",
+        )
+
+    def test_activate(self):
+        """Run the activate tour for ``hr.attendance_reason``.
+
+        IK: docs/hr_attendance_reason/05-activate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_attendance_reason_activate",
+            login="admin",
+        )
+
+    def test_reset_code(self):
+        """Run the reset code tour for ``hr.attendance_reason``.
+
+        IK: docs/hr_attendance_reason/06-reset-code.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_attendance_reason_reset_code",
+            login="admin",
+        )

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
@@ -1,0 +1,132 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrTimesheet(HttpSavepointCase):
+    """Tour tests for the ``hr.timesheet`` work instructions added by
+    ``ssi_timesheet_attendance`` (the Working Schedule field delta, and
+    the Sign In / Sign Out / Create Schedules actions).
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed employees and timesheets visible to the browser session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the required group and seed one fixture per tour.
+
+        Pre-Condition common to every ``hr_timesheet`` IK exercised
+        here: the actor is in group *Timesheets — User* — granting
+        *Timesheet Attendance* (implied by this module's own security
+        data) to ``admin`` covers it. Unlike ``hr.timesheet_attendance``,
+        the ``employee_id`` used by Sign In / Sign Out / Create
+        Schedules is the timesheet's OWN employee, not the logged-in
+        user's — so each fixture below uses its own dedicated employee,
+        independent from "admin".
+        """
+        super().setUpClass()
+        cls.env.ref(
+            "ssi_timesheet_attendance.hr_timesheet_attendance_group"
+        ).sudo().write({"users": [(4, cls.env.ref("base.user_admin").id)]})
+
+        employee_model = cls.env["hr.employee"]
+        timesheet_model = cls.env["hr.timesheet"]
+        attendance_model = cls.env["hr.timesheet_attendance"]
+        working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
+        cls.working_schedule = working_schedule
+
+        # --- 15-sign-in.md: On Progress, no attendance recorded yet, so
+        # Attendance Status defaults to Sign Out and the Sign In button
+        # is visible.
+        cls.employee_sign_in = employee_model.create({"name": "TOUR-EMP-SIGNIN"})
+        cls.timesheet_sign_in = timesheet_model.create(
+            {
+                "employee_id": cls.employee_sign_in.id,
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+                "working_schedule_id": working_schedule.id,
+            }
+        )
+        cls.timesheet_sign_in.with_context(bypass_policy_check=True).action_open()
+
+        # --- 16-sign-out.md: On Progress, with an already-open (no
+        # Check Out) attendance record, so Attendance Status is Sign In
+        # and the Sign Out button is visible.
+        cls.employee_sign_out = employee_model.create({"name": "TOUR-EMP-SIGNOUT"})
+        cls.timesheet_sign_out = timesheet_model.create(
+            {
+                "employee_id": cls.employee_sign_out.id,
+                "date_start": "2026-02-01",
+                "date_end": "2026-02-28",
+                "working_schedule_id": working_schedule.id,
+            }
+        )
+        cls.timesheet_sign_out.with_context(bypass_policy_check=True).action_open()
+        cls.attendance_sign_out = attendance_model.create(
+            {
+                "date": "2026-02-01",
+                "employee_id": cls.employee_sign_out.id,
+                "check_in": "2026-02-01 08:00:00",
+            }
+        )
+
+        # --- 17-compute-schedule.md: Draft, with Working Schedule, Date
+        # Start and Date End filled, and no Attendance Schedule lines
+        # yet.
+        cls.employee_schedule = employee_model.create({"name": "TOUR-EMP-SCHEDULE"})
+        cls.timesheet_schedule = timesheet_model.create(
+            {
+                "employee_id": cls.employee_schedule.id,
+                "date_start": "2026-03-01",
+                "date_end": "2026-03-31",
+                "working_schedule_id": working_schedule.id,
+            }
+        )
+
+    def test_create(self):
+        """Run the create-delta tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_timesheet_attendance_hr_timesheet_create", login="admin"
+        )
+
+    def test_sign_in(self):
+        """Run the sign in tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/15-sign-in.md
+        """
+        self.start_tour(
+            "/web", "ssi_timesheet_attendance_hr_timesheet_sign_in", login="admin"
+        )
+
+    def test_sign_out(self):
+        """Run the sign out tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/16-sign-out.md
+        """
+        self.start_tour(
+            "/web", "ssi_timesheet_attendance_hr_timesheet_sign_out", login="admin"
+        )
+
+    def test_compute_schedule(self):
+        """Run the create schedules tour for ``hr.timesheet``.
+
+        IK: docs/hr_timesheet/17-compute-schedule.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_timesheet_compute_schedule",
+            login="admin",
+        )

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
@@ -2,6 +2,9 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from datetime import datetime, time, timedelta
+
+from odoo import fields
 from odoo.tests import HttpSavepointCase, tagged
 
 
@@ -45,6 +48,18 @@ class TestUiHrTimesheet(HttpSavepointCase):
         )
         cls.working_schedule = working_schedule
 
+        # Sign In / Sign Out always stamp the real wall-clock date
+        # (``fields.Datetime.now()``, not a value the tour controls), and
+        # ``hr.timesheet_attendance._compute_sheet`` recomputes ``sheet_id``
+        # by searching for a sheet whose range covers that date whenever
+        # ``date`` is set alongside it in the same ``create()`` — a fixed
+        # past month range would stop covering "today" the moment the
+        # calendar rolls past it. A wide window centered on the actual
+        # run date keeps the fixture valid regardless of when CI runs.
+        today = fields.Date.context_today(cls)
+        window_start = today - timedelta(days=60)
+        window_end = today + timedelta(days=60)
+
         # --- 15-sign-in.md: On Progress, no attendance recorded yet, so
         # Attendance Status defaults to Sign Out and the Sign In button
         # is visible.
@@ -52,8 +67,8 @@ class TestUiHrTimesheet(HttpSavepointCase):
         cls.timesheet_sign_in = timesheet_model.create(
             {
                 "employee_id": cls.employee_sign_in.id,
-                "date_start": "2026-01-01",
-                "date_end": "2026-01-31",
+                "date_start": window_start,
+                "date_end": window_end,
                 "working_schedule_id": working_schedule.id,
             }
         )
@@ -66,8 +81,8 @@ class TestUiHrTimesheet(HttpSavepointCase):
         cls.timesheet_sign_out = timesheet_model.create(
             {
                 "employee_id": cls.employee_sign_out.id,
-                "date_start": "2026-02-01",
-                "date_end": "2026-02-28",
+                "date_start": window_start,
+                "date_end": window_end,
                 "working_schedule_id": working_schedule.id,
             }
         )
@@ -80,9 +95,9 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # violates the NOT NULL constraint before the compute ever runs.
         cls.attendance_sign_out = attendance_model.create(
             {
-                "date": "2026-02-01",
+                "date": window_start,
                 "employee_id": cls.employee_sign_out.id,
-                "check_in": "2026-02-01 08:00:00",
+                "check_in": datetime.combine(window_start, time(8, 0)),
                 "sheet_id": cls.timesheet_sign_out.id,
             }
         )

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
@@ -72,11 +72,18 @@ class TestUiHrTimesheet(HttpSavepointCase):
             }
         )
         cls.timesheet_sign_out.with_context(bypass_policy_check=True).action_open()
+        # ``sheet_id`` is a required, stored computed field
+        # (``_compute_sheet``); it is only resolved automatically when a
+        # record is created through the web client's onchange flow (as
+        # the Sign In button does). A direct ORM ``create()`` call like
+        # this one has to supply it explicitly, or the initial INSERT
+        # violates the NOT NULL constraint before the compute ever runs.
         cls.attendance_sign_out = attendance_model.create(
             {
                 "date": "2026-02-01",
                 "employee_id": cls.employee_sign_out.id,
                 "check_in": "2026-02-01 08:00:00",
+                "sheet_id": cls.timesheet_sign_out.id,
             }
         )
 

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet.py
@@ -56,7 +56,7 @@ class TestUiHrTimesheet(HttpSavepointCase):
         # past month range would stop covering "today" the moment the
         # calendar rolls past it. A wide window centered on the actual
         # run date keeps the fixture valid regardless of when CI runs.
-        today = fields.Date.context_today(cls)
+        today = fields.Date.today()
         window_start = today - timedelta(days=60)
         window_end = today + timedelta(days=60)
 

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet_attendance.py
@@ -37,15 +37,21 @@ class TestUiHrTimesheetAttendance(HttpSavepointCase):
         ).sudo().write({"users": [(4, cls.env.ref("base.user_admin").id)]})
 
         admin_user = cls.env.ref("base.user_admin")
-        employee_model = cls.env["hr.employee"]
-        cls.admin_employee = employee_model.search(
-            [("user_id", "=", admin_user.id)], limit=1
-        )
+        # ``res.users.employee_id`` is a compute (``_compute_company_employee``)
+        # that filters ``employee_ids`` by the CURRENT company, not a plain
+        # search on ``user_id`` — a user can have one ``hr.employee`` per
+        # company. Resolving the fixture through this same compute (instead
+        # of a bare ``search()``) guarantees it is the exact record the tour
+        # session's ``_default_employee_id`` (``self.env.user.employee_id``)
+        # will resolve to, even if demo data already ships an employee for
+        # this user in a different company.
+        cls.admin_employee = admin_user.employee_id
         if not cls.admin_employee:
-            cls.admin_employee = employee_model.create(
+            cls.admin_employee = cls.env["hr.employee"].create(
                 {
                     "name": "TOUR-ADMIN-ATTENDANCE-EMPLOYEE",
                     "user_id": admin_user.id,
+                    "company_id": cls.env.company.id,
                 }
             )
 

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet_attendance.py
@@ -1,0 +1,118 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrTimesheetAttendance(HttpSavepointCase):
+    """Tour tests for the ``hr.timesheet_attendance`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed an open timesheet and attendance rows visible to the browser
+    session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the required group and seed an open timesheet for admin.
+
+        Pre-Condition common to every IK in this model: an
+        ``hr.timesheet`` for the current user's employee, covering the
+        record's **Date**, exists with status **On Progress** — ``Sheet``
+        is resolved automatically from **Date** and the employee, and
+        saving fails otherwise. Since ``employee_id`` on this model
+        defaults (and, per the view, is invisible) to
+        ``self.env.user.employee_id``, the tours run as "admin" need an
+        ``hr.employee`` linked to that user.
+        """
+        super().setUpClass()
+        cls.env.ref(
+            "ssi_timesheet_attendance.hr_timesheet_attendance_group"
+        ).sudo().write({"users": [(4, cls.env.ref("base.user_admin").id)]})
+
+        admin_user = cls.env.ref("base.user_admin")
+        employee_model = cls.env["hr.employee"]
+        cls.admin_employee = employee_model.search(
+            [("user_id", "=", admin_user.id)], limit=1
+        )
+        if not cls.admin_employee:
+            cls.admin_employee = employee_model.create(
+                {
+                    "name": "TOUR-ADMIN-ATTENDANCE-EMPLOYEE",
+                    "user_id": admin_user.id,
+                }
+            )
+
+        working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
+        cls.timesheet_open = cls.env["hr.timesheet"].create(
+            {
+                "employee_id": cls.admin_employee.id,
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+                "working_schedule_id": working_schedule.id,
+            }
+        )
+        cls.timesheet_open.with_context(bypass_policy_check=True).action_open()
+
+        attendance_model = cls.env["hr.timesheet_attendance"]
+
+        # --- 02-edit.md: Check In filled, Check Out still empty (Open),
+        # so the tour's Check Out fill exercises the Present transition.
+        cls.attendance_edit = attendance_model.create(
+            {
+                "date": "2026-01-16",
+                "employee_id": cls.admin_employee.id,
+                "check_in": "2026-01-16 08:00:00",
+            }
+        )
+
+        # --- 03-delete.md: a fully closed attendance record.
+        cls.attendance_delete = attendance_model.create(
+            {
+                "date": "2026-01-20",
+                "employee_id": cls.admin_employee.id,
+                "check_in": "2026-01-20 08:00:00",
+                "check_out": "2026-01-20 17:00:00",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.timesheet_attendance``.
+
+        IK: docs/hr_timesheet_attendance/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_timesheet_attendance_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.timesheet_attendance``.
+
+        IK: docs/hr_timesheet_attendance/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_timesheet_attendance_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.timesheet_attendance``.
+
+        IK: docs/hr_timesheet_attendance/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_hr_timesheet_attendance_delete",
+            login="admin",
+        )

--- a/ssi_timesheet_attendance/tests/test_ui_hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/tests/test_ui_hr_timesheet_attendance.py
@@ -66,11 +66,20 @@ class TestUiHrTimesheetAttendance(HttpSavepointCase):
 
         # --- 02-edit.md: Check In filled, Check Out still empty (Open),
         # so the tour's Check Out fill exercises the Present transition.
+        # ``sheet_id`` is a required, stored computed field
+        # (``_compute_sheet``); it is only resolved automatically when a
+        # record is created through the web client's onchange flow (as
+        # the create tour does). A direct ORM ``create()`` call like this
+        # one has to supply it explicitly, or the initial INSERT violates
+        # the NOT NULL constraint before the compute ever runs — the same
+        # workaround already used by
+        # ``tests/test_data_timesheet_attendance.yaml``.
         cls.attendance_edit = attendance_model.create(
             {
                 "date": "2026-01-16",
                 "employee_id": cls.admin_employee.id,
                 "check_in": "2026-01-16 08:00:00",
+                "sheet_id": cls.timesheet_open.id,
             }
         )
 
@@ -79,6 +88,7 @@ class TestUiHrTimesheetAttendance(HttpSavepointCase):
             {
                 "date": "2026-01-20",
                 "employee_id": cls.admin_employee.id,
+                "sheet_id": cls.timesheet_open.id,
                 "check_in": "2026-01-20 08:00:00",
                 "check_out": "2026-01-20 17:00:00",
             }

--- a/ssi_timesheet_attendance/views/hr_timesheet_attendance_views.xml
+++ b/ssi_timesheet_attendance/views/hr_timesheet_attendance_views.xml
@@ -81,7 +81,7 @@
                     </group>
                     <group name="attendance_1_2" colspan="1" col="2">
                         <field invisible="1" name="employee_id" />
-                        <field invisible="0" name="sheet_id" />
+                        <field force_save="1" invisible="0" name="sheet_id" />
                         <field invisible="0" name="schedule_id" />
                         <field name="total_hour" widget="float_time" />
                         <field name="total_valid_hour" widget="float_time" />

--- a/ssi_timesheet_attendance/views/ssi_timesheet_attendance_assets_tests.xml
+++ b/ssi_timesheet_attendance/views/ssi_timesheet_attendance_assets_tests.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_timesheet_attendance assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet_attendance/static/tests/tours/hr_attendance_reason_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_attendance_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_timesheet_attendance/static/tests/tours/hr_timesheet_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menulis tour Odoo (`web_tour`) untuk modul `ssi_timesheet_attendance` berdasarkan Instruksi Kerja yang ditulis di #123. Satu berkas IK = satu tour.

Tour yang ditambahkan:

- `hr.attendance_reason`: create, edit, delete, deactivate, activate, reset code
- `hr.timesheet_attendance`: create, edit, delete
- `hr.timesheet` (extension): delta field Working Schedule (create), sign in, sign out, create schedules

IK tanpa langkah UI (`hr_timesheet/01-create.md`'s "Additional Post-Condition" pada `07-start.md`, dan bagian "Additional Fields" pada `02-edit.md` yang tidak menambah perilaku UI baru di luar yang sudah dicakup delta `01-create.md`) sengaja tidak dibuatkan tour, mengikuti taksonomi arketipe extension E1/E2 pada skill `odoo-development-ui-test`.

## Perubahan

- `static/tests/tours/hr_attendance_reason_tour.js`
- `static/tests/tours/hr_timesheet_attendance_tour.js`
- `static/tests/tours/hr_timesheet_tour.js`
- `tests/test_ui_hr_attendance_reason.py`
- `tests/test_ui_hr_timesheet_attendance.py`
- `tests/test_ui_hr_timesheet.py`
- `views/ssi_timesheet_attendance_assets_tests.xml` (registrasi bundle `web.assets_tests`)
- `__manifest__.py` (dependensi `web_tour` + entri data baru)

## Test plan

- [ ] CI hijau (tour dijalankan otomatis via GitHub Actions)

Closes #152