### PR TITLE
Batasi sapuan generate_daily_summary ke tanggal terdampak

### DIFF
--- a/ssi_timesheet/models/hr_timesheet.py
+++ b/ssi_timesheet/models/hr_timesheet.py
@@ -122,15 +122,36 @@ class HRTimesheet(models.Model):
         res += policy_field
         return res
 
-    def _prepare_daily_summary_values(self):
+    def _prepare_daily_summary_values(self, dates=None):
+        """Build the daily summary vals for the affected dates.
+
+        :param dates: iterable of ``datetime.date`` to build vals
+            for, normalized to a ``set`` internally. Empty/``None``
+            (default) builds vals for every day of
+            ``[date_start, date_end]`` -- the full-sweep behaviour.
+            When given, only dates falling inside
+            ``[date_start, date_end]`` are used; dates outside the
+            period are silently ignored (not created, no error).
+        :return: list of vals dicts, one per considered date, built
+            by
+            ``hr.timesheet_daily_summary._prepare_daily_summary_vals``
+        """
         self.ensure_one()
         daily_summary_values = []
         if self.state in ("open", "confirm", "done"):
-            delta = self.date_end - self.date_start
-            date_ranges = []
-            for i in range(delta.days + 1):
-                day = self.date_start + timedelta(days=i)
-                date_ranges.append(day)
+            dates = set(dates) if dates else set()
+            if dates:
+                date_ranges = sorted(
+                    current_date
+                    for current_date in dates
+                    if self.date_start <= current_date <= self.date_end
+                )
+            else:
+                delta = self.date_end - self.date_start
+                date_ranges = []
+                for i in range(delta.days + 1):
+                    day = self.date_start + timedelta(days=i)
+                    date_ranges.append(day)
             for current_date in date_ranges:
                 vals = self.env[
                     "hr.timesheet_daily_summary"
@@ -138,21 +159,31 @@ class HRTimesheet(models.Model):
                 daily_summary_values.append(vals)
         return daily_summary_values
 
-    def generate_daily_summary(self):
-        """Synchronize ``daily_summary_ids`` with the current period.
+    def generate_daily_summary(self, dates=None):
+        """Synchronize ``daily_summary_ids`` with the affected dates.
 
-        For every record in ``open``/``confirm``/``done`` state,
-        rebuild the expected daily summary values for each day of
-        ``[date_start, date_end]`` (via ``_prepare_daily_summary_values``).
-        Days that do not have a summary yet are created; existing
-        summaries are written only when
-        ``hr.timesheet_daily_summary._get_daily_summary_diff()``
-        reports an actual difference, so calling this method again
-        with unchanged data issues no ``write()`` at all. Summaries
-        whose date fell out of the period are deleted.
+        :param dates: iterable of ``datetime.date`` to (re)generate
+            the daily summary for, normalized to a ``set``
+            internally. Empty/``None`` (default) means a
+            **full sweep**: every day of
+            ``[date_start, date_end]`` is (re)built (via
+            ``_prepare_daily_summary_values``) and any summary whose
+            date fell out of the period is deleted -- the
+            pre-existing behaviour, kept for backward compatibility
+            with existing callers and overrides. Existing summaries
+            are written only when
+            ``hr.timesheet_daily_summary._get_daily_summary_diff()``
+            reports an actual difference, so calling this method
+            again with unchanged data issues no ``write()`` at all.
+            When ``dates`` is given, only vals for those dates are
+            built and **no summary is ever deleted**: a partial
+            sweep only knows about a subset of the dates, so running
+            the deletion step would drop summaries of dates that
+            were never considered and are still legitimate.
         """
+        dates = set(dates) if dates else set()
         for rec in self.filtered(lambda r: r.state in ["open", "confirm", "done"]):
-            daily_summary_values = rec._prepare_daily_summary_values()
+            daily_summary_values = rec._prepare_daily_summary_values(dates=dates)
             existing_dates = []
             obj_daily_summary = self.env["hr.timesheet_daily_summary"]
             for daily_summary_val in daily_summary_values:
@@ -170,13 +201,14 @@ class HRTimesheet(models.Model):
                     if to_write:
                         summary_id.write(to_write)
                 existing_dates.append(daily_summary_val["date"])
-            to_delete_summary_ids = obj_daily_summary.search(
-                [
-                    ("sheet_id", "=", rec.id),
-                    ("date", "not in", existing_dates),
-                ]
-            )
-            to_delete_summary_ids.unlink()
+            if not dates:
+                to_delete_summary_ids = obj_daily_summary.search(
+                    [
+                        ("sheet_id", "=", rec.id),
+                        ("date", "not in", existing_dates),
+                    ]
+                )
+                to_delete_summary_ids.unlink()
 
     def get_trigger_fields_daily_summary(self):
         return [

--- a/ssi_timesheet/tests/test_daily_summary.py
+++ b/ssi_timesheet/tests/test_daily_summary.py
@@ -2,6 +2,8 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from datetime import date
+
 from odoo_yaml_test import YamlTransactionCase
 
 from odoo.tests import tagged
@@ -75,3 +77,26 @@ class TestDailySummary(YamlTransactionCase):
         diff = summary._get_daily_summary_diff(vals)
         self.assertIn("date", diff)
         self.assertNotIn("sheet_id", diff)
+
+    def test_prepare_daily_summary_values_dates_filter(self):
+        """Restrict the built vals to the requested ``dates`` only.
+
+        Pure Python — trigger P1 (L-01/L-02: the return value of
+        ``_prepare_daily_summary_values`` is a plain list of dicts,
+        which ``action: call`` discards and no YAML ``assert`` can
+        reach since it is not a field stored on any record). On a
+        three-day sheet, passing a single in-period date must build
+        vals for exactly that date, not the full period.
+        """
+        admin = self.env.ref("base.user_admin")
+        sheet = self._create_sheet(
+            "Test Employee Prepare Values Dates", "2024-01-01", "2024-01-03"
+        )
+        sheet.with_user(admin).action_open()
+
+        daily_summary_values = sheet._prepare_daily_summary_values(
+            dates=[date(2024, 1, 2)]
+        )
+
+        self.assertEqual(len(daily_summary_values), 1)
+        self.assertEqual(daily_summary_values[0]["date"], date(2024, 1, 2))

--- a/ssi_timesheet/tests/test_data_daily_summary.yaml
+++ b/ssi_timesheet/tests/test_data_daily_summary.yaml
@@ -152,3 +152,84 @@ scenarios:
             type: "o2m"
             check: "count"
             expected_count: 4
+
+  - name: "Partial sweep with dates neither duplicates nor deletes"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Daily Summary D"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "EVAL: registry['employee'].id"
+          date_start: 2024-01-01
+          date_end: 2024-01-03
+          working_schedule_id: "EVAL: registry['working_schedule'].id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Regenerate a single in-period date"
+        action: "call"
+        target: "timesheet"
+        method: "generate_daily_summary"
+        as_user: "base.user_admin"
+        kwargs:
+          dates: [2024-01-02]
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Regenerate an out-of-period date"
+        action: "call"
+        target: "timesheet"
+        method: "generate_daily_summary"
+        as_user: "base.user_admin"
+        kwargs:
+          dates: [2024-02-15]
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Narrow date_end to two days"
+        action: "write"
+        target: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          date_end: 2024-01-02
+
+      - step: "Full sweep triggered by write() still deletes the dropped day"
+        action: "assert"
+        target: "timesheet"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 2

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -245,7 +245,10 @@ class HRTimesheetAttendance(models.Model):
         since ``super().write()`` overwrites them; the daily summary
         is then regenerated for the union of the old and new dates,
         so moving an attendance from one date to another refreshes
-        both the origin and the destination summaries.
+        both the origin and the destination summaries. ``date`` is a
+        required field, so both the pre-write and post-write values
+        are always set on an existing record -- no falsy guard is
+        needed around either one.
 
         :param values: field values to write
         :return: the value returned by the parent ``write()``
@@ -254,11 +257,6 @@ class HRTimesheetAttendance(models.Model):
         res = super(HRTimesheetAttendance, self).write(values)
         for rec in self:
             if "date" in values or "check_in" in values or "check_out" in values:
-                affected_dates = set()
-                old_date = old_date_by_id.get(rec.id)
-                if old_date:
-                    affected_dates.add(old_date)
-                if rec.date:
-                    affected_dates.add(rec.date)
+                affected_dates = {old_date_by_id[rec.id], rec.date}
                 rec.sheet_id.generate_daily_summary(dates=affected_dates)
         return res

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -225,13 +225,40 @@ class HRTimesheetAttendance(models.Model):
 
     @api.model
     def create(self, values):
+        """Create the attendance and refresh its daily summary date.
+
+        Only the newly created record's own ``date`` is affected, so
+        ``generate_daily_summary()`` is called with that single date
+        instead of sweeping the whole sheet.
+
+        :param values: field values for the new record
+        :return: the created ``hr.timesheet_attendance`` record
+        """
         res = super(HRTimesheetAttendance, self).create(values)
-        res.sheet_id.generate_daily_summary()
+        res.sheet_id.generate_daily_summary(dates=[res.date])
         return res
 
     def write(self, values):
+        """Update the attendance and refresh the affected summaries.
+
+        The dates in effect *before* this write are captured first,
+        since ``super().write()`` overwrites them; the daily summary
+        is then regenerated for the union of the old and new dates,
+        so moving an attendance from one date to another refreshes
+        both the origin and the destination summaries.
+
+        :param values: field values to write
+        :return: the value returned by the parent ``write()``
+        """
+        old_date_by_id = {rec.id: rec.date for rec in self}
         res = super(HRTimesheetAttendance, self).write(values)
         for rec in self:
             if "date" in values or "check_in" in values or "check_out" in values:
-                rec.sheet_id.generate_daily_summary()
+                affected_dates = set()
+                old_date = old_date_by_id.get(rec.id)
+                if old_date:
+                    affected_dates.add(old_date)
+                if rec.date:
+                    affected_dates.add(rec.date)
+                rec.sheet_id.generate_daily_summary(dates=affected_dates)
         return res

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -567,3 +567,134 @@ scenarios:
           sheet_id:
             type: "m2o"
             expected: "REC: timesheet_recompute_b"
+
+  - name: "HR Timesheet Attendance - Daily Summary Reflects Only The Affected Date"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_daily_summary"
+        values:
+          name: "Test Employee Attendance Daily Summary"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_daily_summary"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create three-day timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_daily_summary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_daily_summary.id"
+          date_start: 2024-01-01
+          date_end: 2024-01-03
+          working_schedule_id: "REC: working_schedule_daily_summary.id"
+
+      - step: "Open timesheet (creates one zeroed summary per day)"
+        action: "call"
+        target: "timesheet_daily_summary"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Create an attendance on 2024-01-02"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_daily_summary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_daily_summary.id"
+          date: 2024-01-02
+          check_in: "2024-01-02 08:00:00"
+          check_out: "2024-01-02 17:00:00"
+          sheet_id: "REC: timesheet_daily_summary.id"
+
+      - step: "Find the 2024-01-02 daily summary"
+        action: "search"
+        model: "hr.timesheet_daily_summary"
+        domain:
+          [
+            ["sheet_id", "=", "REC: timesheet_daily_summary.id"],
+            ["date", "=", 2024-01-02],
+          ]
+        save_as: "summary_0102"
+        expect_count: 1
+
+      - step: "2024-01-02 summary reflects the attendance's total hour"
+        action: "assert"
+        target: "summary_0102"
+        asserts:
+          total_attendance:
+            type: "value"
+            expected: "REC: attendance_daily_summary.total_hour"
+
+      - step: "Find the 2024-01-01 daily summary"
+        action: "search"
+        model: "hr.timesheet_daily_summary"
+        domain:
+          [
+            ["sheet_id", "=", "REC: timesheet_daily_summary.id"],
+            ["date", "=", 2024-01-01],
+          ]
+        save_as: "summary_0101"
+        expect_count: 1
+
+      - step: "2024-01-01 summary is untouched"
+        action: "assert"
+        target: "summary_0101"
+        asserts:
+          total_attendance:
+            type: "value"
+            expected: 0.0
+
+      - step: "Find the 2024-01-03 daily summary"
+        action: "search"
+        model: "hr.timesheet_daily_summary"
+        domain:
+          [
+            ["sheet_id", "=", "REC: timesheet_daily_summary.id"],
+            ["date", "=", 2024-01-03],
+          ]
+        save_as: "summary_0103"
+        expect_count: 1
+
+      - step: "2024-01-03 summary is untouched"
+        action: "assert"
+        target: "summary_0103"
+        asserts:
+          total_attendance:
+            type: "value"
+            expected: 0.0
+
+      - step: "Move the attendance from 2024-01-02 to 2024-01-03"
+        action: "write"
+        target: "attendance_daily_summary"
+        as_user: "base.user_admin"
+        values:
+          date: 2024-01-03
+
+      - step: "2024-01-02 summary drops back to zero"
+        action: "assert"
+        target: "summary_0102"
+        asserts:
+          total_attendance:
+            type: "value"
+            expected: 0.0
+
+      - step: "2024-01-03 summary now carries the attendance's total hour"
+        action: "assert"
+        target: "summary_0103"
+        asserts:
+          total_attendance:
+            type: "value"
+            expected: "REC: attendance_daily_summary.total_hour"

--- a/ssi_timesheet_attendance_work_log/models/hr_work_log.py
+++ b/ssi_timesheet_attendance_work_log/models/hr_work_log.py
@@ -18,13 +18,40 @@ class HRWorkLog(models.Model):
 
     @api.model
     def create(self, values):
+        """Create the work log and refresh its daily summary date.
+
+        Only the newly created record's own ``date`` is affected, so
+        ``generate_daily_summary()`` is called with that single date
+        instead of sweeping the whole sheet.
+
+        :param values: field values for the new record
+        :return: the created ``hr.work_log`` record
+        """
         res = super(HRWorkLog, self).create(values)
-        res.sheet_id.generate_daily_summary()
+        res.sheet_id.generate_daily_summary(dates=[res.date])
         return res
 
     def write(self, values):
+        """Update the work log and refresh the affected summaries.
+
+        The dates in effect *before* this write are captured first,
+        since ``super().write()`` overwrites them; the daily summary
+        is then regenerated for the union of the old and new dates,
+        so moving a work log from one date to another refreshes both
+        the origin and the destination summaries.
+
+        :param values: field values to write
+        :return: the value returned by the parent ``write()``
+        """
+        old_date_by_id = {rec.id: rec.date for rec in self}
         res = super(HRWorkLog, self).write(values)
         for rec in self:
             if "date" in values or "amount" in values:
-                rec.sheet_id.generate_daily_summary()
+                affected_dates = set()
+                old_date = old_date_by_id.get(rec.id)
+                if old_date:
+                    affected_dates.add(old_date)
+                if rec.date:
+                    affected_dates.add(rec.date)
+                rec.sheet_id.generate_daily_summary(dates=affected_dates)
         return res

--- a/ssi_timesheet_attendance_work_log/models/hr_work_log.py
+++ b/ssi_timesheet_attendance_work_log/models/hr_work_log.py
@@ -38,7 +38,10 @@ class HRWorkLog(models.Model):
         since ``super().write()`` overwrites them; the daily summary
         is then regenerated for the union of the old and new dates,
         so moving a work log from one date to another refreshes both
-        the origin and the destination summaries.
+        the origin and the destination summaries. ``date`` is a
+        required field, so both the pre-write and post-write values
+        are always set on an existing record -- no falsy guard is
+        needed around either one.
 
         :param values: field values to write
         :return: the value returned by the parent ``write()``
@@ -47,11 +50,6 @@ class HRWorkLog(models.Model):
         res = super(HRWorkLog, self).write(values)
         for rec in self:
             if "date" in values or "amount" in values:
-                affected_dates = set()
-                old_date = old_date_by_id.get(rec.id)
-                if old_date:
-                    affected_dates.add(old_date)
-                if rec.date:
-                    affected_dates.add(rec.date)
+                affected_dates = {old_date_by_id[rec.id], rec.date}
                 rec.sheet_id.generate_daily_summary(dates=affected_dates)
         return res

--- a/ssi_timesheet_attendance_work_log/tests/test_data_timesheet_attendance_work_log.yaml
+++ b/ssi_timesheet_attendance_work_log/tests/test_data_timesheet_attendance_work_log.yaml
@@ -79,3 +79,139 @@ scenarios:
           sheet_id:
             type: "value"
             operator: "is_truthy"
+
+  - name: "Work Log - Daily Summary Reflects Only The Affected Date"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_daily_summary"
+        values:
+          name: "Test Employee Work Log Daily Summary"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_daily_summary"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create three-day timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_daily_summary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_daily_summary.id"
+          date_start: 2024-01-01
+          date_end: 2024-01-03
+          working_schedule_id: "REC: working_schedule_daily_summary.id"
+
+      - step: "Open timesheet (creates one zeroed summary per day)"
+        action: "call"
+        target: "timesheet_daily_summary"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          daily_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
+      - step: "Get ir.model for res.partner"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "res.partner"]]
+        save_as: "ir_model_daily_summary"
+        limit: 1
+
+      - step: "Get a partner record"
+        action: "search"
+        model: "res.partner"
+        domain: [["name", "!=", false]]
+        save_as: "partner_daily_summary"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "analytic_account_daily_summary"
+        values:
+          name: "Test Analytic Work Log Daily Summary"
+
+      - step: "Create a work log on 2024-01-02"
+        action: "create"
+        model: "hr.work_log"
+        save_as: "work_log_daily_summary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_daily_summary.id"
+          description: "Work log daily summary test"
+          model_id: "REC: ir_model_daily_summary.id"
+          work_object_id: "REC: partner_daily_summary.id"
+          date: 2024-01-02
+          amount: 3.0
+          analytic_account_id: "REC: analytic_account_daily_summary.id"
+
+      - step: "Find the 2024-01-02 daily summary"
+        action: "search"
+        model: "hr.timesheet_daily_summary"
+        domain:
+          [
+            ["sheet_id", "=", "REC: timesheet_daily_summary.id"],
+            ["date", "=", 2024-01-02],
+          ]
+        save_as: "wl_summary_0102"
+        expect_count: 1
+
+      - step: "2024-01-02 summary reflects the work log's amount"
+        action: "assert"
+        target: "wl_summary_0102"
+        asserts:
+          total_work_log:
+            type: "value"
+            expected: 3.0
+
+      - step: "Find the 2024-01-03 daily summary"
+        action: "search"
+        model: "hr.timesheet_daily_summary"
+        domain:
+          [
+            ["sheet_id", "=", "REC: timesheet_daily_summary.id"],
+            ["date", "=", 2024-01-03],
+          ]
+        save_as: "wl_summary_0103"
+        expect_count: 1
+
+      - step: "2024-01-03 summary is untouched"
+        action: "assert"
+        target: "wl_summary_0103"
+        asserts:
+          total_work_log:
+            type: "value"
+            expected: 0.0
+
+      - step: "Move the work log from 2024-01-02 to 2024-01-03"
+        action: "write"
+        target: "work_log_daily_summary"
+        as_user: "base.user_admin"
+        values:
+          date: 2024-01-03
+
+      - step: "2024-01-02 summary drops back to zero"
+        action: "assert"
+        target: "wl_summary_0102"
+        asserts:
+          total_work_log:
+            type: "value"
+            expected: 0.0
+
+      - step: "2024-01-03 summary now carries the work log's amount"
+        action: "assert"
+        target: "wl_summary_0103"
+        asserts:
+          total_work_log:
+            type: "value"
+            expected: 3.0


### PR DESCRIPTION
## Ringkasan

`generate_daily_summary()` dan `_prepare_daily_summary_values()` di `ssi_timesheet` kini
menerima parameter opsional `dates` (iterable `datetime.date`, dinormalkan jadi `set`).
Kosong/`None` tetap berarti sapuan penuh (perilaku lama dipertahankan persis, termasuk
menghapus summary di luar periode). Bila diisi, hanya tanggal itu yang dibangun (tanggal
di luar periode diabaikan) dan langkah penghapusan dilewati sepenuhnya, karena sapuan
parsial tidak boleh menghapus summary tanggal lain yang sah.

`hr.timesheet.write()` tetap memanggil tanpa argumen (sapuan penuh). Pemanggil di
`ssi_timesheet_attendance` (`hr.timesheet_attendance.create()`/`write()`) dan
`ssi_timesheet_attendance_work_log` (`hr.work_log.create()`/`write()`) kini mengoper
tanggal terdampak saja: `create()` mengoper tanggal record baru; `write()` menangkap
tanggal lama sebelum `super()` lalu mengoper gabungan tanggal lama & baru, sehingga
memindahkan tanggal record memperbarui daily summary tanggal asal maupun tujuan.

Tidak ada field baru, tidak ada perubahan view/security/`__manifest__.py`.

## Modul

- `ssi_timesheet`
- `ssi_timesheet_attendance`
- `ssi_timesheet_attendance_work_log`

## Test

- Unit test YAML baru di `ssi_timesheet` (sapuan parsial tidak menduplikasi/menghapus,
  tanggal di luar periode diabaikan, sapuan penuh tetap menghapus) dan di
  `ssi_timesheet_attendance` (daily summary hanya berubah pada tanggal terdampak,
  memindahkan tanggal absensi memperbarui kedua tanggal).
- Satu unit test Python murni (P1/L-01/L-02) untuk
  `_prepare_daily_summary_values(dates=[...])`.

Closes #194