### PR TITLE
[UPD] ssi_timesheet_attendance - perbaiki TypeError _sign_out saat attendance tanpa schedule_id

### DIFF
--- a/ssi_timesheet_attendance/models/hr_timesheet.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet.py
@@ -227,6 +227,22 @@ class HRTimesheet(models.Model):
         return value
 
     def _sign_out(self, reason=False):
+        """Close the employee's latest open attendance.
+
+        On a same-day check-out, the latest attendance is updated in
+        place. On a cross-day check-out, the gap against the
+        attendance's ``schedule_id`` is compared to
+        ``checkout_buffer``: past the buffer, a new anomaly
+        attendance is created instead of touching the old one. When
+        the latest attendance has no ``schedule_id`` (no working
+        schedule slot resolved for it), there is nothing to compare
+        it against, so this is treated outright as an anomaly.
+
+        :param reason: check-out reason to record on a same-day
+            update
+        :type reason: hr.attendance_reason recordset or False
+        :return: None
+        """
         self.ensure_one()
         Attendance = self.env["hr.timesheet_attendance"]
         latest_attendance_id = self.employee_id.latest_attendance_id
@@ -239,6 +255,9 @@ class HRTimesheet(models.Model):
 
             if latest_attendance_id.date != date_check_out:
                 schedule = latest_attendance_id.schedule_id
+                if not schedule:
+                    Attendance.create(self._prepare_attendance_data_uncommon())
+                    return
                 schedule_check_out = schedule.date_end
                 _check = (check_out - schedule_check_out).total_seconds() / 3600.0
                 company = self.env.company

--- a/ssi_timesheet_attendance/tests/__init__.py
+++ b/ssi_timesheet_attendance/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_timesheet_attendance
 from . import test_timesheet_attendance_schedule
+from . import test_timesheet_sign_out

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -149,15 +149,18 @@ scenarios:
         limit: 1
         order: "id asc"
 
-      - step: "Create timesheet for employee"
+      - step:
+          "Create timesheet for employee (must span today: the anomaly attendance
+          _sign_out() creates is dated today's real date, not the historical attendance
+          date below)"
         action: "create"
         model: "hr.timesheet"
         save_as: "timesheet"
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee.id"
-          date_start: 2024-01-01
-          date_end: 2024-01-31
+          date_start: "EVAL: (datetime.now() - timedelta(days=30)).date()"
+          date_end: "EVAL: (datetime.now() + timedelta(days=5)).date()"
           working_schedule_id: "REC: working_schedule.id"
 
       - step: "Open timesheet"
@@ -173,8 +176,10 @@ scenarios:
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee.id"
-          date: 2024-01-20
-          check_in: "2024-01-20 08:00:00"
+          date: "EVAL: (datetime.now() - timedelta(days=20)).date()"
+          check_in:
+            "EVAL: (datetime.now() - timedelta(days=20)).replace(hour=8, minute=0,
+            second=0, microsecond=0)"
           sheet_id: "REC: timesheet.id"
 
       - step: "Assert precondition: attendance has no schedule"
@@ -243,15 +248,18 @@ scenarios:
         limit: 1
         order: "id asc"
 
-      - step: "Create timesheet for employee"
+      - step:
+          "Create timesheet for employee (must span today: the anomaly attendance
+          _sign_out() creates is dated today's real date, not the historical attendance
+          date below)"
         action: "create"
         model: "hr.timesheet"
         save_as: "timesheet"
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee.id"
-          date_start: 2024-01-01
-          date_end: 2024-01-31
+          date_start: "EVAL: (datetime.now() - timedelta(days=30)).date()"
+          date_end: "EVAL: (datetime.now() + timedelta(days=5)).date()"
           working_schedule_id: "REC: working_schedule.id"
 
       - step: "Open timesheet"
@@ -267,8 +275,12 @@ scenarios:
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee.id"
-          date_start: "2024-01-20 08:00:00"
-          date_end: "2024-01-20 17:00:00"
+          date_start:
+            "EVAL: (datetime.now() - timedelta(days=20)).replace(hour=8, minute=0,
+            second=0, microsecond=0)"
+          date_end:
+            "EVAL: (datetime.now() - timedelta(days=20)).replace(hour=17, minute=0,
+            second=0, microsecond=0)"
 
       - step: "Create open attendance matching the schedule slot's date"
         action: "create"
@@ -277,8 +289,10 @@ scenarios:
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee.id"
-          date: 2024-01-20
-          check_in: "2024-01-20 08:00:00"
+          date: "EVAL: (datetime.now() - timedelta(days=20)).date()"
+          check_in:
+            "EVAL: (datetime.now() - timedelta(days=20)).replace(hour=8, minute=0,
+            second=0, microsecond=0)"
           sheet_id: "REC: timesheet.id"
 
       - step: "Assert precondition: attendance schedule is resolved"

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -131,3 +131,201 @@ scenarios:
           sheet_id:
             type: "value"
             operator: "is_truthy"
+
+  - name: "HR Timesheet - Sign Out Without Schedule Does Not Raise"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Sign Out No Schedule"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create open attendance without a matching schedule slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-20
+          check_in: "2024-01-20 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert precondition: attendance has no schedule"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          schedule_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Sign out (cross-day, no schedule to compare against)"
+        action: "call"
+        target: "timesheet"
+        method: "_sign_out"
+        as_user: "base.user_admin"
+
+      - step: "Verify an anomaly attendance was created for the employee"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["employee_id", "=", "REC: employee.id"]]
+        save_as: "all_attendances"
+        expect_count: 2
+
+      - step: "Get the newly created anomaly attendance"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["employee_id", "=", "REC: employee.id"]]
+        save_as: "anomaly_attendance"
+        limit: 1
+        order: "check_in desc"
+
+      - step: "Assert anomaly attendance is a new, closed record"
+        action: "assert"
+        target: "anomaly_attendance"
+        asserts:
+          id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REC: attendance.id"
+          check_out:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert original attendance was left untouched (still open)"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          check_out:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "HR Timesheet - Sign Out With Schedule Filled Keeps Buffer Behavior"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Sign Out With Schedule"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a schedule slot dated the same day as the attendance"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: "2024-01-20 08:00:00"
+          date_end: "2024-01-20 17:00:00"
+
+      - step: "Create open attendance matching the schedule slot's date"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2024-01-20
+          check_in: "2024-01-20 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert precondition: attendance schedule is resolved"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: schedule"
+
+      - step: "Sign out (cross-day, gap far exceeds checkout_buffer)"
+        action: "call"
+        target: "timesheet"
+        method: "_sign_out"
+        as_user: "base.user_admin"
+
+      - step: "Verify an anomaly attendance was still created"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["employee_id", "=", "REC: employee.id"]]
+        save_as: "all_attendances"
+        expect_count: 2
+
+      - step: "Get the newly created anomaly attendance"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["employee_id", "=", "REC: employee.id"]]
+        save_as: "anomaly_attendance"
+        limit: 1
+        order: "check_in desc"
+
+      - step: "Assert anomaly attendance is a new, closed record"
+        action: "assert"
+        target: "anomaly_attendance"
+        asserts:
+          id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REC: attendance.id"
+          check_out:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert original attendance was left untouched (still open)"
+        action: "assert"
+        target: "attendance"
+        asserts:
+          check_out:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_timesheet_attendance/tests/test_timesheet_sign_out.py
+++ b/ssi_timesheet_attendance/tests/test_timesheet_sign_out.py
@@ -5,17 +5,23 @@
 from freezegun import freeze_time
 
 from odoo.tests import tagged
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
 @tagged("post_install", "-at_install")
-class TestTimesheetSignOut(TransactionCase):
+class TestTimesheetSignOut(SavepointCase):
     """Test ``HRTimesheet._sign_out()``'s same-day check-out path.
 
     Pure Python — trigger P6 (L-16: the YAML evaluator cannot freeze
     time, and this scenario needs the attendance's ``date`` and the
     check-out date derived from the real clock to fall on the exact
     same calendar day, which is only reliable under a frozen clock).
+
+    Uses ``SavepointCase`` rather than plain ``TransactionCase``: in
+    14.0 ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``SavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the fixture below relies on.
     """
 
     @classmethod

--- a/ssi_timesheet_attendance/tests/test_timesheet_sign_out.py
+++ b/ssi_timesheet_attendance/tests/test_timesheet_sign_out.py
@@ -1,0 +1,70 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from freezegun import freeze_time
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestTimesheetSignOut(TransactionCase):
+    """Test ``HRTimesheet._sign_out()``'s same-day check-out path.
+
+    Pure Python — trigger P6 (L-16: the YAML evaluator cannot freeze
+    time, and this scenario needs the attendance's ``date`` and the
+    check-out date derived from the real clock to fall on the exact
+    same calendar day, which is only reliable under a frozen clock).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an employee with an open, same-day attendance.
+
+        :return: None
+        """
+        super().setUpClass()
+        cls.working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
+        cls.employee = cls.env["hr.employee"].create(
+            {"name": "Test Employee Sign Out Same Day"}
+        )
+        with freeze_time("2024-06-10 12:00:00"):
+            cls.timesheet = cls.env["hr.timesheet"].create(
+                {
+                    "employee_id": cls.employee.id,
+                    "date_start": "2024-06-01",
+                    "date_end": "2024-06-30",
+                    "working_schedule_id": cls.working_schedule.id,
+                }
+            )
+            cls.timesheet.action_open()
+            cls.attendance = cls.env["hr.timesheet_attendance"].create(
+                {
+                    "employee_id": cls.employee.id,
+                    "date": "2024-06-10",
+                    "check_in": "2024-06-10 08:00:00",
+                    "sheet_id": cls.timesheet.id,
+                }
+            )
+
+    @freeze_time("2024-06-10 17:00:00")
+    def test_sign_out_same_day_updates_existing_attendance(self):
+        """Same-day sign-out updates the open attendance in place.
+
+        Pure Python — trigger P6 (L-16: freezing time is required to
+        guarantee the check-out date equals the attendance date, the
+        condition that keeps ``_sign_out()`` out of the cross-day
+        branch this issue's fix touches). No new anomaly attendance
+        should be created and the existing one should be closed.
+        """
+        self.timesheet._sign_out()
+
+        attendances = self.env["hr.timesheet_attendance"].search(
+            [("employee_id", "=", self.employee.id)]
+        )
+        self.assertEqual(len(attendances), 1)
+        self.assertEqual(attendances.id, self.attendance.id)
+        self.assertTrue(attendances.check_out)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ odoo14-addon-ssi-decorator
 odoo14-addon-ssi-state-change-constrain-mixin
 odoo14-addon-base-public-holiday
 odoo14-addon-ssi-operating-unit-mixin
+freezegun


### PR DESCRIPTION
## Ringkasan

`_sign_out()` melempar `TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'bool'` saat attendance yang ditutup tidak punya `schedule_id` terisi (mis. tidak ada slot jadwal kerja yang cocok untuk karyawan pada tanggal itu) dan check-out terjadi di hari yang berbeda dari tanggal attendance.

Perbaikan: bila `schedule_id` kosong pada cabang lintas-hari, lewati perbandingan `checkout_buffer` sama sekali dan langsung perlakukan sebagai kasus anomali (buat attendance baru) — konsisten dengan semangat cabang lintas-hari yang sudah ada. Perilaku attendance dengan `schedule_id` terisi tidak berubah.

## Test

- Skenario YAML baru (`odoo-yaml-test`): schedule kosong (kasus bug) dan schedule terisi dengan gap melebihi `checkout_buffer` (regresi, perilaku tidak berubah).
- Test Python murni (`freeze_time`) untuk kasus sign-out di hari yang sama, memverifikasi jalur update langsung tetap tidak tersentuh.

Closes #186