### PR TITLE
[UPD] ssi_work_log_cost - IK work_log_rate & hr.work_log (Cost)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,42 @@ Menu: **Human Resource > Timesheets > Timesheets**
 > (additional fields/effects) on top of the base `hr.timesheet` IK, only relevant when
 > `ssi_work_log_mixin` is installed.
 
+### `ssi_work_log_cost` — Model: `work_log_rate`
+
+Menu: **Human Resource > Timesheets > Work Log Rates**
+
+| File                                                          | Action                                        |
+| ------------------------------------------------------------- | --------------------------------------------- |
+| `ssi_work_log_cost/docs/work_log_rate/01-create.md`           | Create a new work log rate                    |
+| `ssi_work_log_cost/docs/work_log_rate/02-edit.md`             | Edit a work log rate                          |
+| `ssi_work_log_cost/docs/work_log_rate/03-delete.md`           | Delete a work log rate                        |
+| `ssi_work_log_cost/docs/work_log_rate/04-confirm.md`          | Confirm a work log rate (submit for approval) |
+| `ssi_work_log_cost/docs/work_log_rate/05-approve.md`          | Approve a work log rate                       |
+| `ssi_work_log_cost/docs/work_log_rate/06-reject.md`           | Reject a work log rate                        |
+| `ssi_work_log_cost/docs/work_log_rate/07-start.md`            | Start a work log rate                         |
+| `ssi_work_log_cost/docs/work_log_rate/09-finish.md`           | Finish a work log rate                        |
+| `ssi_work_log_cost/docs/work_log_rate/10-cancel.md`           | Cancel a work log rate                        |
+| `ssi_work_log_cost/docs/work_log_rate/12-restart.md`          | Restart a cancelled/rejected work log rate    |
+| `ssi_work_log_cost/docs/work_log_rate/13-reset-number.md`     | Reset a work log rate's document number       |
+| `ssi_work_log_cost/docs/work_log_rate/14-restart-approval.md` | Restart a work log rate's approval process    |
+
+> There is no `08-ready.md` — approving (`05-approve.md`) transitions the record
+> directly to **Ready to Start**; there is no separate Set Ready button.
+
+### `ssi_work_log_cost` — Model: `hr.work_log` (extends `ssi_work_log_mixin`)
+
+Menu: **Human Resource > Timesheets > Timesheets** (open a timesheet, then use its
+**Work Log** tab)
+
+| File                                              | Action                                                    |
+| ------------------------------------------------- | --------------------------------------------------------- |
+| `ssi_work_log_cost/docs/hr_work_log/01-create.md` | Additional fields when creating a work log (**Cost** tab) |
+| `ssi_work_log_cost/docs/hr_work_log/02-edit.md`   | Additional fields when editing a work log (**Cost** tab)  |
+
+> Read together with `ssi_work_log_mixin/docs/hr_work_log/*` — these files are deltas
+> (additional fields) on top of the base `hr.work_log` IK, only relevant when
+> `ssi_work_log_cost` is installed and the actor has `show_cost_setting_ok` access.
+
 ---
 
 ## Module Development Guidelines

--- a/ssi_work_log_cost/README.rst
+++ b/ssi_work_log_cost/README.rst
@@ -2,9 +2,28 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-==============
-Work Log Mixin
-==============
+=============
+Work Log Cost
+=============
+
+
+Work Instruction
+================
+
+* `Create Work Log Rate <docs/work_log_rate/index.html>`_
+* `Edit Work Log Rate <docs/work_log_rate/index.html>`_
+* `Delete Work Log Rate <docs/work_log_rate/index.html>`_
+* `Confirm Work Log Rate <docs/work_log_rate/index.html>`_
+* `Approve Work Log Rate <docs/work_log_rate/index.html>`_
+* `Reject Work Log Rate <docs/work_log_rate/index.html>`_
+* `Start Work Log Rate <docs/work_log_rate/index.html>`_
+* `Finish Work Log Rate <docs/work_log_rate/index.html>`_
+* `Cancel Work Log Rate <docs/work_log_rate/index.html>`_
+* `Restart Work Log Rate <docs/work_log_rate/index.html>`_
+* `Reset Document Number — Work Log Rate <docs/work_log_rate/index.html>`_
+* `Restart Approval Process — Work Log Rate <docs/work_log_rate/index.html>`_
+* `Create Work Log (additional fields) <docs/hr_work_log/index.html>`_
+* `Edit Work Log (additional fields) <docs/hr_work_log/index.html>`_
 
 
 Installation

--- a/ssi_work_log_cost/docs/hr_work_log/01-create.md
+++ b/ssi_work_log_cost/docs/hr_work_log/01-create.md
@@ -1,0 +1,48 @@
+# Create Work Log
+
+> **Module:** ssi_work_log_cost
+>
+> **Extends:** ssi_work_log_mixin — model `hr.work_log`, aksi `01-create`
+
+## Additional Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `show_cost_setting_ok`
+  for state `draft` to the actor's group (see the _Standard_ `policy.template` shipped
+  with this module) — the **Cost** tab described below is hidden otherwise. As shipped,
+  this is granted to group _Work log — User_.
+- **Data:** The allowed **Product** and **Pricelist** choices are restricted to those
+  configured on the timesheet's **Document Type** (the `ir.model` record for
+  `hr.timesheet`) — either a fixed list or a Python-evaluated list. This configuration
+  is set up by a developer/administrator and is out of scope for this Work Instruction.
+
+## Additional Fields
+
+When this module is installed and the actor has `show_cost_setting_ok` access, a
+**Cost** tab appears on the work log form with the following fields:
+
+- **Usage**: Automatically filled from the **Document Type**'s **Default Worklog
+  Usage**, if configured (triggered when **Document Type** changes). Change if needed —
+  choices are limited to the usages allowed for the selected **Product**.
+- **Account**: Automatically filled from the selected **Product** and **Usage** (using
+  the product's accounting configuration for that usage). Change if needed. Optional —
+  this module makes the field not required.
+- **Quantity**: Defaults to the work log's own **Duration** (`amount`); recalculated
+  automatically if **Duration** changes. Not directly editable on this tab.
+- **UoM** _(required if **Product** is selected)_: Select the unit of measure for
+  **Quantity**. Choices are limited to units in the selected **Product**'s UoM category.
+- **Currency**: Defaults to the company's currency.
+- **Pricelist**: Automatically filled with the first pricelist allowed for the selected
+  **Currency** (and, once a **Product** is selected, further restricted to pricelists
+  allowed by the **Document Type**). Change if needed.
+- **Product**: Automatically filled with the first product allowed by the **Document
+  Type**, once one becomes available. Change if needed — choices are limited to the
+  products allowed by the **Document Type**.
+- **Price Unit**: Automatically filled from **Product**, **Pricelist**, **Quantity**,
+  and **UoM** (via the pricelist's price computation). Change if needed.
+- **Tax(es)**: Automatically filled from the selected **Product** and **Usage** (using
+  the product's tax configuration for that usage). Change if needed.
+
+## Additional Post-Condition
+
+- **Price Subtotal**, **Tax**, and **Price Total** are computed automatically from
+  **Price Unit**, **Quantity**, and **Tax(es)** — there is nothing to fill in for these.

--- a/ssi_work_log_cost/docs/hr_work_log/02-edit.md
+++ b/ssi_work_log_cost/docs/hr_work_log/02-edit.md
@@ -1,0 +1,12 @@
+# Edit Work Log
+
+> **Module:** ssi_work_log_cost
+>
+> **Extends:** ssi_work_log_mixin — model `hr.work_log`, aksi `02-edit`
+
+## Additional Fields
+
+If the actor has `show_cost_setting_ok` access (see `01-create`), the **Cost** tab's
+fields — **Usage**, **Account**, **UoM**, **Currency**, **Pricelist**, **Product**,
+**Price Unit**, and **Tax(es)** — can be changed the same way as described in
+`01-create`.

--- a/ssi_work_log_cost/docs/work_log_rate/01-create.md
+++ b/ssi_work_log_cost/docs/work_log_rate/01-create.md
@@ -1,0 +1,53 @@
+# Create Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — User_
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`) and `manual_number_ok` (state `draft`) to the relevant groups — see the
+  _Standard_ `policy.template` shipped with this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module (single level, approved by group _Work
+  Log Rate — Validator_).
+- **Config:** An active `sequence.template` for this model exists — see the _Standard_
+  `sequence.template` shipped with this module.
+- **Data:** At least one `product.product` and `product.pricelist` exist to be used as
+  general rate lines.
+- **Access:** User is in group _Work Log Rate — User_, and either the **Employee** to
+  select is themselves (record rule: `employee_id = user.employee_id`), or the user
+  holds a broader data-ownership group (_Direct Subordinate_, _All Subordinate_,
+  _Company_, _Company and All Child Companies_, or _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Employee** _(required)_: Select the employee this rate applies to.
+   - **Date** _(required)_: The rate document's date. Used by the _Standard_
+     `sequence.template` to resolve the date-range segment of the document number.
+   - **Date Start** _(required)_: The first date this rate is valid for the employee.
+   - **Date End**: The last date this rate is valid for the employee. Leave empty for a
+     rate that stays valid indefinitely (no end date).
+4. On the **General Rates** tab, click **Add a line**. Repeat the following steps as
+   many times as needed:
+   - **Product** _(required)_: Select the product this general rate line applies to.
+   - **Pricelist** _(required)_: Select the pricelist that determines the unit price for
+     this product.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new work log rate record is created in **Draft** status.
+- The document number stays **/** until the record transitions to **Ready to Start**
+  (see `05-approve`), unless the actor has _Can Input Manual Document Number_ access
+  (see `13-reset-number`).

--- a/ssi_work_log_cost/docs/work_log_rate/02-edit.md
+++ b/ssi_work_log_cost/docs/work_log_rate/02-edit.md
@@ -1,0 +1,33 @@
+# Edit Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Work Log Rate — User_, and either is the record's
+  **Employee** (record rule), or holds a broader data-ownership group (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Find and open the record to edit.
+3. Change **Employee**, **Date**, **Date Start**, or **Date End** as needed — the same
+   constraints described in `01-create` apply.
+4. On the **General Rates** tab, add, change, or remove lines as needed — the same
+   fields described in `01-create` apply.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_work_log_cost/docs/work_log_rate/03-delete.md
+++ b/ssi_work_log_cost/docs/work_log_rate/03-delete.md
@@ -1,0 +1,29 @@
+# Delete Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Work Log Rate — User_, and either is the record's
+  **Employee** (record rule), or holds a broader data-ownership group.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_work_log_cost/docs/work_log_rate/04-confirm.md
+++ b/ssi_work_log_cost/docs/work_log_rate/04-confirm.md
@@ -1,0 +1,39 @@
+# Confirm Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single level approved by group _Work Log Rate — Validator_).
+- **Access:** User is in group _Work Log Rate — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the _Standard_
+  `approval.template`.
+- Once every approval level has approved (see `05-approve`), the record transitions to
+  **Ready to Start** automatically — there is no separate Set Ready button, and no
+  dedicated Work Instruction for this transition.

--- a/ssi_work_log_cost/docs/work_log_rate/05-approve.md
+++ b/ssi_work_log_cost/docs/work_log_rate/05-approve.md
@@ -1,0 +1,39 @@
+# Approve Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `ready`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses a single level, approved by group
+  _Work Log Rate — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Ready to Start**
+  automatically — there is no separate Set Ready button. With the shipped _Standard_
+  `approval.template` (single level), approving always fulfills the approval and the
+  record goes straight to **Ready to Start**.
+- If the document number is still **/**, it is assigned automatically from the sequence
+  configured by the matching `sequence.template`.

--- a/ssi_work_log_cost/docs/work_log_rate/06-reject.md
+++ b/ssi_work_log_cost/docs/work_log_rate/06-reject.md
@@ -1,0 +1,34 @@
+# Reject Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses a single level, approved by group
+  _Work Log Rate — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_work_log_cost/docs/work_log_rate/07-start.md
+++ b/ssi_work_log_cost/docs/work_log_rate/07-start.md
@@ -1,0 +1,31 @@
+# Start Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — User_
+>
+> **State:** `ready` → `open`
+>
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **Ready to Start**.
+- **Config:** An active `policy.template` for this model grants `open_ok` for state
+  `ready` to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Work Log Rate — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to start.
+3. Click the **Start** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **In Progress**.

--- a/ssi_work_log_cost/docs/work_log_rate/09-finish.md
+++ b/ssi_work_log_cost/docs/work_log_rate/09-finish.md
@@ -1,0 +1,31 @@
+# Finish Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — User_
+>
+> **State:** `open` → `done`
+>
+> **Requires:** `07-start`
+
+## Pre-Condition
+
+- **Record:** Status is **In Progress**.
+- **Config:** An active `policy.template` for this model grants `done_ok` for state
+  `open` to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Work Log Rate — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to finish.
+3. Click the **Done** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.

--- a/ssi_work_log_cost/docs/work_log_rate/10-cancel.md
+++ b/ssi_work_log_cost/docs/work_log_rate/10-cancel.md
@@ -1,0 +1,35 @@
+# Cancel Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — Validator_
+>
+> **State:** `draft` | `confirm` | `ready` | `open` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, **Ready to Start**, **In
+  Progress**, or **Done**.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Work Log Rate — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the work log rate.

--- a/ssi_work_log_cost/docs/work_log_rate/12-restart.md
+++ b/ssi_work_log_cost/docs/work_log_rate/12-restart.md
@@ -1,0 +1,34 @@
+# Restart Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it for
+  states **Cancelled** and **Rejected**).
+- **Access:** User is in group _Work Log Rate — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  (`04-confirm`) starts the approval process from the beginning.

--- a/ssi_work_log_cost/docs/work_log_rate/13-reset-number.md
+++ b/ssi_work_log_cost/docs/work_log_rate/13-reset-number.md
@@ -1,0 +1,34 @@
+# Reset Document Number — Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard_
+  `sequence.template`).
+- **Access:** User is in group _Work Log Rate — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Ready to Start**
+  (see `05-approve`), according to the _Standard_ `sequence.template` configuration.

--- a/ssi_work_log_cost/docs/work_log_rate/14-restart-approval.md
+++ b/ssi_work_log_cost/docs/work_log_rate/14-restart-approval.md
@@ -1,0 +1,44 @@
+# Restart Approval Process — Work Log Rate
+
+> **Module:** ssi_work_log_cost
+>
+> **Model:** `work_log_rate`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Rates
+>
+> **Actor:** user in group _Work Log Rate — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group (see the _Standard_ `policy.template`). As
+  shipped, this policy only evaluates to allowed while the record's **Approval
+  Template** field is still empty — since Confirm (`04-confirm`) already assigns an
+  approval template before the record reaches this state, the button is typically not
+  clickable in practice with the default configuration. See the note below.
+- **Access:** User is in group _Work Log Rate — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Rates** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, this policy is effectively never satisfied under the default configuration.
+> This mirrors the same finding already reported for `hr.work_log` (see
+> `ssi_work_log_mixin/docs/hr_work_log/14-restart-approval.md`) and is not fixed here,
+> since fixing it is a code change out of scope for this Work Instruction.


### PR DESCRIPTION
## Summary

- Menambahkan Instruksi Kerja (IK) lengkap untuk model transaksional `work_log_rate`:
  `01-create`, `02-edit`, `03-delete`, `04-confirm`, `05-approve`, `06-reject`,
  `07-start`, `09-finish`, `10-cancel`, `12-restart`, `13-reset-number`, dan
  `14-restart-approval`. Tidak ada `08-ready` karena transisi `confirm` → `ready`
  terjadi otomatis setelah approval (`_after_approved_method`), bukan lewat tombol.
- Menambahkan IK delta pada `hr.work_log` (`01-create`, `02-edit`) untuk field tambahan
  tab **Cost** (Usage, Account, Quantity, UoM, Currency, Pricelist, Product, Price Unit,
  Tax(es)) yang ditambahkan modul ini.
- Memperbarui `README.rst` modul dengan bagian *Work Instruction*, sekaligus memperbaiki
  judul modul yang sebelumnya salah salin dari `ssi_work_log_mixin` ("Work Log Mixin" →
  "Work Log Cost").
- Memperbarui indeks `AGENTS.md` dengan entri IK di atas.

Tour pasangan IK ini didelegasikan ke item backlog terpisah
(open-synergy/opnsynid-hr-timesheet#159), sesuai Ruang Lingkup issue ini.

Closes #130

## Test plan

- [x] `validate-ik.sh` — 0 ERROR (6 peringatan "belum ada tour", diharapkan karena tour
  didelegasikan ke #159)
- [x] `pre-commit-gate.sh` — GATE OK, 0 pelanggaran baru di seluruh 6 validator
- [ ] CI GitHub (pre-commit, test) — dipantau setelah PR ini dibuka