### PR TITLE
[UPD] ssi_timesheet_attendance - _compute_sheet recompute saat employee_id berubah

### DIFF
--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -23,7 +23,7 @@ class HRTimesheetAttendance(models.Model):
         required=True,
     )
 
-    @api.depends("date")
+    @api.depends("date", "employee_id")
     def _compute_sheet(self):
         """Resolve the open ``hr.timesheet`` sheet covering ``date``.
 

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -468,3 +468,93 @@ scenarios:
           sheet_id:
             type: "m2o"
             expected: "REC: timesheet_april"
+
+  - name: "HR Timesheet Attendance - Compute Sheet Recomputes When Employee Changes"
+    steps:
+      - step: "Create first employee (has an open sheet for June)"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_recompute_a"
+        values:
+          name: "Test Employee Recompute A"
+
+      - step: "Create second employee (has its own open sheet for June)"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_recompute_b"
+        values:
+          name: "Test Employee Recompute B"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_recompute"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create open June timesheet for first employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_recompute_a"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_recompute_a.id"
+          date_start: 2024-06-01
+          date_end: 2024-06-30
+          working_schedule_id: "REC: working_schedule_recompute.id"
+
+      - step: "Open first employee timesheet"
+        action: "call"
+        target: "timesheet_recompute_a"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create open June timesheet for second employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_recompute_b"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_recompute_b.id"
+          date_start: 2024-06-01
+          date_end: 2024-06-30
+          working_schedule_id: "REC: working_schedule_recompute.id"
+
+      - step: "Open second employee timesheet"
+        action: "call"
+        target: "timesheet_recompute_b"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step:
+          "On a new attendance form, set Employee A then Date - sheet resolves to
+          employee A's sheet; then switch Employee to B WITHOUT touching Date again -
+          sheet must recompute to employee B's own sheet (regression guard for
+          @api.depends missing 'employee_id')"
+        action: "form"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_recompute"
+        as_user: "base.user_admin"
+        save: true
+        ops:
+          - set: {employee_id: "REC: employee_recompute_a"}
+          - set: {date: 2024-06-15}
+          - set: {check_in: "2024-06-15 08:00:00"}
+          - assert:
+              sheet_id:
+                type: "m2o"
+                expected: "REC: timesheet_recompute_a"
+          - set: {employee_id: "REC: employee_recompute_b"}
+          - assert:
+              sheet_id:
+                type: "m2o"
+                expected: "REC: timesheet_recompute_b"
+
+      - step: "Assert sheet stays correctly resolved after save"
+        action: "assert"
+        target: "attendance_recompute"
+        asserts:
+          sheet_id:
+            type: "m2o"
+            expected: "REC: timesheet_recompute_b"

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -528,30 +528,39 @@ scenarios:
         as_user: "base.user_admin"
 
       - step:
-          "On a new attendance form, set Employee A then Date - sheet resolves to
-          employee A's sheet; then switch Employee to B WITHOUT touching Date again -
-          sheet must recompute to employee B's own sheet (regression guard for
-          @api.depends missing 'employee_id')"
-        action: "form"
+          "Create attendance dated in June for employee A; sheet_id passed explicitly so
+          the initial INSERT satisfies the NOT NULL constraint (Odoo only computes
+          stored fields AFTER insert, so a required stored compute field can never be
+          left out of create() values)"
+        action: "create"
         model: "hr.timesheet_attendance"
         save_as: "attendance_recompute"
         as_user: "base.user_admin"
-        save: true
-        ops:
-          - set: {employee_id: "REC: employee_recompute_a"}
-          - set: {date: 2024-06-15}
-          - set: {check_in: "2024-06-15 08:00:00"}
-          - assert:
-              sheet_id:
-                type: "m2o"
-                expected: "REC: timesheet_recompute_a"
-          - set: {employee_id: "REC: employee_recompute_b"}
-          - assert:
-              sheet_id:
-                type: "m2o"
-                expected: "REC: timesheet_recompute_b"
+        values:
+          employee_id: "REC: employee_recompute_a.id"
+          date: 2024-06-15
+          check_in: "2024-06-15 08:00:00"
+          sheet_id: "REC: timesheet_recompute_a.id"
 
-      - step: "Assert sheet stays correctly resolved after save"
+      - step: "Assert precondition: sheet_id is employee A's sheet"
+        action: "assert"
+        target: "attendance_recompute"
+        asserts:
+          sheet_id:
+            type: "m2o"
+            expected: "REC: timesheet_recompute_a"
+
+      - step:
+          "Switch the attendance's Employee to B WITHOUT touching Date - write() only
+          updates the given column, so the recompute this triggers runs safely against
+          the already-existing row; this is the exact regression guard for @api.depends
+          missing 'employee_id'"
+        action: "write"
+        target: "attendance_recompute"
+        values:
+          employee_id: "REC: employee_recompute_b.id"
+
+      - step: "Assert sheet_id was recomputed to employee B's own sheet"
         action: "assert"
         target: "attendance_recompute"
         asserts:


### PR DESCRIPTION
Closes #191

Menambah `employee_id` ke `@api.depends()` `_compute_sheet()` pada `hr.timesheet_attendance` agar Sheet ter-recompute ulang saat employee berubah, bukan hanya saat date berubah. Sebelumnya, urutan pengisian form yang mengganti employee setelah date terisi bisa meninggalkan `sheet_id` kosong/basi sampai save, memicu Validation Error alih-alih pesan UserError kustom "Sheet Not FOUND".

Ditambahkan skenario uji regresi di `test_data_timesheet_attendance.yaml`.