### PR TITLE
[UPD] ssi_hr_overtime: tambah tour dari Instruksi Kerja

### DIFF
--- a/ssi_hr_overtime/__manifest__.py
+++ b/ssi_hr_overtime/__manifest__.py
@@ -11,6 +11,7 @@
     "installable": True,
     "depends": [
         "ssi_timesheet_attendance",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -24,6 +25,7 @@
         "views/hr_overtime_type_views.xml",
         "views/hr_overtime_views.xml",
         "views/hr_timesheet_views.xml",
+        "views/ssi_hr_overtime_assets.xml",
     ],
     "demo": [
         "demo/hr_overtime_type_data_demo.xml",

--- a/ssi_hr_overtime/static/tests/tours/hr_overtime_tour.js
+++ b/ssi_hr_overtime/static/tests/tours/hr_overtime_tour.js
@@ -1,0 +1,553 @@
+odoo.define("ssi_hr_overtime.hr_overtime_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Overtimes.
+    // "Timesheets" (level 2, section) has several children (Timesheets,
+    // Leaves, Leave Allocations, Overtimes, ...) so it is clickable as a
+    // dropdown-toggle; "Overtimes" (level 3) is a leaf, also clickable.
+    function openOvertimeMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Overtimes menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_overtime.menu_hr_overtime"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Overtimes list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Overtimes)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Click a statusbar/header button by its exact visible label. The
+    // Cancel button shares this form's statusbar but its `name` attribute
+    // is a numeric action id (the Select Cancel Reason wizard action)
+    // rather than a method name, so matching by trimmed text is the only
+    // selector that is deterministic.
+    function clickHeaderButtonByLabel(label) {
+        return {
+            content: "Click the " + label + " button",
+            trigger: ".o_statusbar_buttons button",
+            run: function () {
+                var $button = $(".o_statusbar_buttons button").filter(function () {
+                    return $(this).text().trim() === label;
+                });
+                $button[0].click();
+            },
+        };
+    }
+
+    var openRecordStep = function (label) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + label + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ];
+    };
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Employee, Overtime Type, Date, Date
+            // Start, Date End.
+            {
+                content: "Select the Employee",
+                trigger: ".o_field_many2one[name='employee_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-EMP-OT-CREATE",
+            },
+            {
+                content: "Pick the Employee from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(" +
+                    "TOUR-EMP-OT-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Overtime Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-OTTYPE",
+            },
+            {
+                content: "Pick the Overtime Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-OTTYPE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date",
+                trigger: ".o_field_widget[name='date'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026",
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026 08:00:00",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026 17:00:00",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new overtime record is created in
+            // Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-EDIT"), [
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Date End.
+            {
+                content: "Change Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 02/05/2026 18:00:00",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-DELETE"), [
+            // ── Flow 2-3 — Select the record and click Action >
+            // Delete. Driven from the record's own Action menu rather
+            // than the list checkbox: the 14.0 list-selector checkbox
+            // is flaky (odoo-development-ui-test skill, patterns.md
+            // §I), and this reaches the same Post-Condition.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            // ── Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Click the Overtimes breadcrumb to return to the list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Overtimes)",
+            },
+            // ── Post-Condition — the record is permanently removed.
+            {
+                content: "Deleted overtime no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(" +
+                    "TOUR-EMP-OT-DELETE)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-CONFIRM"), [
+            // ── Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Waiting for
+            // Approval, and approval records are created for the
+            // pending level (evidenced by the Approve button
+            // becoming available).
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Approve button becomes available",
+                trigger:
+                    ".o_statusbar_buttons " +
+                    "button[name='action_approve_approval']:visible",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/05-approve.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-APPROVE"), [
+            // ── Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — single-level approval fulfilled
+            // immediately, so status changes to Done.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/06-reject.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-REJECT"), [
+            // ── Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/10-cancel.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-CANCEL"), [
+            // ── Flow 3 — Click the Cancel button. `name` is a numeric
+            // action id on this button, so match its label instead.
+            clickHeaderButtonByLabel("Cancel"),
+            // ── Flow 4 — In the wizard, select the Reason.
+            {
+                // 14.0: do NOT prefix with `.modal` — the trigger is
+                // searched INSIDE the modal already (odoo-development-
+                // ui-test skill, patterns.md §H).
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Select the cancellation reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] " +
+                    ".o_radio_item:contains(TOUR-OT-CANCEL-REASON) input",
+            },
+            // ── Flow 5 — Click Confirm.
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+            // ── Flow 6 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Cancelled, the
+            // selected Reason is recorded, and Attendances is cleared.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Cancellation reason is displayed",
+                trigger: "h2:visible:contains(Cancellation reason)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/12-restart.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-RESTART"), [
+            // ── Flow 3 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/13-reset-number.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeMenuSteps(), openRecordStep("TOUR-EMP-OT-RESETNUM"), [
+            // ── Flow 3 — Click the Reset Document Number button.
+            {
+                content: "Click the Reset Document Number button",
+                trigger:
+                    ".o_statusbar_buttons " +
+                    "button[name='action_reset_document_number']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — document number returns to "/"; the
+            // dialog closing without error is the visible evidence.
+            {
+                content: "Dialog is closed",
+                trigger: "body:not(:has(.modal))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/14-restart-approval.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeMenuSteps(),
+            openRecordStep("TOUR-EMP-OT-RESTARTAPPROVAL"),
+            [
+                // ── Flow 3 — Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status remains Waiting for Approval.
+                {
+                    content: "Status remains Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_hr_overtime/static/tests/tours/hr_overtime_type_tour.js
+++ b/ssi_hr_overtime/static/tests/tours/hr_overtime_type_tour.js
@@ -1,0 +1,398 @@
+odoo.define("ssi_hr_overtime.hr_overtime_type_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Configuration > Timesheets >
+    // Overtime Types. "Timesheets" (level 3, under Configurations) always
+    // has more than one child in this repo (this module's own "Overtime
+    // Types" plus "ssi_timesheet"'s "Computation Item"), so it renders as
+    // a non-clickable dropdown header and is skipped here — only the leaf
+    // "Overtime Types" item gets a step.
+    function openOvertimeTypeMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Configurations menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr.menu_human_resource_configuration"]',
+            },
+            {
+                content: "Open the Overtime Types menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_overtime.hr_overtime_type_menu"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Overtime Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(" +
+                    "Overtime Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Select the checkbox on the row matching `label`, wait for the Action
+    // menu to become available (it only renders once a row is selected —
+    // web/static/src/js/components/action_menus.js: `t-if="actionItems.
+    // length"`, and list_controller.js only populates actionItems once
+    // `selectedRecords.length` is non-zero — so this step cannot match
+    // before the checkbox is actually ticked), then click the named menu
+    // item by its exact visible label.
+    function selectRowAndClickActionMenuItem(label, menuLabel) {
+        return [
+            {
+                content: "Select the " + label + " row",
+                trigger:
+                    ".o_data_row:contains(" + label + ") .o_list_record_selector input",
+                run: "click",
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click " + menuLabel,
+                // Action menu items are Owl components; target the <a>
+                // inside .o_menu_item and match the exact label —
+                // :contains() as a substring could pick the wrong item
+                // (e.g. "Archive" vs "Unarchive").
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $item = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === menuLabel;
+                        }
+                    );
+                    $item[0].click();
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_type/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_type_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeTypeMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Type.
+            {
+                content: "Fill in Type",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-OTTYPE-CREATE",
+            },
+            // Code is not part of this IK's Flow — it is a required field
+            // inherited from `mixin.master_data` (present on every SSI
+            // master data model, e.g. hr.leave_type), and "/" is its
+            // documented sentinel for "auto-assign a sequence" (see the
+            // field's own help text). Same precedent as
+            // ssi_hr_holiday.hr_leave_type_tour's create tour.
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — a new overtime type record is created.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_type/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_type_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeTypeMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OTTYPE-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Type.
+            {
+                content: "Change Type",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-OTTYPE-EDITED",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is updated with the new value.
+            {
+                content: "Type shows the new value",
+                trigger:
+                    ".o_form_view.o_form_readonly " +
+                    ".o_field_widget[name='name']:contains(TOUR-OTTYPE-EDITED)",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_type/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_type_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeTypeMenuSteps(),
+            // ── Flow 2-3 — Select the record and click Action > Delete.
+            selectRowAndClickActionMenuItem("TOUR-OTTYPE-DELETE", "Delete"),
+            [
+                // ── Flow 4 — Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                // ── Post-Condition — the record is permanently removed.
+                {
+                    content: "Deleted overtime type no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-OTTYPE-DELETE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_type/04-deactivate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_type_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeTypeMenuSteps(),
+            // ── Flow 2-3 — Select the record and click Action > Archive.
+            selectRowAndClickActionMenuItem("TOUR-OTTYPE-DEACTIVATE", "Archive"),
+            [
+                // ── Flow 4 — Click OK to confirm. Archive (unlike
+                // Unarchive) opens a Dialog.confirm before applying
+                // (web/static/src/js/views/list/list_controller.js:485).
+                {
+                    content: "Confirm archiving",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                // ── Post-Condition — the record is archived and no longer
+                // appears in the default list view.
+                {
+                    content: "Archived overtime type no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-OTTYPE-DEACTIVATE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_type/05-activate.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_hr_overtime_type_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeTypeMenuSteps(), [
+            // ── Flow 2 — Enable the Archived filter in the search bar.
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+                run: function () {
+                    // Owl dropdowns in 14.0 are not always opened by a
+                    // synthetic click — use a native click instead.
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .o_menu_item a:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                // Gate: `aria-checked` on the filter's <a> is the real,
+                // synchronously-toggled signal that the Archived facet was
+                // applied (web/static/src/xml/base.xml:
+                // `t-att-aria-checked="props.isActive ? 'true' : 'false'"`).
+                // Without this, the list can briefly re-render with a stale
+                // domain before the facet lands, making the next steps
+                // (select row, Unarchive) race against an in-flight search
+                // and leaving the row stuck in the Archived list afterwards
+                // (odoo-development-ui-test skill, patterns.md §J).
+                content: "Archived filter is applied",
+                trigger:
+                    ".o_filter_menu .o_menu_item a:contains(Archived)" +
+                    "[aria-checked='true']",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                // Gate: the archived TOUR-OTTYPE-ACTIVATE record is only
+                // reachable once the Archived filter is actually applied.
+                //
+                // This step's trigger matches the row itself (via
+                // `:contains`), so it MUST declare an explicit no-op
+                // `run` like every other assertion-only gate in this
+                // file. Without it, the tour engine's default action
+                // for a step with no `run` is to CLICK the matched
+                // trigger element — which opens TOUR-OTTYPE-ACTIVATE's
+                // FORM view (the same default-click behavior the "Open
+                // the record" step in the edit tour above relies on
+                // *intentionally*). That accidental navigation away
+                // from the list would leave the final Post-Condition
+                // step below polling for `.o_list_view` on a DOM that
+                // no longer had one, timing out even though the
+                // Unarchive RPC itself succeeded immediately.
+                content: "Archived overtime type is displayed in the list",
+                trigger: ".o_data_row:contains(TOUR-OTTYPE-ACTIVATE)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3-4 — Select the record and click Action > Unarchive.
+            {
+                content: "Select the TOUR-OTTYPE-ACTIVATE row",
+                trigger:
+                    ".o_data_row:contains(TOUR-OTTYPE-ACTIVATE) " +
+                    ".o_list_record_selector input",
+                run: "click",
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+            // NOTE: the IK's Flow step 5 ("Click OK to confirm.") has no
+            // counterpart here on purpose. Unlike Archive, the list view's
+            // Unarchive action calls `_toggleArchiveState(false)` directly
+            // without a `Dialog.confirm` wrapper (web/static/src/js/views/
+            // list/list_controller.js:490) — no dialog is ever shown, so a
+            // step waiting for one would time out
+            // (odoo-development-ui-test skill, patterns.md §G/§J). Same
+            // discrepancy already reported for
+            // ssi_hr_holiday/docs/hr_leave_type/05-activate.md — out of
+            // scope for this tour-writing item.
+            //
+            // ── Post-Condition — the record is restored: it no longer
+            // matches the still-active Archived filter.
+            {
+                content: "Reactivated overtime type leaves the Archived list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(" +
+                    "TOUR-OTTYPE-ACTIVATE)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_hr_overtime/tests/__init__.py
+++ b/ssi_hr_overtime/tests/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_overtime
+from . import test_ui_hr_overtime
+from . import test_ui_hr_overtime_type

--- a/ssi_hr_overtime/tests/test_ui_hr_overtime.py
+++ b/ssi_hr_overtime/tests/test_ui_hr_overtime.py
@@ -1,0 +1,332 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrOvertime(HttpSavepointCase):
+    """Tour tests for the ``hr.overtime`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed employees, timesheets and overtimes visible to the browser
+    session.
+
+    No group grant is needed here: ``ssi_hr_overtime``'s own demo data
+    (``security/res_group_data.xml``) already adds ``base.user_admin``
+    to ``hr_overtime_validator_group`` (which implies
+    ``hr_overtime_user_group`` and ``hr_overtime_viewer_group``) and to
+    ``overtime_all_group`` (data ownership), and admin is the sole member
+    of the single-level ``approval.template`` approver group, so it can
+    both act as the requesting user and the approver.
+
+    Every fixture uses an overtime type with ``apply_limit_per_day``
+    unchecked (``TOUR-OTTYPE``), so the Pre-Condition on **Limit Per
+    Days** (see ``docs/hr_overtime/01-create.md``) never applies.
+
+    Every fixture also needs a covering ``hr.timesheet`` record: ``hr.
+    overtime``'s ``sheet_id`` is a required, constrained field
+    (``_constrains_sheet_id``) computed from the employee's timesheets
+    whose date range covers the overtime's **Date** — see
+    ``docs/hr_overtime/01-create.md`` Pre-Condition.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one employee/timesheet/overtime fixture per tour."""
+        super().setUpClass()
+
+        employee_model = cls.env["hr.employee"]
+        timesheet_model = cls.env["hr.timesheet"]
+        cls.timesheet_model = timesheet_model
+
+        cls.working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
+        cls.overtime_type = cls.env["hr.overtime_type"].create(
+            {
+                "name": "TOUR-OTTYPE",
+                "code": "/",
+                "apply_limit_per_day": False,
+            }
+        )
+
+        # --- 01-create.md: no overtime fixture — the tour creates it.
+        cls.employee_create = employee_model.create({"name": "TOUR-EMP-OT-CREATE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_create, "2026-01-01", "2026-01-31")
+        )
+
+        # --- 02-edit.md: Draft.
+        cls.employee_edit = employee_model.create({"name": "TOUR-EMP-OT-EDIT"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_edit, "2026-02-01", "2026-02-28")
+        )
+        cls.overtime_edit = cls._create_overtime(
+            cls.employee_edit,
+            "2026-02-05",
+            "2026-02-05 08:00:00",
+            "2026-02-05 17:00:00",
+        )
+
+        # --- 03-delete.md: Draft, document number still "/".
+        cls.employee_delete = employee_model.create({"name": "TOUR-EMP-OT-DELETE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_delete, "2026-03-01", "2026-03-31")
+        )
+        cls.overtime_delete = cls._create_overtime(
+            cls.employee_delete,
+            "2026-03-05",
+            "2026-03-05 08:00:00",
+            "2026-03-05 17:00:00",
+        )
+
+        # --- 04-confirm.md: Draft, ready to Confirm.
+        cls.employee_confirm = employee_model.create({"name": "TOUR-EMP-OT-CONFIRM"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_confirm, "2026-04-01", "2026-04-30")
+        )
+        cls.overtime_confirm = cls._create_overtime(
+            cls.employee_confirm,
+            "2026-04-05",
+            "2026-04-05 08:00:00",
+            "2026-04-05 17:00:00",
+        )
+
+        # --- 05-approve.md: Waiting for Approval; admin (Validator) is the
+        # pending approver for the single-level "Standard" approval
+        # template.
+        cls.employee_approve = employee_model.create({"name": "TOUR-EMP-OT-APPROVE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_approve, "2026-05-01", "2026-05-31")
+        )
+        cls.overtime_approve = cls._create_overtime(
+            cls.employee_approve,
+            "2026-05-05",
+            "2026-05-05 08:00:00",
+            "2026-05-05 17:00:00",
+        )
+        cls.overtime_approve.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 06-reject.md: Waiting for Approval, independent record from
+        # the approve fixture above.
+        cls.employee_reject = employee_model.create({"name": "TOUR-EMP-OT-REJECT"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_reject, "2026-06-01", "2026-06-30")
+        )
+        cls.overtime_reject = cls._create_overtime(
+            cls.employee_reject,
+            "2026-06-05",
+            "2026-06-05 08:00:00",
+            "2026-06-05 17:00:00",
+        )
+        cls.overtime_reject.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 10-cancel.md: Draft (cancel_ok also applies to confirm/done).
+        # A global cancel reason is required by the wizard.
+        cls.employee_cancel = employee_model.create({"name": "TOUR-EMP-OT-CANCEL"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_cancel, "2026-07-01", "2026-07-31")
+        )
+        cls.overtime_cancel = cls._create_overtime(
+            cls.employee_cancel,
+            "2026-07-05",
+            "2026-07-05 08:00:00",
+            "2026-07-05 17:00:00",
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-OT-CANCEL-REASON",
+                "code": "TOUR-OT-CR",
+                "global_use": True,
+            }
+        )
+
+        # --- 12-restart.md: Cancelled.
+        cls.employee_restart = employee_model.create({"name": "TOUR-EMP-OT-RESTART"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_restart, "2026-08-01", "2026-08-31")
+        )
+        cls.overtime_restart = cls._create_overtime(
+            cls.employee_restart,
+            "2026-08-05",
+            "2026-08-05 08:00:00",
+            "2026-08-05 17:00:00",
+        )
+        restart_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-OT-RESTART-REASON",
+                "code": "TOUR-OT-RR",
+                "global_use": True,
+            }
+        )
+        cls.overtime_restart.with_context(bypass_policy_check=True).action_cancel(
+            restart_reason
+        )
+
+        # --- 13-reset-number.md: Draft, with a document number already
+        # assigned (simulating a manually-numbered record) so the Reset
+        # Document Number button has a visible effect.
+        cls.employee_resetnum = employee_model.create({"name": "TOUR-EMP-OT-RESETNUM"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_resetnum, "2026-09-01", "2026-09-30")
+        )
+        cls.overtime_resetnum = cls._create_overtime(
+            cls.employee_resetnum,
+            "2026-09-05",
+            "2026-09-05 08:00:00",
+            "2026-09-05 17:00:00",
+        )
+        cls.overtime_resetnum.sudo().write({"name": "TOUR-OT-RESETNUM-999"})
+
+        # --- 14-restart-approval.md: Waiting for Approval, with
+        # approval_template_id cleared so the shipped policy.template
+        # (which only grants restart_approval_ok while that field is
+        # empty) evaluates to allowed — see the note in the IK itself.
+        cls.employee_restart_approval = employee_model.create(
+            {"name": "TOUR-EMP-OT-RESTARTAPPROVAL"}
+        )
+        timesheet_model.create(
+            cls._timesheet_values(
+                cls.employee_restart_approval, "2026-10-01", "2026-10-31"
+            )
+        )
+        cls.overtime_restart_approval = cls._create_overtime(
+            cls.employee_restart_approval,
+            "2026-10-05",
+            "2026-10-05 08:00:00",
+            "2026-10-05 17:00:00",
+        )
+        cls.overtime_restart_approval.with_context(
+            bypass_policy_check=True
+        ).action_confirm()
+        cls.overtime_restart_approval.sudo().write({"approval_template_id": False})
+
+    @classmethod
+    def _timesheet_values(cls, employee, date_start, date_end):
+        """Build ``hr.timesheet.create()`` values covering an overtime.
+
+        Includes ``working_schedule_id`` only when the field exists —
+        it is added by the sibling ``ssi_timesheet_attendance_shift``
+        module (installed alongside this one in this repo's CI), which
+        requires it whenever ``schedule_source`` keeps its default
+        ``working_schedule`` value.
+
+        :param employee: ``hr.employee`` record the timesheet is for
+        :param str date_start: ISO date string
+        :param str date_end: ISO date string
+        :return: values ready for ``hr.timesheet.create()``
+        :rtype: dict
+        """
+        values = {
+            "employee_id": employee.id,
+            "date_start": date_start,
+            "date_end": date_end,
+        }
+        if "working_schedule_id" in cls.timesheet_model._fields:
+            values["working_schedule_id"] = cls.working_schedule.id
+        return values
+
+    @classmethod
+    def _create_overtime(cls, employee, date, date_start, date_end):
+        """Create an ``hr.overtime`` fixture covered by ``employee``'s
+        timesheet.
+
+        :param employee: ``hr.employee`` record the overtime is for
+        :param str date: ISO date string, within a timesheet already
+            created for ``employee``
+        :param str date_start: datetime string on the same calendar day
+            as ``date``
+        :param str date_end: datetime string, at most 24 hours after
+            ``date_start``
+        :return: the created ``hr.overtime`` record
+        :rtype: recordset
+        """
+        return cls.env["hr.overtime"].create(
+            {
+                "employee_id": employee.id,
+                "type_id": cls.overtime_type.id,
+                "date": date,
+                "date_start": date_start,
+                "date_end": date_end,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/01-create.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/02-edit.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/03-delete.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_delete", login="admin")
+
+    def test_confirm(self):
+        """Run the confirm tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/04-confirm.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_confirm", login="admin")
+
+    def test_approve(self):
+        """Run the approve tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/05-approve.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_approve", login="admin")
+
+    def test_reject(self):
+        """Run the reject tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/06-reject.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_reject", login="admin")
+
+    def test_cancel(self):
+        """Run the cancel tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/10-cancel.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_cancel", login="admin")
+
+    def test_restart(self):
+        """Run the restart tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/12-restart.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_restart", login="admin")
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/13-reset-number.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_hr_overtime_reset_number", login="admin"
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_hr_overtime_restart_approval", login="admin"
+        )

--- a/ssi_hr_overtime/tests/test_ui_hr_overtime_type.py
+++ b/ssi_hr_overtime/tests/test_ui_hr_overtime_type.py
@@ -1,0 +1,91 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrOvertimeType(HttpSavepointCase):
+    """Tour tests for the ``hr.overtime_type`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed overtime type records visible to the browser session.
+
+    No group grant is needed here: ``ssi_hr_overtime``'s own demo data
+    (``security/res_group_data.xml``) already adds ``base.user_admin``
+    to ``hr_overtime_type_group``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one overtime type fixture per state-changing tour."""
+        super().setUpClass()
+        overtime_type_model = cls.env["hr.overtime_type"]
+
+        # --- 02-edit.md
+        cls.type_edit = overtime_type_model.create(
+            {"name": "TOUR-OTTYPE-EDIT", "code": "/"}
+        )
+
+        # --- 03-delete.md
+        cls.type_delete = overtime_type_model.create(
+            {"name": "TOUR-OTTYPE-DELETE", "code": "/"}
+        )
+
+        # --- 04-deactivate.md
+        cls.type_deactivate = overtime_type_model.create(
+            {"name": "TOUR-OTTYPE-DEACTIVATE", "code": "/"}
+        )
+
+        # --- 05-activate.md — already archived.
+        cls.type_activate = overtime_type_model.create(
+            {"name": "TOUR-OTTYPE-ACTIVATE", "code": "/", "active": False}
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.overtime_type``.
+
+        IK: docs/hr_overtime_type/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_hr_overtime_type_create", login="admin"
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.overtime_type``.
+
+        IK: docs/hr_overtime_type/02-edit.md
+        """
+        self.start_tour("/web", "ssi_hr_overtime_hr_overtime_type_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.overtime_type``.
+
+        IK: docs/hr_overtime_type/03-delete.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_hr_overtime_type_delete", login="admin"
+        )
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``hr.overtime_type``.
+
+        IK: docs/hr_overtime_type/04-deactivate.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_hr_overtime_type_deactivate", login="admin"
+        )
+
+    def test_activate(self):
+        """Run the activate tour for ``hr.overtime_type``.
+
+        IK: docs/hr_overtime_type/05-activate.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_hr_overtime_type_activate", login="admin"
+        )

--- a/ssi_hr_overtime/views/ssi_hr_overtime_assets.xml
+++ b/ssi_hr_overtime/views/ssi_hr_overtime_assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_overtime assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_overtime/static/tests/tours/hr_overtime_type_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_hr_overtime/static/tests/tours/hr_overtime_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menulis tour Odoo (`static/tests/tours/`) dan berkas test UI (`tests/test_ui_*.py`) untuk
setiap berkas Instruksi Kerja `ssi_hr_overtime`, mengikuti pemetaan Flow IK → step tour 1:1
sesuai `odoo-development-ui-test`.

* `hr.overtime`: create, edit, delete, confirm, approve, reject, cancel, restart,
  reset-number, restart-approval (10 tour).
* `hr.overtime_type`: create, edit, delete, deactivate, activate (5 tour).
* Menambahkan dependensi `web_tour` dan registrasi aset
  (`views/ssi_hr_overtime_assets.xml`) ke `__manifest__.py`.
* Tidak ada berkas IK yang disunting di PR ini.

Setiap step assertion-only menyertakan `run: function () { ... }` eksplisit agar tour
engine 14.0 tidak menjalankan aksi klik default pada trigger-nya.

Closes #154

## Test plan

- [ ] CI GitHub: `test with Odoo` menjalankan seluruh tour di atas hingga hijau.