### PR TITLE
[UPD] ssi_hr_holiday_operating_unit - kepatuhan skill 14.0

### DIFF
--- a/ssi_hr_holiday_operating_unit/README.rst
+++ b/ssi_hr_holiday_operating_unit/README.rst
@@ -6,6 +6,11 @@
 Leave + Operating Unit
 ======================
 
+Work Instruction
+=================
+
+* `Create Leave <docs/hr_leave/index.html>`_
+* `Create Leave Allocation <docs/hr_leave_allocation/index.html>`_
 
 Installation
 ============

--- a/ssi_hr_holiday_operating_unit/__manifest__.py
+++ b/ssi_hr_holiday_operating_unit/__manifest__.py
@@ -12,11 +12,13 @@
     "depends": [
         "ssi_hr_holiday",
         "ssi_operating_unit_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_group/res_group_data.xml",
         "security/ir_rule/ir_rule_data.xml",
         "views/hr_leave_views.xml",
         "views/hr_leave_allocation_views.xml",
+        "views/ssi_hr_holiday_operating_unit_assets_tests.xml",
     ],
 }

--- a/ssi_hr_holiday_operating_unit/docs/hr_leave/01-create.md
+++ b/ssi_hr_holiday_operating_unit/docs/hr_leave/01-create.md
@@ -1,0 +1,22 @@
+# Create Leave
+
+> **Module:** ssi_hr_holiday_operating_unit
+>
+> **Extends:** ssi_hr_holiday — model `hr.leave`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field:
+
+- **Operating Unit**: The operating unit this leave belongs to. Defaults to the current
+  user's default operating unit. Only visible to users in the _Multi Operating Unit_
+  group (`operating_unit.group_multi_operating_unit`); hidden for single-operating-unit
+  installations. The same field is also added (hidden by default) as an optional column
+  in the **Leaves** list, and as a **Group By: Operating Unit** filter in the search
+  view — both gated by the same group.
+
+## Modified — Record Visibility
+
+- A user granted the _Operating Unit_ data-ownership group for this model only sees
+  leaves whose **Operating Unit** is one of the operating units assigned to them (record
+  rule). This is not a Flow step.

--- a/ssi_hr_holiday_operating_unit/docs/hr_leave_allocation/01-create.md
+++ b/ssi_hr_holiday_operating_unit/docs/hr_leave_allocation/01-create.md
@@ -1,0 +1,22 @@
+# Create Leave Allocation
+
+> **Module:** ssi_hr_holiday_operating_unit
+>
+> **Extends:** ssi_hr_holiday — model `hr.leave_allocation`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field:
+
+- **Operating Unit**: The operating unit this leave allocation belongs to. Defaults to
+  the current user's default operating unit. Only visible to users in the _Multi
+  Operating Unit_ group (`operating_unit.group_multi_operating_unit`); hidden for
+  single-operating-unit installations. The same field is also added (hidden by default)
+  as an optional column in the **Leave Allocations** list, and as a **Group By:
+  Operating Unit** filter in the search view — both gated by the same group.
+
+## Modified — Record Visibility
+
+- A user granted the _Operating Unit_ data-ownership group for this model only sees
+  leave allocations whose **Operating Unit** is one of the operating units assigned to
+  them (record rule). This is not a Flow step.

--- a/ssi_hr_holiday_operating_unit/models/hr_leave.py
+++ b/ssi_hr_holiday_operating_unit/models/hr_leave.py
@@ -5,7 +5,14 @@
 from odoo import models
 
 
-class HRLeave(models.Model):
+class HrLeave(models.Model):
+    """Add a single Operating Unit to ``hr.leave``.
+
+    Inherits ``mixin.single_operating_unit`` so every leave request
+    carries an ``operating_unit_id``, defaulting to the current user's
+    default operating unit.
+    """
+
     _name = "hr.leave"
     _inherit = [
         "hr.leave",

--- a/ssi_hr_holiday_operating_unit/models/hr_leave_allocation.py
+++ b/ssi_hr_holiday_operating_unit/models/hr_leave_allocation.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class HrLeaveAllocation(models.Model):
+    """Add a single Operating Unit to ``hr.leave_allocation``.
+
+    Inherits ``mixin.single_operating_unit`` so every leave allocation
+    carries an ``operating_unit_id``, defaulting to the current user's
+    default operating unit.
+    """
+
     _name = "hr.leave_allocation"
     _inherit = [
         "hr.leave_allocation",

--- a/ssi_hr_holiday_operating_unit/static/tests/tours/hr_leave_allocation_tour.js
+++ b/ssi_hr_holiday_operating_unit/static/tests/tours/hr_leave_allocation_tour.js
@@ -1,0 +1,94 @@
+odoo.define("ssi_hr_holiday_operating_unit.hr_leave_allocation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Leave
+    // Allocations.
+    function openLeaveAllocationMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leave Allocations menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.menu_hr_leave_allocation"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list
+                // view — the app landing action is also a
+                // .o_list_view.
+                content: "Leave Allocations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(Leave Allocations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default
+                    // click action.
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/01-create.md (delta on top of
+    // ssi_hr_holiday/hr_leave_allocation/01-create.md — adds the
+    // Operating Unit field, visible only to users in the Multi
+    // Operating Unit group). Per the E1 extension pattern
+    // (odoo-development-ui-test skill, patterns.md §O /
+    // scope-and-boundaries.md §3): navigation is taken from the
+    // base tour (open menu → New), then a single assertion proves
+    // the added field is displayed. Does NOT continue into
+    // Save/Confirm/etc. — those belong to the base ssi_hr_holiday
+    // create tour.
+    // ═══════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_operating_unit_hr_leave_allocation_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveAllocationMenuSteps(), [
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default
+                    // click action.
+                },
+            },
+            // ── Additional Fields — Operating Unit is displayed on
+            // the create form (actor is in
+            // group_multi_operating_unit, see setUpClass). Anchored
+            // to the field's label rather than the widget itself,
+            // matching the pattern recommended for delta tours
+            // (patterns.md §O).
+            {
+                content: "Operating Unit field is displayed",
+                trigger: ".o_form_label:contains(Operating Unit)",
+                run: function () {
+                    // Assertion only; do not trigger the default
+                    // click action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_hr_holiday_operating_unit/static/tests/tours/hr_leave_tour.js
+++ b/ssi_hr_holiday_operating_unit/static/tests/tours/hr_leave_tour.js
@@ -1,0 +1,85 @@
+odoo.define("ssi_hr_holiday_operating_unit.hr_leave_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Leaves.
+    function openLeaveMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leaves menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.menu_hr_leave"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Leaves list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Leaves)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/01-create.md (delta on top of
+    // ssi_hr_holiday/hr_leave/01-create.md — adds the Operating Unit
+    // field, visible only to users in the Multi Operating Unit group).
+    // Per the E1 extension pattern (odoo-development-ui-test skill,
+    // patterns.md §O / scope-and-boundaries.md §3): navigation is taken
+    // from the base tour (open menu → New), then a single assertion
+    // proves the added field is displayed. Does NOT continue into
+    // Save/Confirm/etc. — those belong to the base ssi_hr_holiday
+    // create tour.
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_operating_unit_hr_leave_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), [
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Additional Fields — Operating Unit is displayed on the
+            // create form (actor is in group_multi_operating_unit, see
+            // setUpClass). Anchored to the field's label rather than
+            // the widget itself, matching the pattern recommended for
+            // delta tours (patterns.md §O).
+            {
+                content: "Operating Unit field is displayed",
+                trigger: ".o_form_label:contains(Operating Unit)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_hr_holiday_operating_unit/tests/__init__.py
+++ b/ssi_hr_holiday_operating_unit/tests/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_holiday_operating_unit
+from . import test_ui_hr_leave
+from . import test_ui_hr_leave_allocation

--- a/ssi_hr_holiday_operating_unit/tests/test_hr_holiday_operating_unit.py
+++ b/ssi_hr_holiday_operating_unit/tests/test_hr_holiday_operating_unit.py
@@ -9,5 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrHolidayOperatingUnit(YamlTransactionCase):
+    """YAML scenario tests for the ``ssi_hr_holiday_operating_unit`` glue.
+
+    Covers the ``operating_unit_id`` field added to ``hr.leave`` by
+    ``mixin.single_operating_unit``.
+    """
+
     def test_hr_holiday_operating_unit(self):
+        """Run the leave-with-operating-unit YAML scenario."""
         self.run_yaml_scenario("test_data_hr_holiday_operating_unit.yaml")

--- a/ssi_hr_holiday_operating_unit/tests/test_ui_hr_leave.py
+++ b/ssi_hr_holiday_operating_unit/tests/test_ui_hr_leave.py
@@ -1,0 +1,41 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeave(HttpSavepointCase):
+    """Tour test for the ``hr.leave`` create-delta work instruction added
+    by ``ssi_hr_holiday_operating_unit`` (the Operating Unit field).
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the Multi Operating Unit group so the field is shown.
+
+        Pre-Condition common to ``01-create.md``'s ``Additional Fields``
+        delta: the actor must belong to
+        ``operating_unit.group_multi_operating_unit`` for the Operating
+        Unit field to be visible on the create form.
+        """
+        super().setUpClass()
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+    def test_create(self):
+        """Run the create-delta tour for ``hr.leave``.
+
+        IK: docs/hr_leave/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_operating_unit_hr_leave_create", login="admin"
+        )

--- a/ssi_hr_holiday_operating_unit/tests/test_ui_hr_leave_allocation.py
+++ b/ssi_hr_holiday_operating_unit/tests/test_ui_hr_leave_allocation.py
@@ -1,0 +1,44 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveAllocation(HttpSavepointCase):
+    """Tour test for the ``hr.leave_allocation`` create-delta work
+    instruction added by ``ssi_hr_holiday_operating_unit`` (the
+    Operating Unit field).
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the Multi Operating Unit group so the field is shown.
+
+        Pre-Condition common to ``01-create.md``'s ``Additional Fields``
+        delta: the actor must belong to
+        ``operating_unit.group_multi_operating_unit`` for the Operating
+        Unit field to be visible on the create form.
+        """
+        super().setUpClass()
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+    def test_create(self):
+        """Run the create-delta tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_holiday_operating_unit_hr_leave_allocation_create",
+            login="admin",
+        )

--- a/ssi_hr_holiday_operating_unit/views/ssi_hr_holiday_operating_unit_assets_tests.xml
+++ b/ssi_hr_holiday_operating_unit/views/ssi_hr_holiday_operating_unit_assets_tests.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_holiday_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday_operating_unit/static/tests/tours/hr_leave_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday_operating_unit/static/tests/tours/hr_leave_allocation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki temuan `audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` bertingkat ERROR pada modul `ssi_hr_holiday_operating_unit` di validator `module`, `ik`, dan `unit-test`:

* Ubah nama class Python `HRLeave` → `HrLeave` (PascalCase dari `_name`); tidak direferensikan XML/ACL sehingga aman diubah.
* Tambahkan docstring pada class `HrLeave`, `HrLeaveAllocation`, class test `TestHrHolidayOperatingUnit`, dan method `test_hr_holiday_operating_unit`.
* Tulis Instruksi Kerja (IK) delta (arketipe E1 — field `Operating Unit` pada model inherit) di `docs/hr_leave/01-create.md` dan `docs/hr_leave_allocation/01-create.md`, beserta tour UI pasangannya (`static/tests/tours/`) dan test `HttpCase` (`tests/test_ui_hr_leave.py`, `tests/test_ui_hr_leave_allocation.py`).
* Tambahkan bagian `Work Instruction` di `README.rst`.
* Tambahkan dependency `web_tour` dan daftarkan tour ke bundle `web.assets_tests`.

Murni kepatuhan/refactor — tidak ada perubahan perilaku.

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_hr_holiday_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_holiday_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_holiday_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_holiday_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_holiday_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_holiday_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

#GATE repo=opnsynid-hr-timesheet modules=1 failed=0 skipped=0 status=OK

Closes #203