### PR TITLE
[UPD] ssi_hr_leave_allocation_request_batch_documenso_signing - kepatuhan skill

### DIFF
--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/README.rst
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/README.rst
@@ -13,6 +13,11 @@ digital signature platform.
 It adds a *Documenso* tab to the HR Leave Allocation Request Batch form view,
 allowing users to manage signature requests directly from the batch record.
 
+Work Instruction
+================
+
+* `Approve Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
+
 Configuration
 =============
 

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/__manifest__.py
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_hr_leave_allocation_request_batch",
         "ssi_connector_documenso_signing",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/docs/hr_leave_allocation_request_batch/05-approve.md
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/docs/hr_leave_allocation_request_batch/05-approve.md
@@ -1,0 +1,40 @@
+# Approve Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch_documenso_signing
+>
+> **Extends:** ssi_hr_leave_allocation_request_batch — model
+> `hr.leave_allocation_request_batch`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: at Flow base step 2 (open the record to approve), the form already shows a
+  **Signature Requests** tab (injected because `_documenso_signing_create_page = True`).
+  This tab is always present once this module is installed, regardless of whether
+  Documenso signing is actually used for the current approval.
+- The behavior below only applies **when the record's active Approval Template has a
+  Documenso Signing Template configured**. If it does not, the base Flow (steps 3–4,
+  Click **Approve** / click **OK**) applies unchanged, exactly as documented in
+  `ssi_hr_leave_allocation_request_batch/docs/hr_leave_allocation_request_batch/05-approve.md`.
+- When a Documenso Signing Template **is** configured: no per-approver approval record
+  is created for this document — a single `documenso.signature.request` is created and
+  linked instead (during the earlier Confirm action, before this record reaches
+  **Waiting for Approval**). Because there is no per-approver record naming the current
+  user as an active approver, the **Approve** button (Flow base step 3) stays invisible
+  for every user — it can never be clicked.
+- Instead of clicking Approve, the user opens the linked request — shown under the
+  **Approval Signing Request** group as the **Approval Signature Request** field in the
+  **Signature Requests** tab (or via the **Open Signature Requests** button in the same
+  tab) — and, on that request's own form, clicks **Send to Documenso** to send the
+  document for e-signature. The designated signer(s) then sign the document outside
+  Odoo, in Documenso.
+- Approval completes automatically — without any button click on this batch record —
+  once the linked signature request reaches the **Signed** status (checked manually via
+  **Check Status** on the request, or synced automatically by the connector). At that
+  point, the base Post-Condition applies as usual: status automatically changes to
+  **Done**, and the per-employee `hr.leave_allocation` documents described in the base
+  IK are created.
+- If the linked signature request is **cancelled** instead (e.g. a signer declines in
+  Documenso), the record moves directly to the base **Reject** end state — the same
+  outcome as the base Reject action, but triggered automatically by the cancelled
+  request rather than by a user clicking Reject. No `hr.leave_allocation` document is
+  created for any employee in that case.

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/models/hr_leave_allocation_request_batch.py
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/models/hr_leave_allocation_request_batch.py
@@ -6,6 +6,16 @@ from odoo import models
 
 
 class HrLeaveAllocationRequestBatch(models.Model):
+    """Enable Documenso-signed approval on leave allocation batches.
+
+    Adds the Documenso Signing tab to the
+    ``hr.leave_allocation_request_batch`` form and lets an
+    ``approval.template`` route this document to a single
+    ``documenso.signature.request`` instead of the regular
+    approval-record flow, whenever the template defines a
+    ``documenso_signing_template_id``.
+    """
+
     _name = "hr.leave_allocation_request_batch"
     _inherit = [
         "hr.leave_allocation_request_batch",

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/static/tests/tours/hr_leave_allocation_request_batch_tour.js
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/static/tests/tours/hr_leave_allocation_request_batch_tour.js
@@ -1,0 +1,127 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_hr_leave_allocation_request_batch_documenso_signing" +
+        ".hr_leave_allocation_request_batch_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/hr_leave_allocation_request_batch/05-approve.md (E2a
+        // delta -- Modified Flow)
+        // Navigation (open menu -> open record) is retraced from the base
+        // IK ssi_hr_leave_allocation_request_batch/docs/
+        // hr_leave_allocation_request_batch/05-approve.md Flow steps 1-2
+        // -- see skill odoo-development-ui-test,
+        // scope-and-boundaries.md §3 ("E2a -- telusur-ulang aksi itu dari
+        // base sampai titik ubah"). The delta assertion, anchored at base
+        // Flow step 2 (open the record to approve), verifies the
+        // Signature Requests tab injected because
+        // `_documenso_signing_create_page = True`, then stops -- base
+        // Flow steps 3-4 (Approve / OK) and the resulting Done status
+        // are NOT exercised here, since whether the Approve button is
+        // even visible depends on whether the active Approval Template
+        // has a Documenso Signing Template configured, and this tour's
+        // fixture leaves that unconfigured. The final signed/rejected
+        // outcome is driven by the external Documenso connector and out
+        // of scope for a tour.
+        tour.register(
+            "ssi_hr_leave_allocation_request_batch_documenso_signing" +
+                "_hr_leave_allocation_request_batch_approve",
+            {
+                test: true,
+                url: "/web",
+            },
+            [
+                // ── Base Flow 1 — Open the Human Resource > Timesheets >
+                // Leave Allocation Request Batch menu.
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Human Resource app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+                },
+                {
+                    content: "Open the Timesheets section",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+                },
+                {
+                    content: "Open the Leave Allocation Request Batch menu item",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_hr_leave_allocation_request_batch' +
+                        '.menu_hr_leave_allocation_request_batch"]',
+                },
+                {
+                    // Gate: wait for the TARGET action to be mounted, not
+                    // just any list view (the app may land on a stale
+                    // list first).
+                    content: "Leave Allocation Request Batch list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(" +
+                        "Leave Allocation Request Batch)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Base Flow 2 — Open the record to approve.
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(Tour HR Leave Allocation " +
+                        "Batch Documenso Employee) .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Record form is displayed",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Delta assertion (anchor: base Flow step 2) — the
+                // Signature Requests tab is always present once this
+                // module is installed, regardless of whether Documenso
+                // signing is actually used for the current approval.
+                {
+                    content: "Open the Signature Requests tab",
+                    trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+                },
+                {
+                    // Anchored on the group label rather than the
+                    // (currently empty) `approval_signature_request_id`
+                    // many2one widget itself -- a many2one rendered with
+                    // no value has no text node inside its link, so it
+                    // collapses to a zero-size box and jQuery's
+                    // `:visible` (offsetWidth/offsetHeight) never
+                    // matches it, hanging the tour until timeout. The
+                    // group label always has text, so it is a stable
+                    // proxy for "the Approval Signing Request group is
+                    // rendered".
+                    content:
+                        "Signature Requests tab shows the Approval Signing " +
+                        "Request group",
+                    trigger:
+                        ".o_horizontal_separator:contains(Approval Signing " +
+                        "Request)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action. The tour stops here -- it does not click
+                        // Approve, does not assert a final state, and
+                        // never calls the external Documenso service.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/static/tests/tours/hr_leave_allocation_request_batch_tour.js
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/static/tests/tours/hr_leave_allocation_request_batch_tour.js
@@ -73,11 +73,22 @@ odoo.define(
                 },
 
                 // ── Base Flow 2 — Open the record to approve.
+                // Matched on the Type column (added to the tree view by
+                // ssi_hr_leave_allocation_request_batch, right after
+                // "# Document") rather than the employee, because the
+                // list view never shows the employee(s) at all --
+                // `employee_ids` (many2many) is not one of its columns
+                // (# Document/user_id/reviewer_id/activities/state from
+                // the mixin.transaction base tree, plus Type/Date
+                // Start/Date Extended/Number Of Days added by the base
+                // module -- see hr_leave_allocation_request_batch_view_
+                // tree). A trigger built from the employee name can
+                // therefore never match any row.
                 {
                     content: "Open the record",
                     trigger:
                         ".o_data_row:contains(Tour HR Leave Allocation " +
-                        "Batch Documenso Employee) .o_data_cell:first",
+                        "Batch Documenso Type) .o_data_cell:first",
                     extra_trigger: ".o_list_view",
                 },
                 {

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/tests/__init__.py
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_leave_allocation_request_batch_documenso_signing
+from . import test_ui_hr_leave_allocation_request_batch

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/tests/test_hr_leave_allocation_request_batch_documenso_signing.py
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/tests/test_hr_leave_allocation_request_batch_documenso_signing.py
@@ -9,7 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrLeaveAllocationRequestBatchDocumensoSigning(YamlTransactionCase):
+    """Cover ``hr.leave_allocation_request_batch`` with the Documenso
+    signing approval mixin applied.
+    """
+
     def test_hr_leave_allocation_request_batch_documenso_signing(self):
+        """Run the leave allocation request batch creation scenario."""
         self.run_yaml_scenario(
             "test_data_hr_leave_allocation_request_batch_documenso_signing.yaml"
         )

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/tests/test_ui_hr_leave_allocation_request_batch.py
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/tests/test_ui_hr_leave_allocation_request_batch.py
@@ -1,0 +1,83 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. In 14.0, plain HttpCase does not
+# set up cls.env in setUpClass; HttpSavepointCase does.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveAllocationRequestBatch(HttpSavepointCase):
+    """Tour test for the ``hr.leave_allocation_request_batch`` Documenso
+    signing delta.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a batch already Waiting for Approval.
+
+        ``base.user_admin`` is already a member of
+        ``hr_leave_allocation_request_batch_validator_group`` (which
+        implies the ``User`` and ``Viewer`` groups) via
+        ``ssi_hr_leave_allocation_request_batch``'s
+        ``security/res_group_data.xml``, so it can create and confirm
+        the record directly, without extra group setup. A dedicated
+        Leave Type is created rather than reusing an arbitrary demo
+        Leave Type, to keep this fixture isolated from demo data. The
+        Standard approval template used by
+        ``ssi_hr_leave_allocation_request_batch`` demo data has no
+        Documenso Signing Template configured, so the Signature
+        Requests tab is present (``_documenso_signing_create_page =
+        True``) but the base Approve/OK Flow is unaffected -- this
+        tour does not exercise it. Pre-Condition IK 05-approve.md
+        (delta): the record is already Waiting for Approval, reached
+        here via ``action_confirm()`` in Python, not via UI clicks.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        employee = (
+            cls.env["hr.employee"]
+            .with_user(cls.admin)
+            .create({"name": "Tour HR Leave Allocation Batch Documenso Employee"})
+        )
+        leave_type = (
+            cls.env["hr.leave_type"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "Tour HR Leave Allocation Batch Documenso Type",
+                    "code": "TOURHLARBDT",
+                    "need_allocation": True,
+                }
+            )
+        )
+        cls.batch = (
+            cls.env["hr.leave_allocation_request_batch"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "type_id": leave_type.id,
+                    "number_of_days": 3,
+                    "date_start": "2026-01-01",
+                    "date_end": "2026-12-31",
+                    "date_extended": "2026-12-31",
+                    "employee_ids": [(6, 0, [employee.id])],
+                }
+            )
+        )
+        cls.batch.with_context(bypass_policy_check=True).action_confirm()
+
+    def test_approve(self):
+        """Run the approve tour for the Documenso signing delta.
+
+        IK: docs/hr_leave_allocation_request_batch/05-approve.md (E2a
+        delta -- Modified Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_allocation_request_batch_documenso_signing"
+            "_hr_leave_allocation_request_batch_approve",
+            login="admin",
+        )

--- a/ssi_hr_leave_allocation_request_batch_documenso_signing/views/assets.xml
+++ b/ssi_hr_leave_allocation_request_batch_documenso_signing/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_leave_allocation_request_batch_documenso_signing assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_leave_allocation_request_batch_documenso_signing/static/tests/tours/hr_leave_allocation_request_batch_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menutup temuan `audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` pada modul
`ssi_hr_leave_allocation_request_batch_documenso_signing` untuk validator
`module`, `ik`, dan `unit-test`. Murni kepatuhan skill — tidak ada perubahan
perilaku modul.

* Docstring class & method yang hilang (model + file test).
* IK delta E2a baru: `docs/hr_leave_allocation_request_batch/05-approve.md`
  (Modified Flow — tab Signature Requests, alur approval berbasis Documenso
  signing lewat `mixin.documenso_signing_approval`).
* Tour UI + test `HttpCase` pasangan IK tersebut (`web_tour` + `views/assets.xml`).

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_hr_leave_allocation_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_leave_allocation_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_leave_allocation_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_leave_allocation_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_leave_allocation_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_leave_allocation_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-hr-timesheet modules=1 failed=0 skipped=0 status=OK`

Closes #204