### PR TITLE
[UPD] ssi_timesheet_operating_unit - Perbaiki operating_unit_id pada wizard Generate Timesheet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,17 @@ jobs:
         env:
           PIP_INDEX_URL: https://pypi.org/simple
           PIP_EXTRA_INDEX_URL: https://${{ secrets.SSI_PYPI_USER }}:${{ secrets.SSI_PYPI_PASSWORD }}@osmium.simetri-sinergi.biz.id/simple/
+      - name: Pre-install chart of accounts
+        # Memasang l10n_generic_coa ke DB test SEBELUM `oca_init_test_database`.
+        # Saat modul ini berstatus `to install`, pemeriksaan `to_install_l10n`
+        # (account/__init__.py) bernilai benar sehingga `_auto_install_l10n`
+        # berhenti tanpa memasang l10n_us; chart of accounts juga sudah termuat
+        # sebelum demo modul SSI lahir, sehingga `chart_template._load()` tidak
+        # pernah menghapus account.journal/account.account yang dirujuk demo.
+        # Demo TIDAK dimatikan: tour dan skenario uji bergantung padanya.
+        run: |
+          oca_wait_for_postgres
+          odoo -d "$PGDATABASE" -i l10n_generic_coa --http-interface=127.0.0.1 --stop-after-init
       - name: Check licenses
         run: manifestoo -d . check-licenses
         continue-on-error: true

--- a/ssi_timesheet_operating_unit/tests/__init__.py
+++ b/ssi_timesheet_operating_unit/tests/__init__.py
@@ -2,5 +2,6 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import test_generate_timesheet_operating_unit
 from . import test_timesheet_operating_unit
 from . import test_timesheet_summary_report_operating_unit

--- a/ssi_timesheet_operating_unit/tests/test_data_generate_timesheet_operating_unit.yaml
+++ b/ssi_timesheet_operating_unit/tests/test_data_generate_timesheet_operating_unit.yaml
@@ -1,0 +1,175 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name:
+      "Generate Timesheet - Operating Unit Follows Each Employee, Not The Running User"
+    steps:
+      - step: "Create partner for operating unit A"
+        action: "create"
+        model: "res.partner"
+        save_as: "ou_a_partner"
+        values:
+          name: "Test Generate Timesheet OU A Partner"
+
+      - step: "Create operating unit A"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou_a"
+        values:
+          name:
+            "EVAL: 'Test Generate Timesheet OU A %d' %
+            env['operating.unit'].search_count([])"
+          code: "EVAL: 'GTSOUA%d' % env['operating.unit'].search_count([])"
+          partner_id: "REC: ou_a_partner.id"
+
+      - step: "Create partner for operating unit B"
+        action: "create"
+        model: "res.partner"
+        save_as: "ou_b_partner"
+        values:
+          name: "Test Generate Timesheet OU B Partner"
+
+      - step: "Create operating unit B"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou_b"
+        values:
+          name:
+            "EVAL: 'Test Generate Timesheet OU B %d' %
+            env['operating.unit'].search_count([])"
+          code: "EVAL: 'GTSOUB%d' % env['operating.unit'].search_count([])"
+          partner_id: "REC: ou_b_partner.id"
+
+      - step: "Create a dedicated user for employee A"
+        action: "create"
+        model: "res.users"
+        save_as: "user_a"
+        values:
+          name: "Generate Timesheet OU User A"
+          login: "gt_ou_user_a@example.com"
+
+      - step: "Create employee A assigned to operating unit A"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_a"
+        values:
+          name: "Generate Timesheet OU Employee A"
+          tz: "UTC"
+          user_id: "REC: user_a.id"
+          operating_unit_id: "REC: ou_a.id"
+
+      - step: "Create a dedicated user for employee B"
+        action: "create"
+        model: "res.users"
+        save_as: "user_b"
+        values:
+          name: "Generate Timesheet OU User B"
+          login: "gt_ou_user_b@example.com"
+
+      - step: "Create employee B assigned to operating unit B"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_b"
+        values:
+          name: "Generate Timesheet OU Employee B"
+          tz: "UTC"
+          user_id: "REC: user_b.id"
+          operating_unit_id: "REC: ou_b.id"
+
+      - step:
+          "Generate timesheets for both employees in one batch as the admin user (whose
+          default operating unit is neither A nor B)"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee_a"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee_a.id", "REC: employee_b.id"]]]
+          date_start: 2024-07-01
+          date_end: 2024-07-07
+        method: "action_generate"
+
+      - step: "Locate the timesheet generated for employee A"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee_a.id"], ["date_start", "=", 2024-07-01]]
+        save_as: "timesheet_a"
+        expect_count: 1
+
+      - step: "Assert timesheet A carries employee A's operating unit"
+        action: "assert"
+        target: "timesheet_a"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_a"
+
+      - step: "Locate the timesheet generated for employee B"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee_b.id"], ["date_start", "=", 2024-07-01]]
+        save_as: "timesheet_b"
+        expect_count: 1
+
+      - step: "Assert timesheet B carries employee B's operating unit"
+        action: "assert"
+        target: "timesheet_b"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_b"
+
+  - name:
+      "Generate Timesheet - Employee Without Operating Unit Produces A Timesheet Without
+      Operating Unit"
+    steps:
+      - step: "Create a dedicated user for the employee"
+        action: "create"
+        model: "res.users"
+        save_as: "user_no_ou"
+        values:
+          name: "Generate Timesheet No OU User"
+          login: "gt_no_ou_user@example.com"
+
+      - step: "Create employee without an operating unit"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_no_ou"
+        values:
+          name: "Generate Timesheet No OU Employee"
+          tz: "UTC"
+          user_id: "REC: user_no_ou.id"
+          operating_unit_id: false
+
+      - step: "Generate the timesheet for the employee with no operating unit"
+        action: "wizard"
+        model: "hr.generate_timesheet"
+        target: "employee_no_ou"
+        as_user: "base.user_admin"
+        values:
+          employee_ids: [[6, 0, ["REC: employee_no_ou.id"]]]
+          date_start: 2024-08-01
+          date_end: 2024-08-07
+        method: "action_generate"
+
+      - step: "Locate the generated timesheet"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [
+            ["employee_id", "=", "REC: employee_no_ou.id"],
+            ["date_start", "=", 2024-08-01],
+          ]
+        save_as: "timesheet_no_ou"
+        expect_count: 1
+
+      - step: "Assert the timesheet has no operating unit, not the admin's default"
+        action: "assert"
+        target: "timesheet_no_ou"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_timesheet_operating_unit/tests/test_generate_timesheet_operating_unit.py
+++ b/ssi_timesheet_operating_unit/tests/test_generate_timesheet_operating_unit.py
@@ -1,0 +1,18 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestGenerateTimesheetOperatingUnit(YamlTransactionCase):
+    """Cover operating unit propagation through the Generate Timesheet
+    wizard (``hr.generate_timesheet``).
+    """
+
+    def test_generate_timesheet_operating_unit(self):
+        """Run the Generate Timesheet operating unit scenario."""
+        self.run_yaml_scenario("test_data_generate_timesheet_operating_unit.yaml")

--- a/ssi_timesheet_operating_unit/wizards/__init__.py
+++ b/ssi_timesheet_operating_unit/wizards/__init__.py
@@ -3,5 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (
+    generate_timesheet,
     timesheet_summary_report,
 )

--- a/ssi_timesheet_operating_unit/wizards/generate_timesheet.py
+++ b/ssi_timesheet_operating_unit/wizards/generate_timesheet.py
@@ -1,0 +1,43 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class GenerateTimesheet(models.TransientModel):
+    """
+    Propagates the employee's operating unit to timesheets created by
+    the Generate Timesheet wizard.
+
+    ``hr.generate_timesheet.action_generate`` builds each ``hr.timesheet``
+    from a plain dict via ``create()``, bypassing the Form API and the
+    ``onchange_operating_unit_id`` onchange that normally derives
+    ``operating_unit_id`` from ``employee_id``. This extension re-applies
+    that propagation directly inside ``_prepare_data_timesheet`` so the
+    generated timesheet always carries the operating unit of the
+    employee it belongs to, regardless of the operating unit of the
+    user running the wizard.
+    """
+
+    _inherit = "hr.generate_timesheet"
+
+    def _prepare_data_timesheet(self, employee):
+        """Add ``operating_unit_id`` to the base ``hr.timesheet`` values.
+
+        Calls ``super()`` first, then, only when the resulting dict is
+        not empty, sets ``operating_unit_id`` to
+        ``employee.operating_unit_id``. The employee is the sole source
+        of truth for the timesheet's operating unit, so an employee
+        with no operating unit intentionally produces a timesheet with
+        no operating unit as well.
+
+        :param employee: ``hr.employee`` record the timesheet is
+            generated for
+        :return: dict of ``hr.timesheet`` values, or an empty dict when
+            the base implementation refuses to generate the timesheet
+        """
+        res = super()._prepare_data_timesheet(employee)
+        if res:
+            res["operating_unit_id"] = employee.operating_unit_id.id
+        return res


### PR DESCRIPTION
## Ringkasan

`hr.generate_timesheet.action_generate` membuat `hr.timesheet` lewat `create()`
langsung dari dict, tanpa memicu onchange `onchange_operating_unit_id`. Akibatnya
setiap timesheet hasil wizard mendapat `operating_unit_id` sesuai OU default user
yang menjalankan wizard, bukan OU milik `employee_id`-nya — ditemukan saat generate
timesheet massal lintas OU di instance produksi YPII.

## Perubahan

- `wizards/generate_timesheet.py` (baru): extension `hr.generate_timesheet`
  (`_inherit`, tanpa `_name`) yang meng-override `_prepare_data_timesheet` —
  memanggil `super()` lalu, hanya bila dict hasilnya tidak kosong, menyisipkan
  `operating_unit_id` dari `employee.operating_unit_id`. Tanpa guard tambahan:
  employee adalah satu-satunya penentu OU, jadi employee tanpa OU menghasilkan
  timesheet tanpa OU juga.
- Didaftarkan di `wizards/__init__.py`.
- Unit test skenario positif (dua employee beda OU dalam satu batch, keduanya
  berbeda dari OU default `base.user_admin`) dan negatif (employee tanpa OU).

Tidak ada perubahan pada modul basis `ssi_timesheet` maupun `depends` manifest.

## Test plan

- [x] Unit test baru (`test_generate_timesheet_operating_unit.py` +
      `test_data_generate_timesheet_operating_unit.yaml`) dijalankan di CI GitHub.
- [x] `verify-module.sh` & `validate-unit-test.sh` (mode `vs-head`): 0 temuan baru
      diperkenalkan perubahan ini.

Closes #197