### PR TITLE
[UPD] ssi_hr_leave_allocation_request_batch_operating_unit

### DIFF
--- a/ssi_hr_leave_allocation_request_batch_operating_unit/README.rst
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/README.rst
@@ -6,6 +6,10 @@
 Leave Allocation Request Batch + Operating Unit
 ===============================================
 
+Work Instruction
+=================
+
+* `Create Leave Allocation Request Batch <docs/hr_leave_allocation_request_batch/index.html>`_
 
 Installation
 ============

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/__manifest__.py
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/__manifest__.py
@@ -12,10 +12,12 @@
     "depends": [
         "ssi_hr_leave_allocation_request_batch",
         "ssi_operating_unit_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_group/res_group_data.xml",
         "security/ir_rule/ir_rule_data.xml",
         "views/hr_leave_allocation_request_batch_view.xml",
+        "views/ssi_hr_leave_allocation_request_batch_operating_unit_assets_tests.xml",
     ],
 }

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/docs/hr_leave_allocation_request_batch/01-create.md
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/docs/hr_leave_allocation_request_batch/01-create.md
@@ -1,0 +1,23 @@
+# Create Leave Allocation Request Batch
+
+> **Module:** ssi_hr_leave_allocation_request_batch_operating_unit
+>
+> **Extends:** ssi_hr_leave_allocation_request_batch — model
+> `hr.leave_allocation_request_batch`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field:
+
+- **Operating Unit**: The operating unit this leave allocation request batch belongs to.
+  Defaults to the current user's default operating unit. Only visible to users in the
+  _Multi Operating Unit_ group (`operating_unit.group_multi_operating_unit`); hidden for
+  single-operating-unit installations. The same field is also added (hidden by default)
+  as an optional column in the **Leave Allocation Request Batch** list, and as a **Group
+  By: Operating Unit** filter in the search view — both gated by the same group.
+
+## Modified — Record Visibility
+
+- A user granted the _Operating Unit_ data-ownership group for this model only sees
+  leave allocation request batches whose **Operating Unit** is one of the operating
+  units assigned to them (record rule). This is not a Flow step.

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/models/hr_leave_allocation_request_batch.py
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/models/hr_leave_allocation_request_batch.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class HrLeaveAllocationRequestBatch(models.Model):
+    """Add operating unit ownership to leave allocation request batches.
+
+    Mixes in ``mixin.single_operating_unit`` so every batch document
+    carries an ``operating_unit_id``, gating its visibility to users
+    granted the operating units the record belongs to (see the
+    ``ir.rule`` shipped by this module).
+    """
+
     _name = "hr.leave_allocation_request_batch"
     _inherit = [
         "hr.leave_allocation_request_batch",

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/static/tests/tours/hr_leave_allocation_request_batch_tour.js
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/static/tests/tours/hr_leave_allocation_request_batch_tour.js
@@ -1,0 +1,101 @@
+odoo.define(
+    "ssi_hr_leave_allocation_request_batch_operating_unit" +
+        ".hr_leave_allocation_request_batch_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared opening steps: Human Resource > Timesheets > Leave
+        // Allocation Request Batch.
+        function openBatchMenuSteps() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Human Resource app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+                },
+                {
+                    content: "Open the Timesheets section",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+                },
+                {
+                    content: "Open the Leave Allocation Request Batch menu item",
+                    trigger:
+                        ".o_menu_sections " +
+                        "[data-menu-xmlid=" +
+                        '"ssi_hr_leave_allocation_request_batch' +
+                        '.menu_hr_leave_allocation_request_batch"]',
+                },
+                {
+                    // Gate: wait for the TARGET action, not just any
+                    // list view — the app landing action is also a
+                    // .o_list_view.
+                    content: "Leave Allocation Request Batch list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active" +
+                        ":contains(Leave Allocation Request Batch)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+            ];
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // IK: docs/hr_leave_allocation_request_batch/01-create.md
+        // (delta on top of
+        // ssi_hr_leave_allocation_request_batch/hr_leave_allocation_request_batch
+        // /01-create.md — adds the Operating Unit field, visible only
+        // to users in the Multi Operating Unit group). Per the E1
+        // extension pattern (odoo-development-ui-test skill,
+        // patterns.md §O / scope-and-boundaries.md §3): navigation is
+        // taken from the base tour (open menu → Create), then a
+        // single assertion proves the added field is displayed. Does
+        // NOT continue into Save/Confirm/etc. — those belong to the
+        // base ssi_hr_leave_allocation_request_batch create tour.
+        // ═══════════════════════════════════════════════════════════
+        tour.register(
+            "ssi_hr_leave_allocation_request_batch_operating_unit" +
+                "_hr_leave_allocation_request_batch_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openBatchMenuSteps(), [
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+                // ── Additional Fields — Operating Unit is displayed
+                // on the create form (actor is in
+                // group_multi_operating_unit, see setUpClass).
+                // Anchored to the field's label rather than the
+                // widget itself, matching the pattern recommended for
+                // delta tours (patterns.md §O).
+                {
+                    content: "Operating Unit field is displayed",
+                    trigger: ".o_form_label:contains(Operating Unit)",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+            ])
+        );
+    }
+);

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/tests/__init__.py
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_leave_allocation_request_batch_operating_unit
+from . import test_ui_hr_leave_allocation_request_batch

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/tests/test_hr_leave_allocation_request_batch_operating_unit.py
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/tests/test_hr_leave_allocation_request_batch_operating_unit.py
@@ -9,7 +9,15 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrLeaveAllocationRequestBatchOperatingUnit(YamlTransactionCase):
+    """YAML scenario tests for the operating unit glue module.
+
+    Covers the ``operating_unit_id`` field added to
+    ``hr.leave_allocation_request_batch`` by
+    ``mixin.single_operating_unit``.
+    """
+
     def test_hr_leave_allocation_request_batch_operating_unit(self):
+        """Run the batch-with-operating-unit YAML scenario."""
         self.run_yaml_scenario(
             "test_data_hr_leave_allocation_request_batch_operating_unit.yaml"
         )

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/tests/test_ui_hr_leave_allocation_request_batch.py
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/tests/test_ui_hr_leave_allocation_request_batch.py
@@ -1,0 +1,46 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveAllocationRequestBatch(HttpSavepointCase):
+    """Tour test for the create-delta work instruction added by
+    ``ssi_hr_leave_allocation_request_batch_operating_unit`` (the
+    Operating Unit field) on ``hr.leave_allocation_request_batch``.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the Multi Operating Unit group so the field is shown.
+
+        Pre-Condition common to ``01-create.md``'s ``Additional
+        Fields`` delta: the actor must belong to
+        ``operating_unit.group_multi_operating_unit`` for the
+        Operating Unit field to be visible on the create form.
+        """
+        super().setUpClass()
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+    def test_create(self):
+        """Run the create-delta tour for
+        ``hr.leave_allocation_request_batch``.
+
+        IK: docs/hr_leave_allocation_request_batch/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_allocation_request_batch_operating_unit"
+            "_hr_leave_allocation_request_batch_create",
+            login="admin",
+        )

--- a/ssi_hr_leave_allocation_request_batch_operating_unit/views/ssi_hr_leave_allocation_request_batch_operating_unit_assets_tests.xml
+++ b/ssi_hr_leave_allocation_request_batch_operating_unit/views/ssi_hr_leave_allocation_request_batch_operating_unit_assets_tests.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_leave_allocation_request_batch_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_leave_allocation_request_batch_operating_unit/static/tests/tours/hr_leave_allocation_request_batch_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Perbaikan kepatuhan skill hasil sapuan audit `audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` untuk modul `ssi_hr_leave_allocation_request_batch_operating_unit`:

* Tambah docstring pada class model (`HrLeaveAllocationRequestBatch`) dan class/method test (`TestHrLeaveAllocationRequestBatchOperatingUnit`) yang belum memilikinya.
* Tulis Instruksi Kerja (IK) delta pertama untuk modul ini: `docs/hr_leave_allocation_request_batch/01-create.md` (field **Operating Unit** tambahan + catatan record visibility), mengikuti pola E1 (`ssi_hr_holiday_operating_unit`).
* Tambah tour UI (`odoo-development-ui-test`) untuk IK tersebut, beserta bundle `web.assets_tests` dan dependensi `web_tour`.
* Tambah bagian *Work Instruction* di `README.rst`.

Tidak ada perubahan perilaku — murni kepatuhan skill (docstring + dokumentasi + tour pendamping).

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=.../ssi_hr_leave_allocation_request_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=.../ssi_hr_leave_allocation_request_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=.../ssi_hr_leave_allocation_request_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=.../ssi_hr_leave_allocation_request_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Gerbang pre-commit (`pre-commit-gate.sh`, keenam validator):
```
#GATE repo=opnsynid-hr-timesheet modules=1 failed=0 skipped=0 status=OK
```

Closes #206