### PR TITLE
[UPD] ssi_work_log_expense: Instruksi Kerja (IK) work_log_expense & work_log_expense_type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,6 +385,43 @@ Menu: **Human Resource > Timesheets > Timesheets** (open a timesheet, then use i
 > (additional fields) on top of the base `hr.work_log` IK, only relevant when
 > `ssi_work_log_cost` is installed and the actor has `show_cost_setting_ok` access.
 
+### `ssi_work_log_expense` — Model: `work_log_expense`
+
+Menu: **Human Resource > Timesheets > Work Log Expenses**
+
+| File                                                                | Action                                           |
+| ------------------------------------------------------------------- | ------------------------------------------------ |
+| `ssi_work_log_expense/docs/work_log_expense/01-create.md`           | Create a new work log expense                    |
+| `ssi_work_log_expense/docs/work_log_expense/02-edit.md`             | Edit a work log expense                          |
+| `ssi_work_log_expense/docs/work_log_expense/03-delete.md`           | Delete a work log expense                        |
+| `ssi_work_log_expense/docs/work_log_expense/04-confirm.md`          | Confirm a work log expense (submit for approval) |
+| `ssi_work_log_expense/docs/work_log_expense/05-approve.md`          | Approve a work log expense                       |
+| `ssi_work_log_expense/docs/work_log_expense/06-reject.md`           | Reject a work log expense                        |
+| `ssi_work_log_expense/docs/work_log_expense/10-cancel.md`           | Cancel a work log expense                        |
+| `ssi_work_log_expense/docs/work_log_expense/12-restart.md`          | Restart a cancelled/rejected work log expense    |
+| `ssi_work_log_expense/docs/work_log_expense/13-reset-number.md`     | Reset a work log expense's document number       |
+| `ssi_work_log_expense/docs/work_log_expense/14-restart-approval.md` | Restart a work log expense's approval process    |
+
+> There is no `07-start.md`/`09-finish.md` — approving (`05-approve.md`) transitions the
+> record directly to **Done**; there is no separate Start/Finish button. The
+> **Populate** and **Clear** buttons that fill/empty the **Details** tab are documented
+> inline in `01-create.md`/`02-edit.md` (`Inline Actions:` metadata), not as their own
+> files.
+
+### `ssi_work_log_expense` — Model: `work_log_expense_type`
+
+Menu: **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+
+| File                                                               | Action                                                                                  |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `ssi_work_log_expense/docs/work_log_expense_type/01-create.md`     | Create a new work log expense type                                                      |
+| `ssi_work_log_expense/docs/work_log_expense_type/02-edit.md`       | Edit a work log expense type                                                            |
+| `ssi_work_log_expense/docs/work_log_expense_type/03-delete.md`     | Delete a work log expense type                                                          |
+| `ssi_work_log_expense/docs/work_log_expense_type/04-deactivate.md` | Deactivate a work log expense type                                                      |
+| `ssi_work_log_expense/docs/work_log_expense_type/05-activate.md`   | Activate a work log expense type                                                        |
+| `ssi_work_log_expense/docs/work_log_expense_type/06-reset-code.md` | Reset the code of one or more types                                                     |
+| `ssi_work_log_expense/docs/work_log_expense_type/07-generate.md`   | Generate work log expenses from this type (per-employee, using the **Generate** wizard) |
+
 ---
 
 ## Module Development Guidelines

--- a/ssi_work_log_expense/README.rst
+++ b/ssi_work_log_expense/README.rst
@@ -7,6 +7,28 @@ Work Log Expense
 ================
 
 
+Work Instruction
+================
+
+* `Create Work Log Expense <docs/work_log_expense/index.html>`_
+* `Edit Work Log Expense <docs/work_log_expense/index.html>`_
+* `Delete Work Log Expense <docs/work_log_expense/index.html>`_
+* `Confirm Work Log Expense <docs/work_log_expense/index.html>`_
+* `Approve Work Log Expense <docs/work_log_expense/index.html>`_
+* `Reject Work Log Expense <docs/work_log_expense/index.html>`_
+* `Cancel Work Log Expense <docs/work_log_expense/index.html>`_
+* `Restart Work Log Expense <docs/work_log_expense/index.html>`_
+* `Reset Document Number — Work Log Expense <docs/work_log_expense/index.html>`_
+* `Restart Approval Process — Work Log Expense <docs/work_log_expense/index.html>`_
+* `Create Work Log Expense Type <docs/work_log_expense_type/index.html>`_
+* `Edit Work Log Expense Type <docs/work_log_expense_type/index.html>`_
+* `Delete Work Log Expense Type <docs/work_log_expense_type/index.html>`_
+* `Deactivate Work Log Expense Type <docs/work_log_expense_type/index.html>`_
+* `Activate Work Log Expense Type <docs/work_log_expense_type/index.html>`_
+* `Reset Code — Work Log Expense Type <docs/work_log_expense_type/index.html>`_
+* `Generate Work Log Expense <docs/work_log_expense_type/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_work_log_expense/docs/work_log_expense/01-create.md
+++ b/ssi_work_log_expense/docs/work_log_expense/01-create.md
@@ -1,0 +1,72 @@
+# Create Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — User_
+>
+> **State:** `—` → `draft`
+>
+> **Inline Actions:** `action_populate` (Populate), `action_clear` (Clear)
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` (state
+  `draft`) and `manual_number_ok` (state `draft`) to the relevant groups — see the
+  _Standard_ `policy.template` shipped with this module.
+- **Config:** An active `approval.template` for this model exists — see the _Standard_
+  `approval.template` shipped with this module (single level, approved by group _Work
+  Log Expense — Validator_).
+- **Config:** An active `sequence.template` for this model exists — see the _Standard_
+  `sequence.template` shipped with this module.
+- **Data:** An active `work_log_expense_type` record exists, with **Account** and
+  **Journal** configured on it (see `work_log_expense_type/01-create`).
+- **Data:** One or more `hr.work_log` records exist for the employee, in status
+  **Done**, not yet linked to another work log expense, and dated within the range to be
+  entered.
+- **Access:** User is in group _Work Log Expense — User_, and either is the record's
+  **Responsible** (`user_id`, record rule: `user_id = user.id` — defaults to the current
+  user but can be changed to another user while in Draft), or holds a broader
+  data-ownership group evaluated against the record's **Employee** (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Employee** _(required)_: Automatically filled from the current user's linked
+     employee record, if any. Change if needed. **Manager**, **Job Position**, and
+     **Department** are filled in automatically and cannot be edited directly.
+   - **Type** _(required)_: Select the work log expense type. Selecting it automatically
+     fills **Account** and **Journal** from the type, and clears **Analytic Account**.
+   - **Analytic Account**: Optionally narrow the work logs to be populated to a single
+     analytic account. Only accounts allowed by the selected **Type** can be chosen.
+     Leave empty to allow any analytic account/group allowed by the **Type**.
+   - **Date Start** _(required)_: The first date of the work log range to be pulled in.
+   - **Date End** _(required)_: The last date of the work log range to be pulled in.
+   - **Date** _(required)_: The expense document's date. Used by the _Standard_
+     `sequence.template` to resolve the date-range segment of the document number.
+4. On the **Details** tab, click **Populate** to pull in every `hr.work_log` record for
+   the selected **Employee** that is in status **Done**, dated between **Date Start**
+   and **Date End**, not yet linked to another work log expense, and matching the
+   **Analytic Account**/**Type**'s allowed analytic accounts and groups. Populating also
+   (re)builds the **Summary** tab and recalculates **Amount Total**. You may click
+   **Populate** again after changing **Employee**, **Type**, **Analytic Account**,
+   **Date Start**, or **Date End** — it first clears any existing lines before pulling
+   in the new set. Click **Clear** to remove all lines (and the **Summary** tab) without
+   populating new ones. Populating is required before **Confirm** (`04-confirm`)
+   produces a non-zero **Amount Total**, since the accounting entry created on approval
+   is generated from the **Summary** tab.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new work log expense record is created in **Draft** status.
+- The document number stays **/** until the record transitions to **Done** (see
+  `05-approve`), unless the actor has _Can Input Manual Document Number_ access (see
+  `13-reset-number`).

--- a/ssi_work_log_expense/docs/work_log_expense/02-edit.md
+++ b/ssi_work_log_expense/docs/work_log_expense/02-edit.md
@@ -1,0 +1,39 @@
+# Edit Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — User_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_populate` (Populate), `action_clear` (Clear)
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Work Log Expense — User_, and either is the record's
+  **Responsible** (`user_id`, record rule: `user_id = user.id`), or holds a broader
+  data-ownership group evaluated against the record's **Employee** (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Find and open the record to edit.
+3. Change **Employee**, **Type**, **Analytic Account**, **Date Start**, **Date End**, or
+   **Date** as needed — the same constraints described in `01-create` apply.
+4. On the **Details** tab, click **Populate** to refresh the lines after changing
+   **Employee**, **Type**, **Analytic Account**, **Date Start**, or **Date End** — it
+   first clears any existing lines (and the **Summary** tab), then pulls in the work
+   logs matching the current field values, exactly as described in `01-create`. Click
+   **Clear** to remove all lines without populating new ones.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_work_log_expense/docs/work_log_expense/03-delete.md
+++ b/ssi_work_log_expense/docs/work_log_expense/03-delete.md
@@ -1,0 +1,36 @@
+# Delete Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — User_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Work Log Expense — User_, and either is the record's
+  **Responsible** (`user_id`, record rule: `user_id = user.id`), or holds a broader
+  data-ownership group evaluated against the record's **Employee** (_Direct
+  Subordinate_, _All Subordinate_, _Company_, _Company and All Child Companies_, or
+  _All_).
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.
+- Any `hr.work_log` records that were populated onto a deleted record automatically have
+  their `# Expense` link cleared (`ondelete="set null"`), becoming available for
+  population onto another work log expense again. The `work_log_expense_summary` lines
+  on the deleted record are removed together with it (`ondelete="cascade"`).

--- a/ssi_work_log_expense/docs/work_log_expense/04-confirm.md
+++ b/ssi_work_log_expense/docs/work_log_expense/04-confirm.md
@@ -1,0 +1,39 @@
+# Confirm Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level (see the _Standard_ `approval.template`, which defines a
+  single level approved by group _Work Log Expense — Validator_).
+- **Access:** User is in group _Work Log Expense — User_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the _Standard_
+  `approval.template`.
+- Once every approval level has approved (see `05-approve`), the record transitions to
+  **Done** automatically — there is no separate Done button, and no dedicated Work
+  Instruction for this transition.

--- a/ssi_work_log_expense/docs/work_log_expense/05-approve.md
+++ b/ssi_work_log_expense/docs/work_log_expense/05-approve.md
@@ -1,0 +1,45 @@
+# Approve Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. The _Standard_ `approval.template` uses a single level, approved by group
+  _Work Log Expense — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes to **Done** automatically — there
+  is no separate Done button. With the shipped _Standard_ `approval.template` (single
+  level), approving always fulfills the approval and the record goes straight to
+  **Done**.
+- If the document number is still **/**, it is assigned automatically from the sequence
+  configured by the matching `sequence.template` — this is the point where the document
+  number is first issued for this model.
+- An **Accounting Entry** (`account.move`) is created and posted: one debit line on the
+  work log expense's **Account** for **Amount Total**, and one credit line per
+  **Summary** row on that row's **Account**, each carrying its **Analytic Account** and
+  **Product**. The move is shown in the **# Accounting Entry** field on the
+  **Accounting** tab.

--- a/ssi_work_log_expense/docs/work_log_expense/06-reject.md
+++ b/ssi_work_log_expense/docs/work_log_expense/06-reject.md
@@ -1,0 +1,34 @@
+# Reject Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** approver on the pending approval level
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor — computed
+  dynamically: the user must be registered as an approver on the currently pending
+  approval level (see the _Standard_ `policy.template`).
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending. The _Standard_ `approval.template` uses a single level, approved by group
+  _Work Log Expense — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_work_log_expense/docs/work_log_expense/10-cancel.md
+++ b/ssi_work_log_expense/docs/work_log_expense/10-cancel.md
@@ -1,0 +1,38 @@
+# Cancel Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — Validator_
+>
+> **State:** `draft` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft** or **Done**. The _Standard_ `policy.template` does
+  **not** grant `cancel_ok` for status **Waiting for Approval** — a record must be
+  rejected or approved first before it can be cancelled from that point onward.
+- **Config:** An active `policy.template` for this model grants `cancel_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`).
+- **Access:** User is in group _Work Log Expense — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The selected **Reason** is recorded on the work log expense.
+- If the record was **Done**, its **Accounting Entry** (see `05-approve`) is cancelled
+  and removed; the **# Accounting Entry** field on the **Accounting** tab is cleared.

--- a/ssi_work_log_expense/docs/work_log_expense/12-restart.md
+++ b/ssi_work_log_expense/docs/work_log_expense/12-restart.md
@@ -1,0 +1,34 @@
+# Restart Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` for this model grants `restart_ok` for that
+  state to the actor's group (see the _Standard_ `policy.template`, which grants it for
+  states **Cancelled** and **Rejected**).
+- **Access:** User is in group _Work Log Expense — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  (`04-confirm`) starts the approval process from the beginning.

--- a/ssi_work_log_expense/docs/work_log_expense/13-reset-number.md
+++ b/ssi_work_log_expense/docs/work_log_expense/13-reset-number.md
@@ -1,0 +1,34 @@
+# Reset Document Number — Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — Validator_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `manual_number_ok` for
+  state `draft` to the actor's group (see the _Standard_ `policy.template`).
+- **Config:** An active `sequence.template` exists for this model (see the _Standard_
+  `sequence.template`).
+- **Access:** User is in group _Work Log Expense — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field in the title
+   area and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** (see
+  `05-approve`), according to the _Standard_ `sequence.template` configuration.

--- a/ssi_work_log_expense/docs/work_log_expense/14-restart-approval.md
+++ b/ssi_work_log_expense/docs/work_log_expense/14-restart-approval.md
@@ -1,0 +1,45 @@
+# Restart Approval Process — Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense`
+>
+> **Menu:** Human Resource > Timesheets > Work Log Expenses
+>
+> **Actor:** user in group _Work Log Expense — Validator_
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group (see the _Standard_ `policy.template`). As
+  shipped, this policy only evaluates to allowed while the record's **Approval
+  Template** field is still empty — since Confirm (`04-confirm`) already assigns an
+  approval template before the record reaches this state, the button is typically not
+  clickable in practice with the default configuration. See the note below.
+- **Access:** User is in group _Work Log Expense — Validator_.
+
+## Flow
+
+1. Open the **Human Resource > Timesheets > Work Log Expenses** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped _Standard_ `policy.template` grants `restart_approval_ok` only
+> when `approval_template_id` is **not yet** set. Because the `Confirm` action
+> (`04-confirm`) always assigns `approval_template_id` before the record reaches state
+> `confirm`, this policy is effectively never satisfied under the default configuration.
+> This mirrors the same finding already reported for `work_log_rate` (see
+> `ssi_work_log_cost/docs/work_log_rate/14-restart-approval.md`) and `hr.work_log` (see
+> `ssi_work_log_mixin/docs/hr_work_log/14-restart-approval.md`), and is not fixed here,
+> since fixing it is a code change out of scope for this Work Instruction.

--- a/ssi_work_log_expense/docs/work_log_expense_type/01-create.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/01-create.md
@@ -1,0 +1,47 @@
+# Create Work Log Expense Type
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter a short label for the type (for example
+     "Transportation").
+   - **Code** _(required)_: Enter a unique code, or enter **/** to leave it eligible for
+     automatic assignment via **Generate Code**.
+   - **Account** _(required)_: The accrual account credited when a work log expense of
+     this type is populated. Also used as the default **Account** on new work log
+     expense records of this type.
+   - **Journal** _(required)_: The accounting journal used for the accounting entry
+     created when a work log expense of this type is approved.
+4. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model. Only applies while **Code** is still
+   **/**. If no matching `sequence.template` is configured, nothing changes and **Code**
+   must be filled in manually.
+5. On the **Allowed Analytics** tab, fill in **Allowed Analytic Groups** and/or
+   **Allowed Analytic Accounts** to restrict which analytic accounts a work log expense
+   of this type may populate work logs from. Leave both empty to allow any analytic
+   account.
+6. Optionally fill in **Note**.
+7. Click **Save**.
+
+## Post-Condition
+
+- A new work log expense type record is created, active by default.
+- The record becomes selectable as **Type** on a work log expense (see
+  `ssi_work_log_expense/work_log_expense/01-create`).

--- a/ssi_work_log_expense/docs/work_log_expense_type/02-edit.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/02-edit.md
@@ -1,0 +1,39 @@
+# Edit Work Log Expense Type
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Find and open the record to edit.
+3. Change **Name**, **Code**, **Active**, **Account**, **Journal**, or **Note** as
+   needed.
+4. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model — for example after resetting
+   **Code** back to **/** (see `06-reset-code`). Only applies while **Code** is **/**;
+   if no matching `sequence.template` is configured, nothing changes and **Code** must
+   be filled in manually.
+5. On the **Allowed Analytics** tab, add, change, or remove **Allowed Analytic Groups**
+   and **Allowed Analytic Accounts** as needed.
+6. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values. Existing work log expenses that already
+  reference this type keep their own **Account**/**Journal**/**Analytic Account** values
+  — this change only affects the defaults applied to new records going forward.

--- a/ssi_work_log_expense/docs/work_log_expense_type/03-delete.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/03-delete.md
@@ -1,0 +1,30 @@
+# Delete Work Log Expense Type
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system. Deletion fails with a
+  database integrity error if the type is already referenced by an existing **Work Log
+  Expense** record (`type_id` uses `ondelete="restrict"`) — deactivate the record
+  instead (see `04-deactivate`).

--- a/ssi_work_log_expense/docs/work_log_expense_type/04-deactivate.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/04-deactivate.md
@@ -1,0 +1,33 @@
+# Deactivate Work Log Expense Type
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as **Type** on new **Work Log Expense**
+  records.
+- **Work Log Expense** records that already reference this type can still be viewed.

--- a/ssi_work_log_expense/docs/work_log_expense_type/05-activate.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/05-activate.md
@@ -1,0 +1,32 @@
+# Activate Work Log Expense Type
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again as **Type** on new **Work Log Expense** records.

--- a/ssi_work_log_expense/docs/work_log_expense_type/06-reset-code.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/06-reset-code.md
@@ -1,0 +1,31 @@
+# Reset Code — Work Log Expense Type
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** One or more records exist.
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Select one or more records whose code will be reset (check the checkbox).
+3. Click the **Reset code** button that appears above the list.
+4. Click **OK** on the confirmation dialog ("Reset code. Are you sure?").
+
+## Post-Condition
+
+- **Code** of the selected records returns to **/**.
+- The records become eligible for automatic code assignment the next time **Generate
+  Code** is used (see `01-create` and `02-edit`), or the field can be filled in
+  manually.

--- a/ssi_work_log_expense/docs/work_log_expense_type/07-generate.md
+++ b/ssi_work_log_expense/docs/work_log_expense_type/07-generate.md
@@ -1,0 +1,52 @@
+# Generate Work Log Expense
+
+> **Module:** ssi_work_log_expense
+>
+> **Model:** `work_log_expense_type`
+>
+> **Menu:** Human Resource > Configuration > Timesheets > Work Log Expense Types
+>
+> **Actor:** user in group _Work Log Expense Type_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The **Work Log Expense Type** record to generate from exists, with
+  **Account** and **Journal** configured on it.
+- **Data:** One or more `hr.work_log` records exist, in status **Done**, not yet linked
+  to another work log expense, dated within the range to be entered, and matching the
+  type's **Allowed Analytic Groups**/**Allowed Analytic Accounts** (or the **Analytic
+  Account** entered in the wizard, if any).
+- **Access:** User is in group _Work Log Expense Type_.
+
+## Flow
+
+1. Open the **Human Resource > Configuration > Timesheets > Work Log Expense Types**
+   menu.
+2. Open the type record to generate work log expenses from.
+3. Click the **Generate** button in the header.
+4. In the wizard that appears, fill in the fields:
+   - **Analytic Account**: Optionally narrow the work logs to be pulled in to a single
+     analytic account. Leave empty to use the type's **Allowed Analytic Groups**/
+     **Allowed Analytic Accounts**.
+   - **Date Start** _(required)_: The first date of the work log range to be pulled in.
+   - **Date End** _(required)_: The last date of the work log range to be pulled in.
+   - **Date** _(required)_: The date to set on every generated work log expense.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog ("Are you sure?").
+
+## Post-Condition
+
+- One new **Work Log Expense** record is created in **Draft** status for each distinct
+  **Employee** who has at least one matching `hr.work_log` record, with **Type**,
+  **Account**, and **Journal** copied from this type, and **Date Start**/**Date End**/
+  **Date** copied from the wizard.
+- Each generated record is already populated: its **Details** tab is filled with the
+  matching work logs (equivalent to running **Populate**, see
+  `ssi_work_log_expense/work_log_expense/01-create`), and **Amount Total** is
+  recalculated accordingly.
+- If no employee has a matching `hr.work_log` record, nothing is created and no message
+  is shown.
+- The document number of each generated record stays **/** until it transitions to
+  **Done** (see `ssi_work_log_expense/work_log_expense/05-approve`).


### PR DESCRIPTION
## Ringkasan

* Menambahkan Instruksi Kerja (IK) lengkap untuk model transaksional `work_log_expense`:
  `01-create`, `02-edit`, `03-delete`, `04-confirm`, `05-approve`, `06-reject`,
  `10-cancel`, `12-restart`, `13-reset-number`, dan `14-restart-approval`. Tidak ada
  `07-start`/`09-finish` karena approval membawa langsung ke state `done`
  (`_after_approved_method`), bukan lewat tombol terpisah. Tombol **Populate** dan
  **Clear** didokumentasikan sebagai `Inline Actions:` pada `01-create` dan `02-edit`.
* Menambahkan IK master data `work_log_expense_type`: `01-create`, `02-edit`,
  `03-delete`, `04-deactivate`, `05-activate`, `06-reset-code`, dan `07-generate` untuk
  wizard **Generate Work Log Expense** (membuat & langsung mem-populate work log expense
  per employee dari halaman Type).
* Memperbarui `README.rst` modul dengan bagian *Work Instruction*.
* Memperbarui indeks `AGENTS.md` repo dengan entri IK di atas.

Tour pasangan berkas IK ini sengaja **tidak** dibuat di sini — dikerjakan di item terpisah
open-synergy/opnsynid-hr-timesheet#160, sesuai Ruang Lingkup issue #131.

## Referensi

Closes #131

## Test plan

- [x] `~/.claude/skills/odoo-development-instruksi-kerja/assets/validate-ik.sh` — 0 ERROR
      (5 peringatan "tak ada tour" yang memang di luar lingkup item ini)
- [x] `~/.claude/skills/odoo-development-repo-ops/assets/pre-commit-gate.sh` — GATE OK
- [ ] CI (pre-commit + test Odoo) hijau