### PR TITLE
[UPD] ssi_hr_holiday - kepatuhan skill 14.0

### DIFF
--- a/ssi_hr_holiday/models/hr_leave.py
+++ b/ssi_hr_holiday/models/hr_leave.py
@@ -10,7 +10,14 @@ from odoo.exceptions import Warning as UserError
 from odoo.addons.ssi_decorator import ssi_decorator
 
 
-class HRLeave(models.Model):
+class HrLeave(models.Model):
+    """
+    Represents an employee leave request.
+    Tracks the leave lifecycle from draft through approval to done,
+    computing the covering timesheet, matching attendance schedules,
+    leave duration, and the leave allocation the request draws from.
+    """
+
     _name = "hr.leave"
     _inherit = [
         "mixin.transaction_confirm",
@@ -78,6 +85,13 @@ class HRLeave(models.Model):
         "date_end",
     )
     def _compute_sheet(self):
+        """Resolve the timesheet that covers this leave's period.
+
+        Searches ``hr.timesheet`` for a sheet belonging to the same
+        employee whose ``date_start``/``date_end`` bounds the leave's
+        ``date_start``/``date_end``. Leaves this field empty when no
+        such sheet exists.
+        """
         obj_sheet = self.env["hr.timesheet"]
         for record in self:
             sheet_id = False
@@ -106,6 +120,12 @@ class HRLeave(models.Model):
         "employee_id",
     )
     def _compute_schedule_ids(self):
+        """Collect the attendance schedules covered by this leave.
+
+        Searches ``hr.timesheet_attendance_schedule`` for the same
+        employee with a ``date`` between the leave's ``date_start``
+        and ``date_end``.
+        """
         AttendanceSchedule = self.env["hr.timesheet_attendance_schedule"]
         for record in self:
             if record.date_start and record.date_end and record.employee_id:
@@ -143,6 +163,11 @@ class HRLeave(models.Model):
         "date_end",
     )
     def _compute_leave_duration(self):
+        """Compute the leave duration in days.
+
+        Starts from the number of covered ``schedule_ids`` and
+        subtracts any day that falls on a public holiday.
+        """
         PublicHoliday = self.env["base.public.holiday"]
         for record in self:
             leave_duration = 0
@@ -182,6 +207,11 @@ class HRLeave(models.Model):
         "date_end",
     )
     def _compute_leave_allocation_id(self):
+        """Resolve the leave allocation this request draws from.
+
+        Delegates to ``_get_leave_allocation`` once ``type_id``,
+        ``employee_id``, ``date_start`` and ``date_end`` are all set.
+        """
         for record in self:
             result = False
             if (
@@ -217,7 +247,7 @@ class HRLeave(models.Model):
 
     @api.model
     def _get_policy_field(self):
-        res = super(HRLeave, self)._get_policy_field()
+        res = super(HrLeave, self)._get_policy_field()
         policy_field = [
             "confirm_ok",
             "approve_ok",
@@ -235,6 +265,11 @@ class HRLeave(models.Model):
         "employee_id",
     )
     def onchange_policy_template_id(self):
+        """Set the policy template when ``employee_id`` changes.
+
+        Resolves the template through ``_get_template_policy`` so the
+        approval policy fields follow the selected employee.
+        """
         template_id = self._get_template_policy()
         self.policy_template_id = template_id
 
@@ -245,6 +280,17 @@ class HRLeave(models.Model):
         self.number_of_days = self.leave_duration
 
     def _get_leave_allocation(self):
+        """Find the leave allocation to draw this request's days from.
+
+        Searches ``hr.leave_allocation`` for an ``open`` record of the
+        same ``type_id``/``employee_id`` with enough available days
+        and a date range covering this request, ordered by
+        ``date_start`` so the oldest matching allocation is used
+        first.
+
+        :return: a single ``hr.leave_allocation`` record, or an empty
+            recordset when none matches
+        """
         self.ensure_one()
         LeaveAllocation = self.env["hr.leave_allocation"]
         criteria = [
@@ -262,6 +308,11 @@ class HRLeave(models.Model):
 
     @api.constrains("sheet_id")
     def _constrains_sheet_id(self):
+        """Require a covering timesheet for every leave request.
+
+        Raises ``UserError`` when ``sheet_id`` is empty, meaning no
+        ``hr.timesheet`` covers this leave's employee and date range.
+        """
         for record in self.sudo():
             if not record.sheet_id:
                 error_message = _(
@@ -277,6 +328,12 @@ class HRLeave(models.Model):
 
     @api.constrains("date_start", "date_end", "employee_id")
     def _constrains_overlap(self):
+        """Forbid leave requests whose dates overlap another request.
+
+        Delegates the check to ``_check_overlap`` and raises
+        ``UserError`` when an overlapping, non-cancelled/rejected
+        leave already exists for the same employee.
+        """
         for record in self.sudo():
             if not record._check_overlap():
                 error_message = _(
@@ -292,6 +349,12 @@ class HRLeave(models.Model):
 
     @api.constrains("type_id", "number_of_days")
     def _constrains_limit_request(self):
+        """Enforce the leave type's per-request day limit.
+
+        Delegates to ``_check_limit_per_request`` and raises
+        ``UserError`` when ``number_of_days`` exceeds the leave
+        type's ``limit_per_request``.
+        """
         for record in self.sudo():
             limit = record.type_id.limit_per_request
             if not record._check_limit_per_request():
@@ -308,6 +371,13 @@ class HRLeave(models.Model):
 
     @api.constrains("state")
     def _constrains_confirm(self):
+        """Require an available leave allocation to confirm a leave.
+
+        Only checks records whose ``state`` is ``confirm``; delegates
+        to ``_check_leave_allocation_available`` and raises
+        ``UserError`` when the leave type needs an allocation but
+        none is available with enough days.
+        """
         for record in self.sudo():
             if record.state != "confirm":
                 break
@@ -327,6 +397,12 @@ class HRLeave(models.Model):
                 raise UserError(_(error_message))
 
     def _check_overlap(self):
+        """Check whether this leave overlaps another active leave.
+
+        :return: ``False`` when another non-cancelled/rejected leave
+            of the same employee overlaps this record's date range,
+            ``True`` otherwise
+        """
         self.ensure_one()
         result = True
         Leave = self.env["hr.leave"]
@@ -344,6 +420,12 @@ class HRLeave(models.Model):
         return result
 
     def _check_limit_per_request(self):
+        """Check ``number_of_days`` against the leave type's limit.
+
+        :return: ``False`` when the leave type applies a per-request
+            limit and ``number_of_days`` exceeds it, ``True``
+            otherwise
+        """
         self.ensure_one()
         result = True
         if (
@@ -354,6 +436,12 @@ class HRLeave(models.Model):
         return result
 
     def _check_leave_allocation_available(self):
+        """Check that an allocation is available when one is needed.
+
+        :return: ``False`` when the leave type requires an allocation
+            (``need_allocation``) but ``leave_allocation_id`` is
+            empty, ``True`` otherwise
+        """
         self.ensure_one()
         result = True
         if self.type_id.need_allocation:
@@ -363,6 +451,12 @@ class HRLeave(models.Model):
 
     @ssi_decorator.pre_confirm_action()
     def _compute_schedule_leave_allocation(self):
+        """Refresh schedules and allocation right before confirming.
+
+        Runs as a ``pre_confirm_action`` hook so ``schedule_ids`` and
+        ``leave_allocation_id`` reflect the latest data before the
+        confirm policy checks are evaluated.
+        """
         self.ensure_one()
         if not self.schedule_ids:
             self._compute_schedule_ids()
@@ -370,9 +464,20 @@ class HRLeave(models.Model):
 
     @ssi_decorator.pre_cancel_action()
     def _reopen_leave_allocation(self):
+        """Reopen a ``done`` leave allocation when cancelling a leave.
+
+        Runs as a ``pre_cancel_action`` hook so days freed by the
+        cancellation become available again on the allocation.
+        """
         self.ensure_one()
         leave_allocation_ids = self.mapped("leave_allocation_id").filtered(
             lambda allocation: allocation.state == "done"
         )
         if leave_allocation_ids:
             leave_allocation_ids.action_open()
+
+    @ssi_decorator.insert_on_form_view()
+    def _insert_form_element(self, view_arch):
+        if self._automatically_insert_view_element:
+            view_arch = self._reconfigure_statusbar_visible(view_arch)
+        return view_arch

--- a/ssi_hr_holiday/models/hr_leave_allocation.py
+++ b/ssi_hr_holiday/models/hr_leave_allocation.py
@@ -6,8 +6,17 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import pytz
 
+from odoo.addons.ssi_decorator import ssi_decorator
+
 
 class HrLeaveAllocation(models.Model):
+    """
+    Represents an allocation of leave days granted to an employee.
+    Tracks how many days were granted, used, planned, and still
+    available, and automatically terminates allocations past their
+    extended expiry date via a scheduled action.
+    """
+
     _name = "hr.leave_allocation"
     _inherit = [
         "mixin.transaction_confirm",
@@ -89,6 +98,12 @@ class HrLeaveAllocation(models.Model):
         "number_of_days",
     )
     def _compute_num_of_days(self):
+        """Compute used, planned and available days on this allocation.
+
+        Sums ``number_of_days`` of ``leave_ids`` grouped by state
+        (``done`` counts as used, ``confirm`` counts as planned), and
+        derives available days as ``number_of_days`` minus both.
+        """
         for leave in self:
             num_of_days_used = num_of_days_planned = 0.0
             for record in leave.leave_ids:
@@ -179,6 +194,12 @@ class HrLeaveAllocation(models.Model):
 
     @api.depends("policy_template_id")
     def _compute_policy(self):
+        """Recompute approval policy on ``policy_template_id`` change.
+
+        Overridden only to add ``policy_template_id`` as an explicit
+        dependency on top of the mixin's own compute; delegates the
+        whole computation to ``super()``.
+        """
         _super = super(HrLeaveAllocation, self)
         _super._compute_policy()
 
@@ -204,11 +225,22 @@ class HrLeaveAllocation(models.Model):
         "employee_id",
     )
     def onchange_policy_template_id(self):
+        """Set the policy template when ``employee_id`` changes.
+
+        Resolves the template through ``_get_template_policy`` so the
+        approval policy fields follow the selected employee.
+        """
         template_id = self._get_template_policy()
         self.policy_template_id = template_id
 
     @api.constrains("state")
     def _constrains_leave(self):
+        """Forbid cancelling an allocation that still has active leaves.
+
+        Delegates to ``_check_leave`` and raises ``UserError`` when
+        the allocation is being cancelled while it still has leaves
+        that are not ``cancel``/``reject``.
+        """
         for record in self.sudo():
             if record.state == "cancel" and not record._check_leave():
                 error_message = _(
@@ -228,6 +260,12 @@ class HrLeaveAllocation(models.Model):
         "employee_id",
     )
     def _constrains_overlap(self):
+        """Forbid allocations whose dates overlap another allocation.
+
+        Delegates the check to ``_check_overlap`` and raises
+        ``UserError`` when an overlapping, non-cancelled/rejected
+        allocation already exists for the same employee.
+        """
         for record in self.sudo():
             if not record._check_overlap():
                 error_message = _(
@@ -242,6 +280,11 @@ class HrLeaveAllocation(models.Model):
                 raise UserError(error_message)
 
     def _check_leave(self):
+        """Check that no active leave still references this allocation.
+
+        :return: ``False`` when ``leave_ids`` has a leave whose state
+            is not ``cancel``/``reject``, ``True`` otherwise
+        """
         result = True
         if self.leave_ids.filtered(
             lambda leave: leave.state not in ("cancel", "reject")
@@ -250,6 +293,12 @@ class HrLeaveAllocation(models.Model):
         return result
 
     def _check_overlap(self):
+        """Check whether this allocation overlaps another allocation.
+
+        :return: ``False`` when another non-cancelled/rejected
+            allocation of the same employee overlaps this record's
+            date range, ``True`` otherwise
+        """
         self.ensure_one()
         result = True
         criteria = [
@@ -271,6 +320,13 @@ class HrLeaveAllocation(models.Model):
         "date_extended",
     )
     def onchange_date_extended(self):
+        """Keep ``date_extended`` consistent with ``date_end``.
+
+        Resets ``date_extended`` to ``date_end`` when it is empty or
+        ``can_be_extended`` is off, and warns (clamping the value)
+        when a manually set ``date_extended`` is earlier than
+        ``date_end``.
+        """
         if not self.date_extended or not self.can_be_extended:
             self.date_extended = self.date_end
         if self.date_end and self.date_extended < self.date_end:
@@ -283,6 +339,16 @@ class HrLeaveAllocation(models.Model):
             }
 
     def _cron_terminate(self, terminate_reason_code=False):
+        """Terminate allocations whose extended date has passed.
+
+        Scheduled action entry point: searches ``open`` allocations
+        whose ``date_extended`` is before today (in the admin user's,
+        or current user's, timezone) and terminates them using the
+        terminate reason matching ``terminate_reason_code``.
+
+        :param terminate_reason_code: ``code`` of the
+            ``base.terminate_reason`` applied to matched allocations
+        """
         try:
             user_id = self.env.ref("base.user_admin")
         except Exception:
@@ -302,3 +368,9 @@ class HrLeaveAllocation(models.Model):
             limit=1,
         )
         allocation_ids.action_terminate(terminate_reason=terminate_reason__id)
+
+    @ssi_decorator.insert_on_form_view()
+    def _insert_form_element(self, view_arch):
+        if self._automatically_insert_view_element:
+            view_arch = self._reconfigure_statusbar_visible(view_arch)
+        return view_arch

--- a/ssi_hr_holiday/models/hr_leave_type.py
+++ b/ssi_hr_holiday/models/hr_leave_type.py
@@ -6,6 +6,12 @@ from odoo import fields, models
 
 
 class HrLeaveType(models.Model):
+    """
+    Represents a category of leave (e.g. annual, sick, unpaid).
+    Configures whether requests of this type need an allocation to
+    draw from and whether a per-request day limit applies.
+    """
+
     _name = "hr.leave_type"
     _inherit = ["mixin.master_data"]
     _description = "Leave Type"

--- a/ssi_hr_holiday/models/hr_timesheet.py
+++ b/ssi_hr_holiday/models/hr_timesheet.py
@@ -5,7 +5,13 @@
 from odoo import fields, models
 
 
-class HRTimesheet(models.Model):
+class HrTimesheet(models.Model):
+    """
+    Adds leave traceability to timesheets.
+    Links each leave request whose period this timesheet covers back
+    to the timesheet, so leaves are visible from their sheet.
+    """
+
     _name = "hr.timesheet"
     _inherit = "hr.timesheet"
 

--- a/ssi_hr_holiday/models/hr_timesheet_attendance_schedule.py
+++ b/ssi_hr_holiday/models/hr_timesheet_attendance_schedule.py
@@ -5,7 +5,13 @@
 from odoo import fields, models
 
 
-class HRTimesheetAttendanceSchedule(models.Model):
+class HrTimesheetAttendanceSchedule(models.Model):
+    """
+    Adds leave traceability to attendance schedule days.
+    Links each leave request that covers this schedule day back to
+    it, so a schedule day shows which leaves apply to it.
+    """
+
     _name = "hr.timesheet_attendance_schedule"
     _inherit = "hr.timesheet_attendance_schedule"
 

--- a/ssi_hr_holiday/tests/test_hr_holiday.py
+++ b/ssi_hr_holiday/tests/test_hr_holiday.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrHoliday(YamlTransactionCase):
+    """Cover ``hr.leave`` and ``hr.leave_allocation`` CRUD and rules."""
+
     def test_hr_holiday(self):
+        """Run the ``hr.leave``/``hr.leave_allocation`` YAML scenario."""
         self.run_yaml_scenario("test_data_hr_holiday.yaml")


### PR DESCRIPTION
## Ringkasan

Memperbaiki temuan sapuan kepatuhan `audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` pada modul `ssi_hr_holiday`:

- Menambahkan `_insert_form_element()` pada `hr.leave` dan `hr.leave_allocation` mengikuti pola mixin SSI yang sudah dipakai modul lain di repo ini.
- Mengganti nama class Python ke PascalCase turunan `_name`: `HRLeave` -> `HrLeave`, `HRTimesheet` -> `HrTimesheet`, `HRTimesheetAttendanceSchedule` -> `HrTimesheetAttendanceSchedule`. Class Python tidak direferensikan XML/ACL, jadi perubahan ini lokal ke berkasnya.
- Melengkapi docstring pada setiap class & method yang ditemukan validator `module` dan `unit-test`, termasuk pada berkas `tests/`.

Murni kepatuhan/refactor — tidak ada perubahan perilaku maupun field baru.

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_hr_holiday series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_holiday series=14.0 error=0 warn=9 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_holiday series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_holiday series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_holiday series=14.0 error=0 warn=2 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_holiday series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-hr-timesheet modules=1 failed=0 skipped=0 status=OK`

Peringatan (`!`) di luar lingkup issue ini (butuh konfirmasi manusia terpisah, kontrak validator §5b).

Closes #202