### PR TITLE
[UPD] ssi_timesheet - final_amount pada laporan analisis & summary XLSX

### DIFF
--- a/ssi_timesheet/reports/hr_timesheet_computation_analysis.py
+++ b/ssi_timesheet/reports/hr_timesheet_computation_analysis.py
@@ -6,6 +6,14 @@ from odoo import api, fields, models
 
 
 class HrTimesheetComputationAnalysis(models.Model):
+    """Analysis report on top of ``hr.timesheet_computation``.
+
+    One row per computation line, exposing ``amount`` (the raw
+    computed value, kept for traceability), ``correction_amount``
+    (the manual override), and ``final_amount`` (the sum of both,
+    the value actually used downstream) as measures.
+    """
+
     _name = "hr.timesheet_computation_analysis"
     _description = "Timesheet Computation Analysis"
     _auto = False
@@ -52,6 +60,18 @@ class HrTimesheetComputationAnalysis(models.Model):
     amount = fields.Float(
         string="Amount",
     )
+    correction_amount = fields.Float(
+        string="Correction Amount",
+        help="Manual correction applied on top of the computed "
+        "amount, summed from ``hr.timesheet_computation."
+        "correction_amount``.",
+    )
+    final_amount = fields.Float(
+        string="Final Amount",
+        help="Amount actually used downstream: ``amount`` plus "
+        "``correction_amount``, summed from ``hr.timesheet_"
+        "computation.final_amount``.",
+    )
 
     @property
     def _table_query(self):
@@ -65,6 +85,15 @@ class HrTimesheetComputationAnalysis(models.Model):
 
     @api.model
     def _select(self):
+        """Build the SQL ``SELECT`` clause of the report.
+
+        ``amount``, ``correction_amount``, and ``final_amount`` are
+        each summed from ``hr_timesheet_computation`` (one row per
+        line after ``_group_by``, so the sum is a no-op per line but
+        keeps the aggregate consistent when grouped by pivot).
+
+        :return: SQL ``SELECT ...`` string
+        """
         select_str = """
         SELECT
             a.id AS id,
@@ -77,7 +106,9 @@ class HrTimesheetComputationAnalysis(models.Model):
             b.date_start AS date_start,
             b.date_end AS date_end,
             c.parent_id AS parent_id,
-            SUM(a.amount) AS amount
+            SUM(a.amount) AS amount,
+            SUM(a.correction_amount) AS correction_amount,
+            SUM(a.final_amount) AS final_amount
         """
         return select_str
 

--- a/ssi_timesheet/reports/hr_timesheet_computation_analysis.xml
+++ b/ssi_timesheet/reports/hr_timesheet_computation_analysis.xml
@@ -194,6 +194,8 @@
     <field name="arch" type="xml">
          <pivot>
              <field name="amount" type="measure" />
+             <field name="correction_amount" type="measure" />
+             <field name="final_amount" type="measure" />
         </pivot>
     </field>
 </record>

--- a/ssi_timesheet/tests/__init__.py
+++ b/ssi_timesheet/tests/__init__.py
@@ -5,6 +5,7 @@
 from . import test_daily_summary
 from . import test_timesheet
 from . import test_timesheet_computation
+from . import test_timesheet_computation_analysis
 from . import test_timesheet_summary_report
 from . import test_ui_hr_timesheet
 from . import test_ui_hr_timesheet_computation_item

--- a/ssi_timesheet/tests/test_data_timesheet_computation_analysis.yaml
+++ b/ssi_timesheet/tests/test_data_timesheet_computation_analysis.yaml
@@ -1,0 +1,117 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Create computation item (result = 10.0)"
+      action: "create"
+      model: "hr.timesheet_computation_item"
+      save_as: "item1"
+      values:
+        name: "Computation Item 1"
+        # "/" is excluded from the unique-code check (mixin.master_data),
+        # which matters here because `setup:` re-runs before EVERY
+        # scenario in this file and would otherwise collide on a fixed
+        # code (see odoo-development-unit-test test-traps.md T-01).
+        code: "/"
+        python_code: "result = 10.0"
+
+    - step: "Create employee with the item registered"
+      action: "create"
+      model: "hr.employee"
+      save_as: "employee"
+      values:
+        name: "Test Employee Timesheet Computation Analysis"
+        timesheet_computation_ids:
+          - - 6
+            - 0
+            - - "REC: item1.id"
+
+    - step: "Get working schedule"
+      action: "search"
+      model: "resource.calendar"
+      domain: []
+      save_as: "working_schedule"
+      limit: 1
+      order: "id asc"
+
+    - step: "Create timesheet (draft)"
+      action: "create"
+      model: "hr.timesheet"
+      save_as: "timesheet"
+      as_user: "base.user_admin"
+      values:
+        employee_id: "REC: employee.id"
+        date_start: 2026-02-01
+        date_end: 2026-02-28
+        working_schedule_id: "REC: working_schedule.id"
+
+    - step: "Open timesheet (triggers reload + compute)"
+      action: "call"
+      target: "timesheet"
+      method: "action_open"
+      as_user: "base.user_admin"
+
+    - step: "Locate the computation line for the item"
+      action: "search"
+      model: "hr.timesheet_computation"
+      domain:
+        - ["sheet_id", "=", "REC: timesheet.id"]
+        - ["item_id", "=", "REC: item1.id"]
+      save_as: "line1"
+      limit: 1
+
+scenarios:
+  - name: "Positif 1 - correction is reflected in the analysis report"
+    steps:
+      - step: "Write a correction on the computation line"
+        action: "write"
+        target: "line1"
+        values:
+          correction_amount: 2.5
+
+      - step: "Locate the analysis row for this timesheet"
+        action: "search"
+        model: "hr.timesheet_computation_analysis"
+        domain:
+          - ["timesheet_id", "=", "REC: timesheet.id"]
+        save_as: "analysis_line"
+        limit: 1
+
+      - step: "Assert amount/correction/final on the analysis row"
+        action: "assert"
+        target: "analysis_line"
+        asserts:
+          amount:
+            type: "value"
+            expected: 10.0
+          correction_amount:
+            type: "value"
+            expected: 2.5
+          final_amount:
+            type: "value"
+            expected: 12.5
+
+  - name: "Positif 2 - no correction keeps final_amount equal to amount"
+    steps:
+      - step: "Locate the analysis row for this timesheet"
+        action: "search"
+        model: "hr.timesheet_computation_analysis"
+        domain:
+          - ["timesheet_id", "=", "REC: timesheet.id"]
+        save_as: "analysis_line_nocorr"
+        limit: 1
+
+      - step: "Assert final_amount equals amount when uncorrected"
+        action: "assert"
+        target: "analysis_line_nocorr"
+        asserts:
+          amount:
+            type: "value"
+            expected: 10.0
+          correction_amount:
+            type: "value"
+            expected: 0.0
+          final_amount:
+            type: "value"
+            expected: 10.0

--- a/ssi_timesheet/tests/test_timesheet_computation_analysis.py
+++ b/ssi_timesheet/tests/test_timesheet_computation_analysis.py
@@ -1,0 +1,18 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTimesheetComputationAnalysis(YamlTransactionCase):
+    """Cover ``correction_amount``/``final_amount`` on the SQL view
+    report ``hr.timesheet_computation_analysis``.
+    """
+
+    def test_timesheet_computation_analysis(self):
+        """Run the correction/final amount scenarios on the report."""
+        self.run_yaml_scenario("test_data_timesheet_computation_analysis.yaml")

--- a/ssi_timesheet/tests/test_timesheet_summary_report.py
+++ b/ssi_timesheet/tests/test_timesheet_summary_report.py
@@ -85,11 +85,11 @@ class TestTimesheetSummaryReport(YamlTransactionCase):
     def test_amounts_by_employee_uses_final_amount_with_correction(self):
         """Aggregated amount reflects amount plus correction_amount.
 
-        Pure Python — trigger P1 (skill ``odoo-development-unit-test``,
-        ``python-escape-hatch.md`` §3): the assertion is on the return
-        value of ``_get_amounts_by_employee`` (a plain Python dict),
-        not on a side effect verifiable through a domain search on a
-        model.
+        Pure Python — trigger P1 (L-01: ``action: call`` discards a
+        method's return value, so YAML cannot assert it): the
+        assertion is on the return value of
+        ``_get_amounts_by_employee`` (a plain Python dict), not on a
+        side effect verifiable through a domain search on a model.
         """
         item = self._create_item("Count Corr", "TSUM_CORR", 3.0)
         timesheet, employee = self._create_done_timesheet(
@@ -111,11 +111,12 @@ class TestTimesheetSummaryReport(YamlTransactionCase):
     def test_amounts_by_employee_without_correction_matches_amount(self):
         """Aggregated amount equals amount when there is no correction.
 
-        Pure Python — trigger P1 (skill ``odoo-development-unit-test``,
-        ``python-escape-hatch.md`` §3): the assertion is on the return
-        value of ``_get_amounts_by_employee`` (a plain Python dict),
-        not on a side effect verifiable through a domain search on a
-        model. This is the zero-regression counterpart to
+        Pure Python — trigger P1 (L-01: ``action: call`` discards a
+        method's return value, so YAML cannot assert it): the
+        assertion is on the return value of
+        ``_get_amounts_by_employee`` (a plain Python dict), not on a
+        side effect verifiable through a domain search on a model.
+        This is the zero-regression counterpart to
         ``test_amounts_by_employee_uses_final_amount_with_correction``:
         with the default ``correction_amount`` of ``0.0``, the result
         must stay identical to the pre-fix behaviour that summed the


### PR DESCRIPTION
## Ringkasan

Melengkapi laporan `ssi_timesheet` agar konsisten memakai `final_amount` (nilai setelah
koreksi manual), sesuai yang sudah diterapkan pada `hr.timesheet_computation` (lihat #116).

* `hr.timesheet_computation_analysis` (SQL view `reports/hr_timesheet_computation_analysis.py`)
  menambahkan `correction_amount` dan `final_amount` pada `_select()` dan model — `amount`
  tetap dipertahankan sebagai nilai sebelum koreksi.
* View pivot laporan analisis memasang `final_amount` & `correction_amount` sebagai measure,
  di samping `amount` yang sudah ada.
* Laporan XLSX `timesheet_summary` (`reports/timesheet_summary_xlsx.py`) sudah menjumlahkan
  `final_amount` (dikerjakan sebelumnya); PR ini melengkapi docstring dua test Python murni
  terkait agar menyebut kode pemicu `P1` dan keterbatasan `L-01` sesuai Skenario Uji issue.
* Tidak ada field/kolom/XML ID yang dihapus atau diganti nama.

## Test plan

- [x] Unit test YAML baru: `hr.timesheet_computation_analysis` dengan koreksi →
      `final_amount` = `amount` + `correction_amount`.
- [x] Unit test YAML baru: `hr.timesheet_computation_analysis` tanpa koreksi →
      `final_amount` = `amount`.
- [x] `~/.claude/skills/odoo-development-repo-ops/assets/pre-commit-gate.sh` → `GATE OK`
      (0 pelanggaran baru pada `ssi_timesheet`, keenam validator).
- [x] CI GitHub (menyusul, dipantau di PR ini).

Closes open-synergy/opnsynid-hr-timesheet#117