### PR TITLE
[UPD] ssi_timesheet_attendance - perbaiki UserError _compute_sheet saat date kosong

### DIFF
--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -25,8 +25,19 @@ class HRTimesheetAttendance(models.Model):
 
     @api.depends("date")
     def _compute_sheet(self):
+        """Resolve the open ``hr.timesheet`` sheet covering ``date``.
+
+        :raises UserError: if ``date`` is set but no open sheet covers it.
+        """
         obj_sheet = self.env["hr.timesheet"]
         for record in self:
+            if not record.date:
+                # New/incomplete record: nothing to search for yet. Leave
+                # ``sheet_id`` empty instead of raising - the required
+                # constraint on ``sheet_id`` will block save until ``date``
+                # (and therefore ``sheet_id``) is filled in.
+                record.sheet_id = False
+                continue
             criteria = [
                 ("employee_id", "=", record.employee_id.id),
                 ("date_start", "<=", record.date),

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -364,15 +364,17 @@ scenarios:
         values:
           name: "Test Employee No Sheet"
 
-      - step: "Attempt to create attendance with Date but no open timesheet"
-        action: "create"
+      - step:
+          "Fill Date on the form with no open timesheet - raises Sheet Not FOUND on the
+          onchange, before any INSERT is attempted"
+        action: "form"
         model: "hr.timesheet_attendance"
         as_user: "base.user_admin"
         expect_error:
           type: "UserError"
           message_contains: "Sheet Not FOUND"
         values:
-          employee_id: "REC: employee_no_sheet.id"
+          employee_id: "REC: employee_no_sheet"
           date: 2024-02-01
           check_in: "2024-02-01 08:00:00"
 
@@ -411,21 +413,17 @@ scenarios:
         as_user: "base.user_admin"
 
       - step:
-          "Create attendance with Date covered by the open sheet, without explicitly
-          passing sheet_id"
-        action: "create"
+          "Fill the form with Date covered by the open sheet, without explicitly passing
+          sheet_id - the onchange resolves it before save"
+        action: "form"
         model: "hr.timesheet_attendance"
         save_as: "attendance_compute_sheet"
         as_user: "base.user_admin"
         values:
-          employee_id: "REC: employee_compute_sheet.id"
+          employee_id: "REC: employee_compute_sheet"
           date: 2024-03-15
           check_in: "2024-03-15 08:00:00"
           check_out: "2024-03-15 17:00:00"
-
-      - step: "Assert sheet_id resolved to the matching open timesheet"
-        action: "assert"
-        target: "attendance_compute_sheet"
         asserts:
           sheet_id:
             type: "m2o"

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -343,3 +343,90 @@ scenarios:
           check_out:
             type: "value"
             operator: "is_falsy"
+
+  - name: "HR Timesheet Attendance - Compute Sheet With Empty Date Does Not Raise"
+    steps:
+      - step: "Open a new attendance form without filling Date"
+        action: "form"
+        model: "hr.timesheet_attendance"
+        save: false
+        asserts:
+          sheet_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "HR Timesheet Attendance - Compute Sheet With Date But No Open Sheet Raises"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_no_sheet"
+        values:
+          name: "Test Employee No Sheet"
+
+      - step: "Attempt to create attendance with Date but no open timesheet"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+          message_contains: "Sheet Not FOUND"
+        values:
+          employee_id: "REC: employee_no_sheet.id"
+          date: 2024-02-01
+          check_in: "2024-02-01 08:00:00"
+
+  - name: "HR Timesheet Attendance - Compute Sheet Resolves Matching Sheet"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_compute_sheet"
+        values:
+          name: "Test Employee Compute Sheet"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_compute_sheet"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_compute_sheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_compute_sheet.id"
+          date_start: 2024-03-01
+          date_end: 2024-03-31
+          working_schedule_id: "REC: working_schedule_compute_sheet.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_compute_sheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step:
+          "Create attendance with Date covered by the open sheet, without explicitly
+          passing sheet_id"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_compute_sheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_compute_sheet.id"
+          date: 2024-03-15
+          check_in: "2024-03-15 08:00:00"
+          check_out: "2024-03-15 17:00:00"
+
+      - step: "Assert sheet_id resolved to the matching open timesheet"
+        action: "assert"
+        target: "attendance_compute_sheet"
+        asserts:
+          sheet_id:
+            type: "m2o"
+            expected: "REC: timesheet_compute_sheet"

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -395,10 +395,10 @@ scenarios:
         limit: 1
         order: "id asc"
 
-      - step: "Create timesheet for employee"
+      - step: "Create first open timesheet (March)"
         action: "create"
         model: "hr.timesheet"
-        save_as: "timesheet_compute_sheet"
+        save_as: "timesheet_march"
         as_user: "base.user_admin"
         values:
           employee_id: "REC: employee_compute_sheet.id"
@@ -406,25 +406,65 @@ scenarios:
           date_end: 2024-03-31
           working_schedule_id: "REC: working_schedule_compute_sheet.id"
 
-      - step: "Open timesheet"
+      - step: "Open March timesheet"
         action: "call"
-        target: "timesheet_compute_sheet"
+        target: "timesheet_march"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create second open timesheet (April)"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_april"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_compute_sheet.id"
+          date_start: 2024-04-01
+          date_end: 2024-04-30
+          working_schedule_id: "REC: working_schedule_compute_sheet.id"
+
+      - step: "Open April timesheet"
+        action: "call"
+        target: "timesheet_april"
         method: "action_open"
         as_user: "base.user_admin"
 
       - step:
-          "Fill the form with Date covered by the open sheet, without explicitly passing
-          sheet_id - the onchange resolves it before save"
-        action: "form"
+          "Create attendance dated in March; sheet_id passed explicitly so the initial
+          INSERT satisfies the NOT NULL constraint (Odoo only computes stored fields
+          AFTER insert, so a required stored compute field can never be left out of
+          create() values)"
+        action: "create"
         model: "hr.timesheet_attendance"
         save_as: "attendance_compute_sheet"
         as_user: "base.user_admin"
         values:
-          employee_id: "REC: employee_compute_sheet"
+          employee_id: "REC: employee_compute_sheet.id"
           date: 2024-03-15
           check_in: "2024-03-15 08:00:00"
-          check_out: "2024-03-15 17:00:00"
+          sheet_id: "REC: timesheet_march.id"
+
+      - step: "Assert precondition: sheet_id is the March sheet"
+        action: "assert"
+        target: "attendance_compute_sheet"
         asserts:
           sheet_id:
             type: "m2o"
-            expected: "REC: timesheet_compute_sheet"
+            expected: "REC: timesheet_march"
+
+      - step:
+          "Move the attendance Date into April without touching sheet_id - write() only
+          updates the given columns, so the recompute this triggers via
+          @api.depends('date') runs safely against the already-existing row"
+        action: "write"
+        target: "attendance_compute_sheet"
+        values:
+          date: 2024-04-15
+
+      - step: "Assert sheet_id was recomputed to the April sheet"
+        action: "assert"
+        target: "attendance_compute_sheet"
+        asserts:
+          sheet_id:
+            type: "m2o"
+            expected: "REC: timesheet_april"


### PR DESCRIPTION
## Ringkasan

`_compute_sheet()` pada model `hr.timesheet_attendance` melempar `UserError`
"Sheet Not FOUND" bahkan saat form Create baru dibuka (sebelum field Date
diisi sama sekali), karena Odoo mengevaluasi seluruh field ter-compute lewat
onchange/default_get untuk record baru, dan compute langsung mencari sheet
tanpa memeriksa apakah `date` sudah terisi.

Perbaikan: bila `record.date` kosong, `_compute_sheet()` kini melewati
pencarian dan langsung menyetel `sheet_id = False` tanpa error. Field
`sheet_id` tetap `required=True`, sehingga constraint standar Odoo yang akan
menolak SAVE bila Date (dan karenanya Sheet) belum terisi. Perilaku saat
`date` terisi tapi tak ada sheet yang cocok tidak berubah - tetap melempar
`UserError` persis seperti sebelumnya.

## Test

Menambahkan tiga skenario baru ke
`ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml`:

- Form Create baru tanpa Date terisi -> tidak ada exception, `sheet_id`
  falsy.
- Create dengan Date terisi tapi tak ada `hr.timesheet` open yang cocok ->
  tetap `UserError` "Sheet Not FOUND".
- Create dengan Date terisi dan ada sheet yang cocok (tanpa passing
  `sheet_id` eksplisit) -> `sheet_id` tetap ter-resolve dengan benar
  (regresi).

Closes #188