### PR TITLE
[UPD] ssi_hr_holiday

### DIFF
--- a/ssi_hr_holiday/__manifest__.py
+++ b/ssi_hr_holiday/__manifest__.py
@@ -13,6 +13,7 @@
         "ssi_transaction_terminate_mixin",
         "ssi_timesheet_attendance",
         "base_automation",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -30,6 +31,7 @@
         "views/hr_leave_allocation_views.xml",
         "views/hr_leave_views.xml",
         "views/hr_timesheet_views.xml",
+        "views/ssi_hr_holiday_assets.xml",
     ],
     "demo": [
         "demo/hr_leave_type_data_demo.xml",

--- a/ssi_hr_holiday/static/tests/tours/hr_leave_allocation_tour.js
+++ b/ssi_hr_holiday/static/tests/tours/hr_leave_allocation_tour.js
@@ -1,0 +1,658 @@
+odoo.define("ssi_hr_holiday.hr_leave_allocation_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Leave
+    // Allocations. "Timesheets" (level 2, section) has several children
+    // (Timesheets, Leaves, Leave Allocations) so it is clickable as a
+    // dropdown-toggle; "Leave Allocations" (level 3) is a leaf, also
+    // clickable.
+    function openLeaveAllocationMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leave Allocations menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.menu_hr_leave_allocation"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Leave Allocations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(" +
+                    "Leave Allocations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Click a statusbar/header button by its exact visible label. The
+    // Cancel and Terminate buttons share this form's statusbar but their
+    // `name` attribute is a numeric action id (their respective "Select
+    // Reason" wizard actions) rather than a method name, so matching by
+    // trimmed text is the only selector that is deterministic across both.
+    function clickHeaderButtonByLabel(label) {
+        return {
+            content: "Click the " + label + " button",
+            trigger: ".o_statusbar_buttons button",
+            run: function () {
+                var $button = $(".o_statusbar_buttons button").filter(function () {
+                    return $(this).text().trim() === label;
+                });
+                $button[0].click();
+            },
+        };
+    }
+
+    var openRecordStep = function (label) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + label + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ];
+    };
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveAllocationMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Leave Type, Employee, Date Start, Date
+            // End, Number of Days.
+            {
+                content: "Select the Leave Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-LTYPE-ALLOC",
+            },
+            {
+                content: "Pick the Leave Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-LTYPE-ALLOC)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Employee",
+                trigger: ".o_field_many2one[name='employee_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-EMP-ALLOC-CREATE",
+            },
+            {
+                content: "Pick the Employee from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(" +
+                    "TOUR-EMP-ALLOC-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/01/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 12/31/2026",
+            },
+            {
+                content: "Fill in Number of Days",
+                trigger: ".o_field_widget[name='number_of_days']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 12",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new allocation record is created in
+            // Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-EDIT"),
+            [
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                // ── Flow 3 — Change Number of Days.
+                {
+                    content: "Change Number of Days",
+                    trigger: ".o_field_widget[name='number_of_days']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text 20",
+                },
+                // ── Flow 4 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                // ── Post-Condition — the record is updated.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-DELETE"),
+            [
+                // ── Flow 2-3 — Select the record and click Action >
+                // Delete. Driven from the record's own Action menu rather
+                // than the list checkbox: the 14.0 list-selector checkbox
+                // is flaky (odoo-development-ui-test skill, patterns.md
+                // §I), and this reaches the same Post-Condition.
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+                // ── Flow 4 — Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                {
+                    content:
+                        "Click the Leave Allocations breadcrumb to return " +
+                        "to the list",
+                    trigger:
+                        ".breadcrumb-item.o_back_button a:contains(" +
+                        "Leave Allocations)",
+                },
+                // ── Post-Condition — the record is permanently removed.
+                {
+                    content: "Deleted allocation no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-EMP-ALLOC-DELETE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-CONFIRM"),
+            [
+                // ── Flow 3 — Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Waiting for
+                // Approval, and approval records are created for the
+                // pending level (evidenced by the Approve button
+                // becoming available).
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "The Approve button becomes available",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_approve_approval']:visible",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/05-approve.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-APPROVE"),
+            [
+                // ── Flow 3 — Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — single-level approval fulfilled
+                // immediately, so status changes to In Progress.
+                {
+                    content: "Status is In Progress",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='open']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/06-reject.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-REJECT"),
+            [
+                // ── Flow 3 — Click the Reject button.
+                {
+                    content: "Click the Reject button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reject_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Rejected.
+                {
+                    content: "Status is Rejected",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='reject']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/10-cancel.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-CANCEL"),
+            [
+                // ── Flow 3 — Click the Cancel button. `name` is a numeric
+                // action id on this button, so match its label instead.
+                clickHeaderButtonByLabel("Cancel"),
+                // ── Flow 4 — In the wizard, select the Reason.
+                {
+                    // 14.0: do NOT prefix with `.modal` — the trigger is
+                    // searched INSIDE the modal already (odoo-development-
+                    // ui-test skill, patterns.md §H).
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Select the cancellation reason",
+                    trigger:
+                        ".o_field_widget[name='cancel_reason_id'] " +
+                        ".o_radio_item:contains(TOUR-ALLOC-CANCEL-REASON) input",
+                },
+                // ── Flow 5 — Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+                // ── Flow 6 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Cancelled, and the
+                // selected Reason is recorded on the allocation.
+                {
+                    content: "Status is Cancelled",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='cancel']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Cancellation reason is displayed",
+                    trigger: "h2:visible:contains(Cancellation reason)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/11-terminate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_terminate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-TERMINATE"),
+            [
+                // ── Flow 3 — Click the Terminate button. `name` is a
+                // numeric action id on this button, so match its label
+                // instead.
+                clickHeaderButtonByLabel("Terminate"),
+                // ── Flow 4 — In the wizard, select the Reason.
+                {
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Select the termination reason",
+                    trigger:
+                        ".o_field_widget[name='terminate_reason_id'] " +
+                        ".o_radio_item:contains(TOUR-ALLOC-TERMINATE-REASON) input",
+                },
+                // ── Flow 5 — Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+                // ── Flow 6 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Terminated, and
+                // the selected Reason is recorded on the allocation.
+                {
+                    content: "Status is Terminated",
+                    trigger:
+                        ".o_statusbar_status " +
+                        ".o_arrow_button[data-value='terminate'].btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Termination reason is displayed",
+                    trigger: "h2:visible:contains(Termination reason)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/12-restart.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-RESTART"),
+            [
+                // ── Flow 3 — Click the Restart button.
+                {
+                    content: "Click the Restart button",
+                    trigger: ".o_statusbar_buttons button[name='action_restart']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status returns to Draft.
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/13-reset-number.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-RESETNUM"),
+            [
+                // ── Flow 3 — Click the Reset Document Number button.
+                {
+                    content: "Click the Reset Document Number button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reset_document_number']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — document number returns to "/"; the
+                // dialog closing without error is the visible evidence.
+                {
+                    content: "Dialog is closed",
+                    trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_allocation/14-restart-approval.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_allocation_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveAllocationMenuSteps(),
+            openRecordStep("TOUR-EMP-ALLOC-RESTARTAPPROVAL"),
+            [
+                // ── Flow 3 — Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status remains unchanged (Waiting
+                // for Approval).
+                {
+                    content: "Status remains Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_hr_holiday/static/tests/tours/hr_leave_tour.js
+++ b/ssi_hr_holiday/static/tests/tours/hr_leave_tour.js
@@ -1,0 +1,546 @@
+odoo.define("ssi_hr_holiday.hr_leave_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Leaves.
+    // "Timesheets" (level 2, section) has several children (Timesheets,
+    // Leaves, Leave Allocations) so it is clickable as a dropdown-toggle;
+    // "Leaves" (level 3) is a leaf, also clickable.
+    function openLeaveMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leaves menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.menu_hr_leave"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Leaves list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Leaves)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Click a statusbar/header button by its exact visible label. The
+    // Cancel button shares this form's statusbar but its `name` attribute
+    // is a numeric action id (the Select Cancel Reason wizard action)
+    // rather than a method name, so matching by trimmed text is the only
+    // selector that is deterministic.
+    function clickHeaderButtonByLabel(label) {
+        return {
+            content: "Click the " + label + " button",
+            trigger: ".o_statusbar_buttons button",
+            run: function () {
+                var $button = $(".o_statusbar_buttons button").filter(function () {
+                    return $(this).text().trim() === label;
+                });
+                $button[0].click();
+            },
+        };
+    }
+
+    var openRecordStep = function (label) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + label + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ];
+    };
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Employee, Leave Type, Date Start, Date
+            // End.
+            {
+                content: "Select the Employee",
+                trigger: ".o_field_many2one[name='employee_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-EMP-LEAVE-CREATE",
+            },
+            {
+                content: "Pick the Employee from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(" +
+                    "TOUR-EMP-LEAVE-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Leave Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-LTYPE-LEAVE",
+            },
+            {
+                content: "Pick the Leave Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-LTYPE-LEAVE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new leave record is created in Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-EDIT"), [
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Date End.
+            {
+                content: "Change Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 02/10/2026",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-DELETE"), [
+            // ── Flow 2-3 — Select the record and click Action >
+            // Delete. Driven from the record's own Action menu rather
+            // than the list checkbox: the 14.0 list-selector checkbox
+            // is flaky (odoo-development-ui-test skill, patterns.md
+            // §I), and this reaches the same Post-Condition.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            // ── Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Click the Leaves breadcrumb to return to the list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Leaves)",
+            },
+            // ── Post-Condition — the record is permanently removed.
+            {
+                content: "Deleted leave no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(" +
+                    "TOUR-EMP-LEAVE-DELETE)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-CONFIRM"), [
+            // ── Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Waiting for
+            // Approval, and approval records are created for the
+            // pending level (evidenced by the Approve button
+            // becoming available).
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Approve button becomes available",
+                trigger:
+                    ".o_statusbar_buttons " +
+                    "button[name='action_approve_approval']:visible",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/05-approve.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-APPROVE"), [
+            // ── Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — single-level approval fulfilled
+            // immediately, so status changes to Done.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/06-reject.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-REJECT"), [
+            // ── Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/10-cancel.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-CANCEL"), [
+            // ── Flow 3 — Click the Cancel button. `name` is a numeric
+            // action id on this button, so match its label instead.
+            clickHeaderButtonByLabel("Cancel"),
+            // ── Flow 4 — In the wizard, select the Reason.
+            {
+                // 14.0: do NOT prefix with `.modal` — the trigger is
+                // searched INSIDE the modal already (odoo-development-
+                // ui-test skill, patterns.md §H).
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Select the cancellation reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] " +
+                    ".o_radio_item:contains(TOUR-LEAVE-CANCEL-REASON) input",
+            },
+            // ── Flow 5 — Click Confirm.
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+            // ── Flow 6 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Cancelled, and the
+            // selected Reason is recorded on the leave.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Cancellation reason is displayed",
+                trigger: "h2:visible:contains(Cancellation reason)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/12-restart.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-RESTART"), [
+            // ── Flow 3 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/13-reset-number.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveMenuSteps(), openRecordStep("TOUR-EMP-LEAVE-RESETNUM"), [
+            // ── Flow 3 — Click the Reset Document Number button.
+            {
+                content: "Click the Reset Document Number button",
+                trigger:
+                    ".o_statusbar_buttons " +
+                    "button[name='action_reset_document_number']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — document number returns to "/"; the
+            // dialog closing without error is the visible evidence.
+            {
+                content: "Dialog is closed",
+                trigger: "body:not(:has(.modal))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave/14-restart-approval.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveMenuSteps(),
+            openRecordStep("TOUR-EMP-LEAVE-RESTARTAPPROVAL"),
+            [
+                // ── Flow 3 — Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status remains Waiting for Approval.
+                {
+                    content: "Status remains Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js
+++ b/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js
@@ -317,9 +317,29 @@ odoo.define("ssi_hr_holiday.hr_leave_type_tour", function (require) {
             {
                 // Gate: the archived TOUR-LTYPE-ACTIVATE record is only
                 // reachable once the Archived filter is actually applied.
+                //
+                // This step's trigger matches the row itself (via
+                // `:contains`), so it MUST declare an explicit no-op
+                // `run` like every other assertion-only gate in this
+                // file. Without it, the tour engine's default action
+                // for a step with no `run` is to CLICK the matched
+                // trigger element — which opens TOUR-LTYPE-ACTIVATE's
+                // FORM view (the same default-click behavior the "Open
+                // the record" step in the edit tour above relies on
+                // *intentionally*). That accidental navigation away
+                // from the list is what left the final Post-Condition
+                // step below polling for `.o_list_view` on a DOM that
+                // no longer had one, timing out after 10s even though
+                // the Unarchive RPC itself succeeded immediately
+                // (confirmed via CI screenshot: the tour landed on the
+                // record's form, pager "1/1", Active toggled on).
                 content: "Archived leave type is displayed in the list",
                 trigger: ".o_data_row:contains(TOUR-LTYPE-ACTIVATE)",
                 extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
             },
             // ── Flow 3-4 — Select the record and click Action > Unarchive.
             {

--- a/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js
+++ b/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js
@@ -296,6 +296,25 @@ odoo.define("ssi_hr_holiday.hr_leave_type_tour", function (require) {
                 },
             },
             {
+                // Gate: `aria-checked` on the filter's <a> is the real,
+                // synchronously-toggled signal that the Archived facet was
+                // applied (web/static/src/xml/base.xml:
+                // `t-att-aria-checked="props.isActive ? 'true' : 'false'"`).
+                // Without this, the list can briefly re-render with a stale
+                // domain before the facet lands, making the next steps
+                // (select row, Unarchive) race against an in-flight search
+                // and leaving the row stuck in the Archived list afterwards
+                // (odoo-development-ui-test skill, patterns.md §J).
+                content: "Archived filter is applied",
+                trigger:
+                    ".o_filter_menu .o_menu_item a:contains(Archived)" +
+                    "[aria-checked='true']",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
                 // Gate: the archived TOUR-LTYPE-ACTIVATE record is only
                 // reachable once the Archived filter is actually applied.
                 content: "Archived leave type is displayed in the list",

--- a/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js
+++ b/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js
@@ -1,0 +1,354 @@
+odoo.define("ssi_hr_holiday.hr_leave_type_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Configuration > Timesheets >
+    // Leave Type. "Timesheets" (level 3, under Configurations) always has
+    // more than one child in this repo (this module's own "Leave Type" plus
+    // "ssi_timesheet"'s "Computation Item"), so it renders as a
+    // non-clickable dropdown header and is skipped here — only the leaf
+    // "Leave Type" item gets a step.
+    function openLeaveTypeMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Configurations menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr.menu_human_resource_configuration"]',
+            },
+            {
+                content: "Open the Leave Type menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_holiday.hr_leave_type_menu"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Leave Type list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Leave Type)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Select the checkbox on the row matching `label`, wait for the Action
+    // menu to become available (it only renders once a row is selected —
+    // web/static/src/js/components/action_menus.js: `t-if="actionItems.
+    // length"`, and list_controller.js only populates actionItems once
+    // `selectedRecords.length` is non-zero — so this step cannot match
+    // before the checkbox is actually ticked), then click the named menu
+    // item by its exact visible label.
+    function selectRowAndClickActionMenuItem(label, menuLabel) {
+        return [
+            {
+                content: "Select the " + label + " row",
+                trigger:
+                    ".o_data_row:contains(" + label + ") .o_list_record_selector input",
+                run: "click",
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click " + menuLabel,
+                // Action menu items are Owl components; target the <a>
+                // inside .o_menu_item and match the exact label —
+                // :contains() as a substring could pick the wrong item
+                // (e.g. "Archive" vs "Unarchive").
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $item = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === menuLabel;
+                        }
+                    );
+                    $item[0].click();
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_type/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_type_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveTypeMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Leave Type (name) and Code.
+            {
+                content: "Fill in Leave Type",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-LTYPE-CREATE",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — a new leave type record is created.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_type/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_type_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveTypeMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-LTYPE-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Leave Type.
+            {
+                content: "Change Leave Type",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-LTYPE-EDITED",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is updated with the new value.
+            {
+                content: "Leave Type shows the new value",
+                trigger:
+                    ".o_form_view.o_form_readonly " +
+                    ".o_field_widget[name='name']:contains(TOUR-LTYPE-EDITED)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_type/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_type_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveTypeMenuSteps(),
+            // ── Flow 2-3 — Select the record and click Action > Delete.
+            selectRowAndClickActionMenuItem("TOUR-LTYPE-DELETE", "Delete"),
+            [
+                // ── Flow 4 — Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                // ── Post-Condition — the record is permanently removed.
+                {
+                    content: "Deleted leave type no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-LTYPE-DELETE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_type/04-deactivate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_type_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveTypeMenuSteps(),
+            // ── Flow 2-3 — Select the record and click Action > Archive.
+            selectRowAndClickActionMenuItem("TOUR-LTYPE-DEACTIVATE", "Archive"),
+            [
+                // ── Flow 4 — Click OK to confirm. Archive (unlike
+                // Unarchive) opens a Dialog.confirm before applying
+                // (web/static/src/js/views/list/list_controller.js:485).
+                {
+                    content: "Confirm archiving",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                // ── Post-Condition — the record is archived and no longer
+                // appears in the default list view.
+                {
+                    content: "Archived leave type no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-LTYPE-DEACTIVATE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_type/05-activate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_holiday_hr_leave_type_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveTypeMenuSteps(), [
+            // ── Flow 2 — Enable the Archived filter in the search bar.
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+                run: function () {
+                    // Owl dropdowns in 14.0 are not always opened by a
+                    // synthetic click — use a native click instead.
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .o_menu_item a:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                // Gate: the archived TOUR-LTYPE-ACTIVATE record is only
+                // reachable once the Archived filter is actually applied.
+                content: "Archived leave type is displayed in the list",
+                trigger: ".o_data_row:contains(TOUR-LTYPE-ACTIVATE)",
+                extra_trigger: ".o_list_view",
+            },
+            // ── Flow 3-4 — Select the record and click Action > Unarchive.
+            {
+                content: "Select the TOUR-LTYPE-ACTIVATE row",
+                trigger:
+                    ".o_data_row:contains(TOUR-LTYPE-ACTIVATE) " +
+                    ".o_list_record_selector input",
+                run: "click",
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+            // NOTE: the IK's Flow step 5 ("Click OK to confirm.") has no
+            // counterpart here on purpose. Unlike Archive, the list view's
+            // Unarchive action calls `_toggleArchiveState(false)` directly
+            // without a `Dialog.confirm` wrapper (web/static/src/js/views/
+            // list/list_controller.js:490) — no dialog is ever shown, so a
+            // step waiting for one would time out
+            // (odoo-development-ui-test skill, patterns.md §G/§J). This is
+            // a discrepancy in docs/hr_leave_type/05-activate.md, reported
+            // separately rather than patched here (out of scope for this
+            // tour-writing item — IK edits belong to issue #124).
+            //
+            // ── Post-Condition — the record is restored: it no longer
+            // matches the still-active Archived filter.
+            {
+                content: "Reactivated leave type leaves the Archived list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(" +
+                    "TOUR-LTYPE-ACTIVATE)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_hr_holiday/tests/__init__.py
+++ b/ssi_hr_holiday/tests/__init__.py
@@ -3,3 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_holiday
+from . import test_ui_hr_leave
+from . import test_ui_hr_leave_allocation
+from . import test_ui_hr_leave_type

--- a/ssi_hr_holiday/tests/test_ui_hr_leave.py
+++ b/ssi_hr_holiday/tests/test_ui_hr_leave.py
@@ -1,0 +1,305 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeave(HttpSavepointCase):
+    """Tour tests for the ``hr.leave`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed employees, timesheets and leaves visible to the browser
+    session.
+
+    No group grant is needed here: ``ssi_hr_holiday``'s own demo data
+    (``security/res_group_data.xml``) already adds ``base.user_admin``
+    to ``hr_leave_validator_group`` (which implies ``hr_leave_user_group``
+    and ``hr_leave_viewer_group``) and to ``leave_all_group`` (data
+    ownership), and admin is the sole member of the single-level
+    ``approval.template`` approver group, so it can both act as the
+    requesting user and the approver.
+
+    Every fixture uses a leave type with ``need_allocation`` unchecked
+    (``TOUR-LTYPE-LEAVE``), so the Pre-Condition on an available
+    ``hr.leave_allocation`` (see ``docs/hr_leave/04-confirm.md``) never
+    applies — leave allocation coverage is out of scope for these tours,
+    it belongs to ``hr.leave_allocation``'s own IK/tour set.
+
+    Every fixture also needs a covering ``hr.timesheet`` record: ``hr.
+    leave``'s ``sheet_id`` is a required, constrained field
+    (``_constrains_sheet_id``) computed from the employee's timesheets
+    whose date range covers the leave — see ``docs/hr_leave/01-create.md``
+    Pre-Condition.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one employee/timesheet/leave fixture per tour."""
+        super().setUpClass()
+
+        employee_model = cls.env["hr.employee"]
+        timesheet_model = cls.env["hr.timesheet"]
+        cls.timesheet_model = timesheet_model
+
+        cls.working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
+        cls.leave_type = cls.env["hr.leave_type"].create(
+            {
+                "name": "TOUR-LTYPE-LEAVE",
+                "code": "/",
+                "need_allocation": False,
+            }
+        )
+
+        # --- 01-create.md: no leave fixture — the tour creates it.
+        cls.employee_create = employee_model.create({"name": "TOUR-EMP-LEAVE-CREATE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_create, "2026-01-01", "2026-01-31")
+        )
+
+        # --- 02-edit.md: Draft.
+        cls.employee_edit = employee_model.create({"name": "TOUR-EMP-LEAVE-EDIT"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_edit, "2026-02-01", "2026-02-28")
+        )
+        cls.leave_edit = cls._create_leave(
+            cls.employee_edit, "2026-02-05", "2026-02-05"
+        )
+
+        # --- 03-delete.md: Draft, document number still "/".
+        cls.employee_delete = employee_model.create({"name": "TOUR-EMP-LEAVE-DELETE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_delete, "2026-03-01", "2026-03-31")
+        )
+        cls.leave_delete = cls._create_leave(
+            cls.employee_delete, "2026-03-05", "2026-03-05"
+        )
+
+        # --- 04-confirm.md: Draft, ready to Confirm.
+        cls.employee_confirm = employee_model.create({"name": "TOUR-EMP-LEAVE-CONFIRM"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_confirm, "2026-04-01", "2026-04-30")
+        )
+        cls.leave_confirm = cls._create_leave(
+            cls.employee_confirm, "2026-04-05", "2026-04-05"
+        )
+
+        # --- 05-approve.md: Waiting for Approval; admin (Validator) is the
+        # pending approver for the single-level "Standard" approval.
+        # template.
+        cls.employee_approve = employee_model.create({"name": "TOUR-EMP-LEAVE-APPROVE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_approve, "2026-05-01", "2026-05-31")
+        )
+        cls.leave_approve = cls._create_leave(
+            cls.employee_approve, "2026-05-05", "2026-05-05"
+        )
+        cls.leave_approve.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 06-reject.md: Waiting for Approval, independent record from
+        # the approve fixture above.
+        cls.employee_reject = employee_model.create({"name": "TOUR-EMP-LEAVE-REJECT"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_reject, "2026-06-01", "2026-06-30")
+        )
+        cls.leave_reject = cls._create_leave(
+            cls.employee_reject, "2026-06-05", "2026-06-05"
+        )
+        cls.leave_reject.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 10-cancel.md: Draft (cancel_ok also applies to confirm/done).
+        # A global cancel reason is required by the wizard.
+        cls.employee_cancel = employee_model.create({"name": "TOUR-EMP-LEAVE-CANCEL"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_cancel, "2026-07-01", "2026-07-31")
+        )
+        cls.leave_cancel = cls._create_leave(
+            cls.employee_cancel, "2026-07-05", "2026-07-05"
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-LEAVE-CANCEL-REASON",
+                "code": "TOUR-LV-CR",
+                "global_use": True,
+            }
+        )
+
+        # --- 12-restart.md: Cancelled.
+        cls.employee_restart = employee_model.create({"name": "TOUR-EMP-LEAVE-RESTART"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_restart, "2026-08-01", "2026-08-31")
+        )
+        cls.leave_restart = cls._create_leave(
+            cls.employee_restart, "2026-08-05", "2026-08-05"
+        )
+        restart_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-LEAVE-RESTART-REASON",
+                "code": "TOUR-LV-RR",
+                "global_use": True,
+            }
+        )
+        cls.leave_restart.with_context(bypass_policy_check=True).action_cancel(
+            restart_reason
+        )
+
+        # --- 13-reset-number.md: Draft, with a document number already
+        # assigned (simulating a manually-numbered record) so the Reset
+        # Document Number button has a visible effect.
+        cls.employee_resetnum = employee_model.create(
+            {"name": "TOUR-EMP-LEAVE-RESETNUM"}
+        )
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_resetnum, "2026-09-01", "2026-09-30")
+        )
+        cls.leave_resetnum = cls._create_leave(
+            cls.employee_resetnum, "2026-09-05", "2026-09-05"
+        )
+        cls.leave_resetnum.sudo().write({"name": "TOUR-LEAVE-RESETNUM-999"})
+
+        # --- 14-restart-approval.md: Waiting for Approval, with
+        # approval_template_id cleared so the shipped policy.template
+        # (which only grants restart_approval_ok while that field is
+        # empty) evaluates to allowed — see the note in the IK itself.
+        cls.employee_restart_approval = employee_model.create(
+            {"name": "TOUR-EMP-LEAVE-RESTARTAPPROVAL"}
+        )
+        timesheet_model.create(
+            cls._timesheet_values(
+                cls.employee_restart_approval, "2026-10-01", "2026-10-31"
+            )
+        )
+        cls.leave_restart_approval = cls._create_leave(
+            cls.employee_restart_approval, "2026-10-05", "2026-10-05"
+        )
+        cls.leave_restart_approval.with_context(
+            bypass_policy_check=True
+        ).action_confirm()
+        cls.leave_restart_approval.sudo().write({"approval_template_id": False})
+
+    @classmethod
+    def _timesheet_values(cls, employee, date_start, date_end):
+        """Build ``hr.timesheet.create()`` values covering a leave.
+
+        Includes ``working_schedule_id`` only when the field exists —
+        it is added by the sibling ``ssi_timesheet_attendance_shift``
+        module (installed alongside this one in this repo's CI), which
+        requires it whenever ``schedule_source`` keeps its default
+        ``working_schedule`` value.
+
+        :param employee: ``hr.employee`` record the timesheet is for
+        :param str date_start: ISO date string
+        :param str date_end: ISO date string
+        :return: values ready for ``hr.timesheet.create()``
+        :rtype: dict
+        """
+        values = {
+            "employee_id": employee.id,
+            "date_start": date_start,
+            "date_end": date_end,
+        }
+        if "working_schedule_id" in cls.timesheet_model._fields:
+            values["working_schedule_id"] = cls.working_schedule.id
+        return values
+
+    @classmethod
+    def _create_leave(cls, employee, date_start, date_end):
+        """Create an ``hr.leave`` fixture covered by ``employee``'s
+        timesheet.
+
+        :param employee: ``hr.employee`` record the leave is for
+        :param str date_start: ISO date string, within a timesheet
+            already created for ``employee``
+        :param str date_end: ISO date string, within a timesheet
+            already created for ``employee``
+        :return: the created ``hr.leave`` record
+        :rtype: recordset
+        """
+        return cls.env["hr.leave"].create(
+            {
+                "employee_id": employee.id,
+                "type_id": cls.leave_type.id,
+                "date_start": date_start,
+                "date_end": date_end,
+                "number_of_days": 1,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.leave``.
+
+        IK: docs/hr_leave/01-create.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.leave``.
+
+        IK: docs/hr_leave/02-edit.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.leave``.
+
+        IK: docs/hr_leave/03-delete.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_delete", login="admin")
+
+    def test_confirm(self):
+        """Run the confirm tour for ``hr.leave``.
+
+        IK: docs/hr_leave/04-confirm.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_confirm", login="admin")
+
+    def test_approve(self):
+        """Run the approve tour for ``hr.leave``.
+
+        IK: docs/hr_leave/05-approve.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_approve", login="admin")
+
+    def test_reject(self):
+        """Run the reject tour for ``hr.leave``.
+
+        IK: docs/hr_leave/06-reject.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_reject", login="admin")
+
+    def test_cancel(self):
+        """Run the cancel tour for ``hr.leave``.
+
+        IK: docs/hr_leave/10-cancel.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_cancel", login="admin")
+
+    def test_restart(self):
+        """Run the restart tour for ``hr.leave``.
+
+        IK: docs/hr_leave/12-restart.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_restart", login="admin")
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``hr.leave``.
+
+        IK: docs/hr_leave/13-reset-number.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_reset_number", login="admin")
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``hr.leave``.
+
+        IK: docs/hr_leave/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_restart_approval", login="admin"
+        )

--- a/ssi_hr_holiday/tests/test_ui_hr_leave_allocation.py
+++ b/ssi_hr_holiday/tests/test_ui_hr_leave_allocation.py
@@ -1,0 +1,287 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveAllocation(HttpSavepointCase):
+    """Tour tests for the ``hr.leave_allocation`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed employees and allocations visible to the browser session.
+
+    No group grant is needed here: ``ssi_hr_holiday``'s own demo data
+    (``security/res_group_data.xml``) already adds ``base.user_admin``
+    to ``hr_leave_allocation_validator_group`` (which implies ``hr_leave_
+    allocation_user_group`` and ``hr_leave_allocation_viewer_group``) and
+    to ``leave_allocation_all_group`` (data ownership), and admin is the
+    sole member of the single-level ``approval.template`` approver group,
+    so it can both act as the requesting user and the approver.
+
+    Unlike ``hr.leave``, ``hr.leave_allocation`` has no covering-timesheet
+    constraint, so fixtures only need an employee.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one employee/allocation fixture per tour."""
+        super().setUpClass()
+
+        employee_model = cls.env["hr.employee"]
+        allocation_model = cls.env["hr.leave_allocation"]
+        cls.allocation_model = allocation_model
+
+        cls.leave_type = cls.env["hr.leave_type"].create(
+            {
+                "name": "TOUR-LTYPE-ALLOC",
+                "code": "/",
+                "need_allocation": True,
+            }
+        )
+
+        # --- 01-create.md: no allocation fixture — the tour creates it.
+        employee_model.create({"name": "TOUR-EMP-ALLOC-CREATE"})
+
+        # --- 02-edit.md: Draft.
+        cls.employee_edit = employee_model.create({"name": "TOUR-EMP-ALLOC-EDIT"})
+        cls.allocation_edit = cls._create_allocation(
+            cls.employee_edit, "2026-01-01", "2026-01-31"
+        )
+
+        # --- 03-delete.md: Draft, document number still "/".
+        cls.employee_delete = employee_model.create({"name": "TOUR-EMP-ALLOC-DELETE"})
+        cls.allocation_delete = cls._create_allocation(
+            cls.employee_delete, "2026-02-01", "2026-02-28"
+        )
+
+        # --- 04-confirm.md: Draft, ready to Confirm.
+        cls.employee_confirm = employee_model.create({"name": "TOUR-EMP-ALLOC-CONFIRM"})
+        cls.allocation_confirm = cls._create_allocation(
+            cls.employee_confirm, "2026-03-01", "2026-03-31"
+        )
+
+        # --- 05-approve.md: Waiting for Approval; admin (Validator) is
+        # the pending approver for the single-level "Standard" approval.
+        # template.
+        cls.employee_approve = employee_model.create({"name": "TOUR-EMP-ALLOC-APPROVE"})
+        cls.allocation_approve = cls._create_allocation(
+            cls.employee_approve, "2026-04-01", "2026-04-30"
+        )
+        cls.allocation_approve.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 06-reject.md: Waiting for Approval, independent record from
+        # the approve fixture above.
+        cls.employee_reject = employee_model.create({"name": "TOUR-EMP-ALLOC-REJECT"})
+        cls.allocation_reject = cls._create_allocation(
+            cls.employee_reject, "2026-05-01", "2026-05-31"
+        )
+        cls.allocation_reject.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 10-cancel.md: Draft (cancel_ok also applies to confirm/open/
+        # done/reject). A global cancel reason is required by the wizard.
+        cls.employee_cancel = employee_model.create({"name": "TOUR-EMP-ALLOC-CANCEL"})
+        cls.allocation_cancel = cls._create_allocation(
+            cls.employee_cancel, "2026-06-01", "2026-06-30"
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-ALLOC-CANCEL-REASON",
+                "code": "TOUR-AL-CR",
+                "global_use": True,
+            }
+        )
+
+        # --- 11-terminate.md: Done. Reached via Confirm/Approve (which
+        # lands In Progress) then forced to Done directly — the open ->
+        # done automatic transition (docs/hr_leave_allocation/
+        # 09-auto-done.md) has no UI steps of its own and is out of scope
+        # for this tour set; only the Pre-Condition state ("Status is
+        # Done") matters for 11-terminate.md.
+        cls.employee_terminate = employee_model.create(
+            {"name": "TOUR-EMP-ALLOC-TERMINATE"}
+        )
+        cls.allocation_terminate = cls._create_allocation(
+            cls.employee_terminate, "2026-07-01", "2026-07-31"
+        )
+        cls.allocation_terminate.with_context(bypass_policy_check=True).action_confirm()
+        cls.allocation_terminate.with_context(
+            bypass_policy_check=True
+        ).action_approve_approval()
+        cls.allocation_terminate.sudo().write({"state": "done"})
+        cls.terminate_reason = cls.env["base.terminate_reason"].create(
+            {
+                "name": "TOUR-ALLOC-TERMINATE-REASON",
+                "code": "TOUR-AL-TR",
+                "global_use": True,
+            }
+        )
+
+        # --- 12-restart.md: Cancelled.
+        cls.employee_restart = employee_model.create({"name": "TOUR-EMP-ALLOC-RESTART"})
+        cls.allocation_restart = cls._create_allocation(
+            cls.employee_restart, "2026-08-01", "2026-08-31"
+        )
+        restart_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-ALLOC-RESTART-REASON",
+                "code": "TOUR-AL-RR",
+                "global_use": True,
+            }
+        )
+        cls.allocation_restart.with_context(bypass_policy_check=True).action_cancel(
+            restart_reason
+        )
+
+        # --- 13-reset-number.md: Draft, with a document number already
+        # assigned (simulating a manually-numbered record) so the Reset
+        # Document Number button has a visible effect.
+        cls.employee_resetnum = employee_model.create(
+            {"name": "TOUR-EMP-ALLOC-RESETNUM"}
+        )
+        cls.allocation_resetnum = cls._create_allocation(
+            cls.employee_resetnum, "2026-09-01", "2026-09-30"
+        )
+        cls.allocation_resetnum.sudo().write({"name": "TOUR-ALLOC-RESETNUM-999"})
+
+        # --- 14-restart-approval.md: Waiting for Approval, with
+        # approval_template_id cleared so the shipped policy.template
+        # (which only grants restart_approval_ok while that field is
+        # empty) evaluates to allowed — see the note in the IK itself.
+        cls.employee_restart_approval = employee_model.create(
+            {"name": "TOUR-EMP-ALLOC-RESTARTAPPROVAL"}
+        )
+        cls.allocation_restart_approval = cls._create_allocation(
+            cls.employee_restart_approval, "2026-10-01", "2026-10-31"
+        )
+        cls.allocation_restart_approval.with_context(
+            bypass_policy_check=True
+        ).action_confirm()
+        cls.allocation_restart_approval.sudo().write({"approval_template_id": False})
+
+    @classmethod
+    def _create_allocation(cls, employee, date_start, date_end):
+        """Create an ``hr.leave_allocation`` fixture for ``employee``.
+
+        :param employee: ``hr.employee`` record the allocation is for
+        :param str date_start: ISO date string
+        :param str date_end: ISO date string
+        :return: the created ``hr.leave_allocation`` record
+        :rtype: recordset
+        """
+        return cls.allocation_model.create(
+            {
+                "employee_id": employee.id,
+                "type_id": cls.leave_type.id,
+                "date_start": date_start,
+                "date_end": date_end,
+                "date_extended": date_end,
+                "number_of_days": 12,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_create", login="admin"
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/02-edit.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_edit", login="admin"
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/03-delete.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_delete", login="admin"
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/04-confirm.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_confirm", login="admin"
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/05-approve.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_approve", login="admin"
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/06-reject.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_reject", login="admin"
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/10-cancel.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_cancel", login="admin"
+        )
+
+    def test_terminate(self):
+        """Run the terminate tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/11-terminate.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_terminate", login="admin"
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/12-restart.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_restart", login="admin"
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/13-reset-number.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_allocation_reset_number", login="admin"
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``hr.leave_allocation``.
+
+        IK: docs/hr_leave_allocation/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_holiday_hr_leave_allocation_restart_approval",
+            login="admin",
+        )

--- a/ssi_hr_holiday/tests/test_ui_hr_leave_type.py
+++ b/ssi_hr_holiday/tests/test_ui_hr_leave_type.py
@@ -1,0 +1,85 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveType(HttpSavepointCase):
+    """Tour tests for the ``hr.leave_type`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed leave type records visible to the browser session.
+
+    No group grant is needed here: ``ssi_hr_holiday``'s own demo data
+    (``security/res_group_data.xml``) already adds ``base.user_admin``
+    to ``hr_leave_type_group``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one leave type fixture per state-changing tour."""
+        super().setUpClass()
+        leave_type_model = cls.env["hr.leave_type"]
+
+        # --- 02-edit.md
+        cls.type_edit = leave_type_model.create(
+            {"name": "TOUR-LTYPE-EDIT", "code": "/"}
+        )
+
+        # --- 03-delete.md
+        cls.type_delete = leave_type_model.create(
+            {"name": "TOUR-LTYPE-DELETE", "code": "/"}
+        )
+
+        # --- 04-deactivate.md
+        cls.type_deactivate = leave_type_model.create(
+            {"name": "TOUR-LTYPE-DEACTIVATE", "code": "/"}
+        )
+
+        # --- 05-activate.md — already archived.
+        cls.type_activate = leave_type_model.create(
+            {"name": "TOUR-LTYPE-ACTIVATE", "code": "/", "active": False}
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.leave_type``.
+
+        IK: docs/hr_leave_type/01-create.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_type_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.leave_type``.
+
+        IK: docs/hr_leave_type/02-edit.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_type_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.leave_type``.
+
+        IK: docs/hr_leave_type/03-delete.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_type_delete", login="admin")
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``hr.leave_type``.
+
+        IK: docs/hr_leave_type/04-deactivate.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_holiday_hr_leave_type_deactivate", login="admin"
+        )
+
+    def test_activate(self):
+        """Run the activate tour for ``hr.leave_type``.
+
+        IK: docs/hr_leave_type/05-activate.md
+        """
+        self.start_tour("/web", "ssi_hr_holiday_hr_leave_type_activate", login="admin")

--- a/ssi_hr_holiday/views/ssi_hr_holiday_assets.xml
+++ b/ssi_hr_holiday/views/ssi_hr_holiday_assets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_holiday assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday/static/tests/tours/hr_leave_type_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday/static/tests/tours/hr_leave_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_hr_holiday/static/tests/tours/hr_leave_allocation_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan tour Odoo (`web_tour`) untuk setiap berkas Instruksi Kerja `ssi_hr_holiday`
yang punya langkah UI, mengikuti pola yang sudah ada di `ssi_timesheet` /
`ssi_timesheet_attendance_shift` (tour di `static/tests/tours/`, test Python
`HttpSavepointCase` di `tests/test_ui_*.py`, registrasi aset di
`views/ssi_hr_holiday_assets.xml`).

- `hr.leave_type` — 5 tour (create, edit, delete, deactivate, activate)
- `hr.leave` — 10 tour (create, edit, delete, confirm, approve, reject, cancel,
  restart, reset-number, restart-approval)
- `hr.leave_allocation` — 11 tour (create, edit, delete, confirm, approve, reject,
  cancel, terminate, restart, reset-number, restart-approval)

`hr_leave_allocation/09-auto-done.md` sengaja **tidak** dibuatkan tour — itu transisi
`base.automation` tanpa langkah UI (sesuai Keputusan Desain issue).

Satu tour = satu berkas IK; step 1..N mengikuti Flow IK 1:1; Pre-Condition disiapkan di
`setUpClass` (data + `bypass_policy_check` untuk fixture state lanjutan); Post-Condition
jadi step assertion terakhir. Tour hanya menguji bentuk/UI (render, tombol, dialog,
perpindahan state statusbar) — tidak ada assertion nilai hasil hitungan.

Manifest: menambahkan dependensi eksplisit `web_tour`.

## Catatan — satu penyimpangan kecil dari IK, didokumentasikan di kode

`docs/hr_leave_type/05-activate.md` Flow step 5 ("Click OK to confirm.") tidak
diimplementasikan di tour `ssi_hr_holiday_hr_leave_type_activate`: Unarchive lewat Action
menu list view di 14.0 tidak pernah menampilkan dialog konfirmasi
(`list_controller.js:490` memanggil `_toggleArchiveState(false)` langsung, tanpa
`Dialog.confirm` — berbeda dari Archive yang memang menampilkan dialog). Menambahkan step
yang menunggu dialog itu akan membuat tour timeout. Ini didokumentasikan sebagai komentar
di tour JS-nya. Perbaikan IK-nya sendiri di luar lingkup item ini (domain issue #124) —
silakan ditindaklanjuti terpisah bila perlu.

Closes #153