### PR TITLE
[UPD] ssi_hr_holiday_documenso_signing - kepatuhan skill 14.0

### DIFF
--- a/ssi_hr_holiday_documenso_signing/README.rst
+++ b/ssi_hr_holiday_documenso_signing/README.rst
@@ -13,6 +13,12 @@ platform.
 It adds a *Documenso* tab to both the HR Leave and HR Leave Allocation form
 views, allowing users to manage signature requests directly from each record.
 
+Work Instruction
+================
+
+* `Approve Leave <docs/hr_leave/index.html>`_
+* `Approve Leave Allocation <docs/hr_leave_allocation/index.html>`_
+
 Configuration
 =============
 

--- a/ssi_hr_holiday_documenso_signing/__manifest__.py
+++ b/ssi_hr_holiday_documenso_signing/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_hr_holiday",
         "ssi_connector_documenso_signing",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_hr_holiday_documenso_signing/docs/hr_leave/05-approve.md
+++ b/ssi_hr_holiday_documenso_signing/docs/hr_leave/05-approve.md
@@ -1,0 +1,38 @@
+# Approve Leave
+
+> **Module:** ssi_hr_holiday_documenso_signing
+>
+> **Extends:** ssi_hr_holiday — model `hr.leave`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: at Flow base step 2 (open the record to approve), the form already shows a
+  **Signature Requests** tab (injected because `_documenso_signing_create_page = True`).
+  This tab is always present once this module is installed, regardless of whether
+  Documenso signing is actually used for the current approval.
+- The behavior below only applies **when the record's active Approval Template has a
+  Documenso Signing Template configured**. If it does not, the base Flow (steps 3–4,
+  Click **Approve** / click **OK**) applies unchanged, exactly as documented in
+  `ssi_hr_holiday/docs/hr_leave/05-approve.md`.
+- When a Documenso Signing Template **is** configured: no per-approver approval record
+  is created for this document — a single `documenso.signature.request` is created and
+  linked instead (during the earlier Confirm action, before this record reaches
+  **Waiting for Approval**). Because there is no per-approver record naming the current
+  user as an active approver, the **Approve** button (Flow base step 3) stays invisible
+  for every user — it can never be clicked.
+- Instead of clicking Approve, the user opens the linked request — shown under the
+  **Approval Signing Request** group as the **Approval Signature Request** field in the
+  **Signature Requests** tab (or via the **Open Signature Requests** button in the same
+  tab) — and, on that request's own form, clicks **Send to Documenso** to send the
+  document for e-signature. The designated signer(s) then sign the document outside
+  Odoo, in Documenso.
+- Approval completes automatically — without any button click on this Leave record —
+  once the linked signature request reaches the **Signed** status (checked manually via
+  **Check Status** on the request, or synced automatically by the connector). At that
+  point, the base Post-Condition applies as usual: status automatically changes to
+  **Done** (or remains **Waiting for Approval** if other approval levels are still
+  pending).
+- If the linked signature request is **cancelled** instead (e.g. a signer declines in
+  Documenso), the record moves directly to **Rejected** — the same end state as the base
+  Reject action, but triggered automatically by the cancelled request rather than by a
+  user clicking Reject.

--- a/ssi_hr_holiday_documenso_signing/docs/hr_leave_allocation/05-approve.md
+++ b/ssi_hr_holiday_documenso_signing/docs/hr_leave_allocation/05-approve.md
@@ -1,0 +1,38 @@
+# Approve Leave Allocation
+
+> **Module:** ssi_hr_holiday_documenso_signing
+>
+> **Extends:** ssi_hr_holiday — model `hr.leave_allocation`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: at Flow base step 2 (open the record to approve), the form already shows a
+  **Signature Requests** tab (injected because `_documenso_signing_create_page = True`).
+  This tab is always present once this module is installed, regardless of whether
+  Documenso signing is actually used for the current approval.
+- The behavior below only applies **when the record's active Approval Template has a
+  Documenso Signing Template configured**. If it does not, the base Flow (steps 3–4,
+  Click **Approve** / click **OK**) applies unchanged, exactly as documented in
+  `ssi_hr_holiday/docs/hr_leave_allocation/05-approve.md`.
+- When a Documenso Signing Template **is** configured: no per-approver approval record
+  is created for this document — a single `documenso.signature.request` is created and
+  linked instead (during the earlier Confirm action, before this record reaches
+  **Waiting for Approval**). Because there is no per-approver record naming the current
+  user as an active approver, the **Approve** button (Flow base step 3) stays invisible
+  for every user — it can never be clicked.
+- Instead of clicking Approve, the user opens the linked request — shown under the
+  **Approval Signing Request** group as the **Approval Signature Request** field in the
+  **Signature Requests** tab (or via the **Open Signature Requests** button in the same
+  tab) — and, on that request's own form, clicks **Send to Documenso** to send the
+  document for e-signature. The designated signer(s) then sign the document outside
+  Odoo, in Documenso.
+- Approval completes automatically — without any button click on this Leave Allocation
+  record — once the linked signature request reaches the **Signed** status (checked
+  manually via **Check Status** on the request, or synced automatically by the
+  connector). At that point, the base Post-Condition applies as usual: status
+  automatically changes to **In Progress** (or remains **Waiting for Approval** if other
+  approval levels are still pending).
+- If the linked signature request is **cancelled** instead (e.g. a signer declines in
+  Documenso), the record moves directly to **Rejected** — the same end state as the base
+  Reject action, but triggered automatically by the cancelled request rather than by a
+  user clicking Reject.

--- a/ssi_hr_holiday_documenso_signing/models/hr_leave.py
+++ b/ssi_hr_holiday_documenso_signing/models/hr_leave.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class HrLeave(models.Model):
+    """Enable Documenso-signed approval on time off requests.
+
+    Adds the Documenso Signing tab to the ``hr.leave`` form and lets an
+    ``approval.template`` route this document to a single
+    ``documenso.signature.request`` instead of the regular approval-record
+    flow, whenever the template defines a
+    ``documenso_signing_template_id``.
+    """
+
     _name = "hr.leave"
     _inherit = [
         "hr.leave",

--- a/ssi_hr_holiday_documenso_signing/models/hr_leave_allocation.py
+++ b/ssi_hr_holiday_documenso_signing/models/hr_leave_allocation.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class HrLeaveAllocation(models.Model):
+    """Enable Documenso-signed approval on leave allocations.
+
+    Adds the Documenso Signing tab to the ``hr.leave_allocation`` form and
+    lets an ``approval.template`` route this document to a single
+    ``documenso.signature.request`` instead of the regular approval-record
+    flow, whenever the template defines a
+    ``documenso_signing_template_id``.
+    """
+
     _name = "hr.leave_allocation"
     _inherit = [
         "hr.leave_allocation",

--- a/ssi_hr_holiday_documenso_signing/static/tests/tours/hr_leave_allocation_tour.js
+++ b/ssi_hr_holiday_documenso_signing/static/tests/tours/hr_leave_allocation_tour.js
@@ -1,0 +1,122 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_hr_holiday_documenso_signing.hr_leave_allocation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/hr_leave_allocation/05-approve.md (E2a delta --
+    // Modified Flow)
+    // Navigation (open menu -> open record) is retraced from the
+    // base IK ssi_hr_holiday/docs/hr_leave_allocation/05-approve.md
+    // Flow steps 1-2 -- see skill odoo-development-ui-test,
+    // scope-and-boundaries.md §3 ("E2a -- telusur-ulang aksi itu
+    // dari base sampai titik ubah"). The delta assertion, anchored
+    // at base Flow step 2 (open the record to approve), verifies
+    // the Signature Requests tab injected because
+    // `_documenso_signing_create_page = True`, then stops -- base
+    // Flow steps 3-4 (Approve / OK) and the resulting In Progress
+    // status are NOT exercised here, since whether the Approve
+    // button is even visible depends on whether the active
+    // Approval Template has a Documenso Signing Template
+    // configured, and this tour's fixture leaves that
+    // unconfigured. The final signed/rejected outcome is driven by
+    // the external Documenso connector and out of scope for a tour
+    // (Keputusan Desain, issue
+    // open-synergy/opnsynid-hr-timesheet#201).
+    tour.register(
+        "ssi_hr_holiday_documenso_signing_hr_leave_allocation_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Human Resource > Timesheets >
+            // Leave Allocations menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leave Allocations menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.menu_hr_leave_allocation"]',
+            },
+            {
+                // Gate: wait for the TARGET action to be mounted, not
+                // just any list view (the app may land on a stale
+                // list first).
+                content: "Leave Allocations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(" +
+                    "Leave Allocations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(Tour HR Holiday Documenso " +
+                    "Allocation Employee) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record form is displayed",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+
+            // ── Delta assertion (anchor: base Flow step 2) — the
+            // Signature Requests tab is always present once this
+            // module is installed, regardless of whether Documenso
+            // signing is actually used for the current approval.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored on the group label rather than the
+                // (currently empty) `approval_signature_request_id`
+                // many2one widget itself -- a many2one rendered with
+                // no value has no text node inside its link, so it
+                // collapses to a zero-size box and jQuery's
+                // `:visible` (offsetWidth/offsetHeight) never
+                // matches it, hanging the tour until timeout. The
+                // group label always has text, so it is a stable
+                // proxy for "the Approval Signing Request group is
+                // rendered".
+                content:
+                    "Signature Requests tab shows the Approval Signing " +
+                    "Request group",
+                trigger:
+                    ".o_horizontal_separator:contains(Approval Signing " + "Request)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action. The tour stops here -- it does not click
+                    // Approve, does not assert a final state, and
+                    // never calls the external Documenso service.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_hr_holiday_documenso_signing/static/tests/tours/hr_leave_tour.js
+++ b/ssi_hr_holiday_documenso_signing/static/tests/tours/hr_leave_tour.js
@@ -1,0 +1,110 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_hr_holiday_documenso_signing.hr_leave_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/hr_leave/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record) is retraced from the base IK
+    // ssi_hr_holiday/docs/hr_leave/05-approve.md Flow steps 1-2 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("E2a
+    // -- telusur-ulang aksi itu dari base sampai titik ubah"). The delta
+    // assertion, anchored at base Flow step 2 (open the record to
+    // approve), verifies the Signature Requests tab injected because
+    // `_documenso_signing_create_page = True`, then stops -- base Flow
+    // steps 3-4 (Approve / OK) and the resulting Done status are NOT
+    // exercised here, since whether the Approve button is even visible
+    // depends on whether the active Approval Template has a Documenso
+    // Signing Template configured, and this tour's fixture leaves that
+    // unconfigured. The final signed/rejected outcome is driven by the
+    // external Documenso connector and out of scope for a tour
+    // (Keputusan Desain, issue
+    // open-synergy/opnsynid-hr-timesheet#201).
+    tour.register(
+        "ssi_hr_holiday_documenso_signing_hr_leave_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Human Resource > Timesheets >
+            // Leaves menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leaves menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.menu_hr_leave"]',
+            },
+            {
+                // Gate: wait for the TARGET action to be mounted, not
+                // just any list view (the app may land on a stale list
+                // first).
+                content: "Leaves list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Leaves)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(Tour HR Holiday Documenso Leave Employee) " +
+                    ".o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record form is displayed",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // ── Delta assertion (anchor: base Flow step 2) — the
+            // Signature Requests tab is always present once this module
+            // is installed, regardless of whether Documenso signing is
+            // actually used for the current approval.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored on the group label rather than the (currently
+                // empty) `approval_signature_request_id` many2one widget
+                // itself -- a many2one rendered with no value has no text
+                // node inside its link, so it collapses to a zero-size
+                // box and jQuery's `:visible` (offsetWidth/offsetHeight)
+                // never matches it, hanging the tour until timeout. The
+                // group label always has text, so it is a stable proxy
+                // for "the Approval Signing Request group is rendered".
+                content:
+                    "Signature Requests tab shows the Approval Signing " +
+                    "Request group",
+                trigger: ".o_horizontal_separator:contains(Approval Signing Request)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                    // The tour stops here -- it does not click Approve, does
+                    // not assert a final state, and never calls the external
+                    // Documenso service.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_hr_holiday_documenso_signing/tests/__init__.py
+++ b/ssi_hr_holiday_documenso_signing/tests/__init__.py
@@ -2,4 +2,8 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import test_hr_holiday_documenso_signing
+from . import (
+    test_hr_holiday_documenso_signing,
+    test_ui_hr_leave,
+    test_ui_hr_leave_allocation,
+)

--- a/ssi_hr_holiday_documenso_signing/tests/test_hr_holiday_documenso_signing.py
+++ b/ssi_hr_holiday_documenso_signing/tests/test_hr_holiday_documenso_signing.py
@@ -9,5 +9,10 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrHolidayDocumensoSigning(YamlTransactionCase):
+    """Cover ``hr.leave`` and ``hr.leave_allocation`` with the Documenso
+    signing approval mixin applied.
+    """
+
     def test_hr_holiday_documenso_signing(self):
+        """Run the leave and leave allocation creation scenarios."""
         self.run_yaml_scenario("test_data_hr_holiday_documenso_signing.yaml")

--- a/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave.py
+++ b/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave.py
@@ -26,12 +26,18 @@ class TestUiHrLeave(HttpSavepointCase):
         ``_check_leave_allocation_available`` when the type needs
         allocation and none is available (see
         ``ssi_hr_holiday/tests/test_data_hr_holiday.yaml``, "Sick Leave
-        Test", for the same pattern). Pre-Condition IK 05-approve.md
-        (delta): the record is already Waiting for Approval, reached
-        here via ``action_confirm()`` in Python, not via UI clicks. The
-        "Standard" approval template used by ``ssi_hr_holiday`` demo
-        data has no Documenso Signing Template configured, so the
-        Signature Requests tab is present
+        Test", for the same pattern). An ``hr.timesheet`` covering the
+        leave's date range is also created for the employee --
+        ``_constrains_sheet_id`` requires ``sheet_id`` (computed from a
+        matching ``hr.timesheet``) to be set once ``sheet_id`` is
+        (re)computed and flushed, which can happen well after
+        ``action_confirm()`` returns (e.g. during a later test's own
+        ``setUp()``), so the timesheet must exist regardless. Pre-
+        Condition IK 05-approve.md (delta): the record is already
+        Waiting for Approval, reached here via ``action_confirm()`` in
+        Python, not via UI clicks. The "Standard" approval template
+        used by ``ssi_hr_holiday`` demo data has no Documenso Signing
+        Template configured, so the Signature Requests tab is present
         (``_documenso_signing_create_page = True``) but the base
         Approve/OK Flow is unaffected -- this tour does not exercise
         it.
@@ -55,6 +61,18 @@ class TestUiHrLeave(HttpSavepointCase):
                 }
             )
         )
+        # Pre-Condition (implicit, `_constrains_sheet_id`): the leave's
+        # date range must fall within an existing hr.timesheet for the
+        # same employee, or `action_confirm()` is rejected with
+        # "Timesheet not found for employee ...".
+        cls.env["hr.timesheet"].with_user(cls.admin).create(
+            {
+                "employee_id": employee.id,
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+                "working_schedule_id": cls.env.company.resource_calendar_id.id,
+            }
+        )
         cls.leave = (
             cls.env["hr.leave"]
             .with_user(cls.admin)
@@ -62,8 +80,8 @@ class TestUiHrLeave(HttpSavepointCase):
                 {
                     "employee_id": employee.id,
                     "type_id": leave_type.id,
-                    "date_start": "2026-01-15 08:00:00",
-                    "date_end": "2026-01-15 17:00:00",
+                    "date_start": "2026-01-15",
+                    "date_end": "2026-01-15",
                 }
             )
         )

--- a/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave.py
+++ b/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave.py
@@ -19,12 +19,19 @@ class TestUiHrLeave(HttpSavepointCase):
         ``hr_leave_validator_group`` (which implies the ``User`` and
         ``Viewer`` groups) via ``ssi_hr_holiday``'s
         ``security/res_group_data.xml``, so it can create and confirm
-        the record directly, without extra group setup. Pre-Condition
-        IK 05-approve.md (delta): the record is already Waiting for
-        Approval, reached here via ``action_confirm()`` in Python, not
-        via UI clicks. The "Standard" approval template used by
-        ``ssi_hr_holiday`` demo data has no Documenso Signing Template
-        configured, so the Signature Requests tab is present
+        the record directly, without extra group setup. A dedicated
+        Leave Type with ``need_allocation = False`` is created rather
+        than reusing an arbitrary demo Leave Type -- ``action_confirm``
+        rejects the record via ``_constrains_confirm`` /
+        ``_check_leave_allocation_available`` when the type needs
+        allocation and none is available (see
+        ``ssi_hr_holiday/tests/test_data_hr_holiday.yaml``, "Sick Leave
+        Test", for the same pattern). Pre-Condition IK 05-approve.md
+        (delta): the record is already Waiting for Approval, reached
+        here via ``action_confirm()`` in Python, not via UI clicks. The
+        "Standard" approval template used by ``ssi_hr_holiday`` demo
+        data has no Documenso Signing Template configured, so the
+        Signature Requests tab is present
         (``_documenso_signing_create_page = True``) but the base
         Approve/OK Flow is unaffected -- this tour does not exercise
         it.
@@ -37,7 +44,17 @@ class TestUiHrLeave(HttpSavepointCase):
             .with_user(cls.admin)
             .create({"name": "Tour HR Holiday Documenso Leave Employee"})
         )
-        leave_type = cls.env["hr.leave_type"].search([], limit=1, order="id asc")
+        leave_type = (
+            cls.env["hr.leave_type"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "Tour HR Holiday Documenso Leave Type",
+                    "code": "TOURHHDLT",
+                    "need_allocation": False,
+                }
+            )
+        )
         cls.leave = (
             cls.env["hr.leave"]
             .with_user(cls.admin)

--- a/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave.py
+++ b/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave.py
@@ -1,0 +1,64 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. In 14.0, plain HttpCase does not
+# set up cls.env in setUpClass; HttpSavepointCase does.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeave(HttpSavepointCase):
+    """Tour test for the ``hr.leave`` Documenso signing delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a Leave already Waiting for Approval.
+
+        ``base.user_admin`` is already a member of
+        ``hr_leave_validator_group`` (which implies the ``User`` and
+        ``Viewer`` groups) via ``ssi_hr_holiday``'s
+        ``security/res_group_data.xml``, so it can create and confirm
+        the record directly, without extra group setup. Pre-Condition
+        IK 05-approve.md (delta): the record is already Waiting for
+        Approval, reached here via ``action_confirm()`` in Python, not
+        via UI clicks. The "Standard" approval template used by
+        ``ssi_hr_holiday`` demo data has no Documenso Signing Template
+        configured, so the Signature Requests tab is present
+        (``_documenso_signing_create_page = True``) but the base
+        Approve/OK Flow is unaffected -- this tour does not exercise
+        it.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        employee = (
+            cls.env["hr.employee"]
+            .with_user(cls.admin)
+            .create({"name": "Tour HR Holiday Documenso Leave Employee"})
+        )
+        leave_type = cls.env["hr.leave_type"].search([], limit=1, order="id asc")
+        cls.leave = (
+            cls.env["hr.leave"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "employee_id": employee.id,
+                    "type_id": leave_type.id,
+                    "date_start": "2026-01-15 08:00:00",
+                    "date_end": "2026-01-15 17:00:00",
+                }
+            )
+        )
+        cls.leave.with_context(bypass_policy_check=True).action_confirm()
+
+    def test_approve(self):
+        """Run the approve tour for the Documenso signing delta.
+
+        IK: docs/hr_leave/05-approve.md (E2a delta -- Modified Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_holiday_documenso_signing_hr_leave_approve",
+            login="admin",
+        )

--- a/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave_allocation.py
+++ b/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave_allocation.py
@@ -19,7 +19,13 @@ class TestUiHrLeaveAllocation(HttpSavepointCase):
         ``hr_leave_allocation_validator_group`` (which implies the
         ``User`` and ``Viewer`` groups) via ``ssi_hr_holiday``'s
         ``security/res_group_data.xml``, so it can create and confirm
-        the record directly, without extra group setup. Pre-Condition
+        the record directly, without extra group setup. A dedicated
+        Leave Type is created rather than reusing an arbitrary demo
+        Leave Type, to keep this fixture isolated from demo data (see
+        ``test_ui_hr_leave.py`` for why that matters on ``hr.leave``'s
+        own confirm; it does not affect ``hr.leave_allocation``'s
+        confirm, which has no allocation-availability constraint of its
+        own, but isolation is kept consistent either way). Pre-Condition
         IK 05-approve.md (delta): the record is already Waiting for
         Approval, reached here via ``action_confirm()`` in Python, not
         via UI clicks. The "Standard" approval template used by
@@ -37,7 +43,17 @@ class TestUiHrLeaveAllocation(HttpSavepointCase):
             .with_user(cls.admin)
             .create({"name": "Tour HR Holiday Documenso Allocation Employee"})
         )
-        leave_type = cls.env["hr.leave_type"].search([], limit=1, order="id asc")
+        leave_type = (
+            cls.env["hr.leave_type"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "Tour HR Holiday Documenso Allocation Type",
+                    "code": "TOURHHDALT",
+                    "need_allocation": True,
+                }
+            )
+        )
         cls.allocation = (
             cls.env["hr.leave_allocation"]
             .with_user(cls.admin)

--- a/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave_allocation.py
+++ b/ssi_hr_holiday_documenso_signing/tests/test_ui_hr_leave_allocation.py
@@ -1,0 +1,67 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. In 14.0, plain HttpCase does not
+# set up cls.env in setUpClass; HttpSavepointCase does.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveAllocation(HttpSavepointCase):
+    """Tour test for the ``hr.leave_allocation`` Documenso signing delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a Leave Allocation already Waiting for Approval.
+
+        ``base.user_admin`` is already a member of
+        ``hr_leave_allocation_validator_group`` (which implies the
+        ``User`` and ``Viewer`` groups) via ``ssi_hr_holiday``'s
+        ``security/res_group_data.xml``, so it can create and confirm
+        the record directly, without extra group setup. Pre-Condition
+        IK 05-approve.md (delta): the record is already Waiting for
+        Approval, reached here via ``action_confirm()`` in Python, not
+        via UI clicks. The "Standard" approval template used by
+        ``ssi_hr_holiday`` demo data has no Documenso Signing Template
+        configured, so the Signature Requests tab is present
+        (``_documenso_signing_create_page = True``) but the base
+        Approve/OK Flow is unaffected -- this tour does not exercise
+        it.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        employee = (
+            cls.env["hr.employee"]
+            .with_user(cls.admin)
+            .create({"name": "Tour HR Holiday Documenso Allocation Employee"})
+        )
+        leave_type = cls.env["hr.leave_type"].search([], limit=1, order="id asc")
+        cls.allocation = (
+            cls.env["hr.leave_allocation"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "employee_id": employee.id,
+                    "type_id": leave_type.id,
+                    "number_of_days": 3,
+                    "date_start": "2026-01-01",
+                    "date_end": "2026-12-31",
+                    "date_extended": "2026-12-31",
+                }
+            )
+        )
+        cls.allocation.with_context(bypass_policy_check=True).action_confirm()
+
+    def test_approve(self):
+        """Run the approve tour for the Documenso signing delta.
+
+        IK: docs/hr_leave_allocation/05-approve.md (E2a delta --
+        Modified Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_holiday_documenso_signing_hr_leave_allocation_approve",
+            login="admin",
+        )

--- a/ssi_hr_holiday_documenso_signing/views/assets.xml
+++ b/ssi_hr_holiday_documenso_signing/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_holiday_documenso_signing assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday_documenso_signing/static/tests/tours/hr_leave_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday_documenso_signing/static/tests/tours/hr_leave_allocation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` menemukan 7 pelanggaran ERROR pada modul `ssi_hr_holiday_documenso_signing` (validator `module`, `ik`, `unit-test`). PR ini menyelesaikan seluruhnya tanpa mengubah perilaku:

* Menambahkan docstring pada class & method di `models/hr_leave.py`, `models/hr_leave_allocation.py`, dan `tests/test_hr_holiday_documenso_signing.py`.
* Menulis IK delta (arketipe E2a) untuk aksi Approve pada `hr.leave` dan `hr.leave_allocation` di `docs/`, mendokumentasikan tab **Signature Requests** yang selalu tampil dan perubahan alur approval saat `approval.template` memiliki Documenso Signing Template terkonfigurasi.
* Menambahkan tour UI delta untuk kedua IK tersebut (`static/tests/tours/`) berikut bundle `web.assets_tests` dan test `HttpCase`-nya (`tests/test_ui_hr_leave.py`, `tests/test_ui_hr_leave_allocation.py`).
* Memperbarui `README.rst` dengan bagian Work Instruction.

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_hr_holiday_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_holiday_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_holiday_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_holiday_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_holiday_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_holiday_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Gate pra-commit (`pre-commit-gate.sh`): `GATE OK: 6 pemeriksaan, 0 pelanggaran baru.`

Closes #201

🤖 Generated with Claude Code — eksekusi backlog otomatis