### PR TITLE
[UPD] ssi_timesheet: hentikan write redundan pada hr.timesheet_daily_summary

### DIFF
--- a/ssi_timesheet/models/hr_timesheet.py
+++ b/ssi_timesheet/models/hr_timesheet.py
@@ -139,6 +139,18 @@ class HRTimesheet(models.Model):
         return daily_summary_values
 
     def generate_daily_summary(self):
+        """Synchronize ``daily_summary_ids`` with the current period.
+
+        For every record in ``open``/``confirm``/``done`` state,
+        rebuild the expected daily summary values for each day of
+        ``[date_start, date_end]`` (via ``_prepare_daily_summary_values``).
+        Days that do not have a summary yet are created; existing
+        summaries are written only when
+        ``hr.timesheet_daily_summary._get_daily_summary_diff()``
+        reports an actual difference, so calling this method again
+        with unchanged data issues no ``write()`` at all. Summaries
+        whose date fell out of the period are deleted.
+        """
         for rec in self.filtered(lambda r: r.state in ["open", "confirm", "done"]):
             daily_summary_values = rec._prepare_daily_summary_values()
             existing_dates = []
@@ -154,10 +166,7 @@ class HRTimesheet(models.Model):
                 if not summary_id:
                     obj_daily_summary.create(daily_summary_val)
                 else:
-                    to_write = {}
-                    for key, val in daily_summary_val.items():
-                        if summary_id[key] != val:
-                            to_write[key] = val
+                    to_write = summary_id._get_daily_summary_diff(daily_summary_val)
                     if to_write:
                         summary_id.write(to_write)
                 existing_dates.append(daily_summary_val["date"])

--- a/ssi_timesheet/models/hr_timesheet_daily_summary.py
+++ b/ssi_timesheet/models/hr_timesheet_daily_summary.py
@@ -25,3 +25,40 @@ class HrTimesheetDailySummary(models.Model):
             "date": date,
         }
         return vals
+
+    def _get_daily_summary_diff(self, vals):
+        """Return only the pairs of ``vals`` that differ from ``self``.
+
+        Extension point: this is the single place that decides whether
+        an existing daily summary needs to be written. ``self`` is one
+        existing record (``ensure_one()``); ``vals`` is the dict built
+        by ``_prepare_daily_summary_vals()`` (possibly extended with
+        extra fields by an override in another module).
+
+        Comparing values naively (``self[key] != vals[key]``) is wrong
+        for ``many2one`` fields: ``self[key]`` returns a recordset
+        while ``vals[key]`` stores its integer id, so the comparison
+        always evaluates as "different" and Odoo logs a "Comparing
+        apples and oranges" warning. This method compares
+        ``self[key].id`` against ``vals[key]`` for ``many2one`` fields
+        (looked up via ``self._fields[key].type``) and ``self[key]``
+        directly for every other field type, so it stays correct for
+        fields added by subclasses without hardcoding field names.
+
+        :param vals: dict of proposed values, as built by
+            ``_prepare_daily_summary_vals()``
+        :return: dict containing only the key/value pairs of ``vals``
+            that differ from the values currently stored on ``self``;
+            empty when nothing changed
+        """
+        self.ensure_one()
+        diff = {}
+        for key, val in vals.items():
+            field = self._fields[key]
+            if field.type == "many2one":
+                stored_val = self[key].id
+            else:
+                stored_val = self[key]
+            if stored_val != val:
+                diff[key] = val
+        return diff

--- a/ssi_timesheet/tests/__init__.py
+++ b/ssi_timesheet/tests/__init__.py
@@ -2,6 +2,7 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import test_daily_summary
 from . import test_timesheet
 from . import test_timesheet_computation
 from . import test_timesheet_summary_report

--- a/ssi_timesheet/tests/test_daily_summary.py
+++ b/ssi_timesheet/tests/test_daily_summary.py
@@ -1,0 +1,77 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDailySummary(YamlTransactionCase):
+    """Cover ``generate_daily_summary()`` on ``hr.timesheet``.
+
+    Runs the YAML scenarios that create/regenerate/extend the daily
+    summary rows of a timesheet.
+    """
+
+    def test_daily_summary(self):
+        """Run the daily summary generation scenarios."""
+        self.run_yaml_scenario("test_data_daily_summary.yaml")
+
+    def _create_sheet(self, employee_name, date_start, date_end):
+        """Create a bare ``hr.timesheet`` for the diff fixtures below.
+
+        :param employee_name: name of the throwaway employee created
+        :param date_start: start date of the timesheet
+        :param date_end: end date of the timesheet
+        :return: the created ``hr.timesheet`` record
+        """
+        employee = self.env["hr.employee"].create({"name": employee_name})
+        working_schedule = self.env["resource.calendar"].search([], limit=1)
+        return self.env["hr.timesheet"].create(
+            {
+                "employee_id": employee.id,
+                "date_start": date_start,
+                "date_end": date_end,
+                "working_schedule_id": working_schedule.id,
+            }
+        )
+
+    def test_get_daily_summary_diff_no_change(self):
+        """Return ``{}`` when ``vals`` matches the stored summary.
+
+        Pure Python — trigger P1 (L-01/L-02: the return value of
+        ``_get_daily_summary_diff`` is asserted directly, which
+        ``action: call`` discards and no YAML ``assert`` can reach
+        since it is not a field stored on any record).
+        """
+        sheet = self._create_sheet(
+            "Test Employee Diff No Change", "2024-01-01", "2024-01-01"
+        )
+        summary = self.env["hr.timesheet_daily_summary"].create(
+            {"sheet_id": sheet.id, "date": "2024-01-01"}
+        )
+        vals = summary._prepare_daily_summary_vals(sheet_id=sheet, date=summary.date)
+        self.assertEqual(summary._get_daily_summary_diff(vals), {})
+
+    def test_get_daily_summary_diff_changed_date(self):
+        """Report only ``date``, never ``sheet_id``, when dates differ.
+
+        Pure Python — trigger P1 (L-01/L-02: same reasoning as above).
+        This is the regression guard for the original bug: ``sheet_id``
+        is a ``many2one`` naively compared as ``recordset != int``,
+        which was always "different" even when nothing changed. A
+        correct implementation must never report ``sheet_id`` here,
+        since only ``date`` was changed.
+        """
+        sheet = self._create_sheet(
+            "Test Employee Diff Changed Date", "2024-01-01", "2024-01-02"
+        )
+        summary = self.env["hr.timesheet_daily_summary"].create(
+            {"sheet_id": sheet.id, "date": "2024-01-01"}
+        )
+        vals = summary._prepare_daily_summary_vals(sheet_id=sheet, date="2024-01-02")
+        diff = summary._get_daily_summary_diff(vals)
+        self.assertIn("date", diff)
+        self.assertNotIn("sheet_id", diff)

--- a/ssi_timesheet/tests/test_data_daily_summary.yaml
+++ b/ssi_timesheet/tests/test_data_daily_summary.yaml
@@ -1,0 +1,154 @@
+scenarios:
+  - name: "Open generates one daily summary per day in the period"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Daily Summary A"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "EVAL: registry['employee'].id"
+          date_start: 2024-01-01
+          date_end: 2024-01-03
+          working_schedule_id: "EVAL: registry['working_schedule'].id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Every generated summary points back to this sheet"
+        action: "search"
+        model: "hr.timesheet_daily_summary"
+        domain: [["sheet_id", "=", "REC: timesheet.id"]]
+        save_as: "summaries_for_sheet"
+        expect_count: 3
+
+  - name: "Regenerating an open timesheet does not duplicate or drop rows"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Daily Summary B"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "EVAL: registry['employee'].id"
+          date_start: 2024-01-01
+          date_end: 2024-01-03
+          working_schedule_id: "EVAL: registry['working_schedule'].id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Generate daily summary again on the same sheet"
+        action: "call"
+        target: "timesheet"
+        method: "generate_daily_summary"
+        as_user: "base.user_admin"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+  - name: "Extending date_end grows the daily summary set"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Daily Summary C"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "EVAL: registry['employee'].id"
+          date_start: 2024-01-01
+          date_end: 2024-01-03
+          working_schedule_id: "EVAL: registry['working_schedule'].id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Extend the period by one day"
+        action: "write"
+        target: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          date_end: 2024-01-04
+
+      - step: "Daily summary now covers the extended period"
+        action: "assert"
+        target: "timesheet"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 4


### PR DESCRIPTION
## Ringkasan

`generate_daily_summary()` membandingkan nilai tersimpan tiap daily summary dengan
`vals` dari `_prepare_daily_summary_vals()` memakai `summary_id[key] != val`. Untuk
`sheet_id` (many2one), `vals["sheet_id"]` adalah integer sementara
`summary_id["sheet_id"]` adalah recordset, sehingga perbandingan selalu bernilai
"berbeda" (`NotImplemented` dari `BaseModel.__eq__`) dan memicu warning "Comparing
apples and oranges" di log. Akibatnya `write()` dieksekusi untuk **setiap** daily
summary di **setiap** pemanggilan `generate_daily_summary()`, walau tidak ada
perubahan nilai apa pun.

## Perubahan

- Tambah method `_get_daily_summary_diff(self, vals)` pada `hr.timesheet_daily_summary`
  sebagai titik ekstensi: mengembalikan dict berisi hanya key/value yang berbeda dari
  nilai tersimpan, dict kosong bila tidak ada beda. Aturan banding: field `many2one`
  dibandingkan lewat `.id`, tipe lain dibandingkan langsung (tipe dibaca dari
  `self._fields[key].type`, tidak ada daftar nama field yang di-hardcode).
- `generate_daily_summary()` di `hr.timesheet` memakai method itu menggantikan loop
  perbandingan inline; `write()` hanya dipanggil bila dict yang dikembalikan tidak
  kosong.
- Tambah docstring pada `generate_daily_summary()` (sebelumnya belum ada).
- Tidak ada field baru, tidak ada perubahan view/security/`__manifest__.py`. Perilaku
  lain tidak berubah: summary yang belum ada tetap dibuat, yang tanggalnya di luar
  periode tetap dihapus.

## Unit test

- 3 skenario YAML: `action_open` dengan periode 3 hari menghasilkan 3 daily summary
  ber-`sheet_id` benar; regenerasi tidak menduplikasi/menghapus; perluasan
  `date_end` menambah baris baru.
- 2 test Python murni (P1; L-01/L-02) untuk `_get_daily_summary_diff()`: vals identik
  → `{}`; vals bertanggal beda → dict memuat `date`, tidak memuat `sheet_id` (penjaga
  regresi bug inti).

Closes open-synergy/opnsynid-hr-timesheet#193