### PR TITLE
[UPD] ssi_hr_overtime_batch: tour UI dari Instruksi Kerja

### DIFF
--- a/ssi_hr_overtime_batch/__manifest__.py
+++ b/ssi_hr_overtime_batch/__manifest__.py
@@ -12,6 +12,7 @@
     "installable": True,
     "depends": [
         "ssi_hr_overtime",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -24,6 +25,7 @@
         "data/approval_template_data.xml",
         "views/hr_overtime_batch_views.xml",
         "views/hr_overtime_views.xml",
+        "views/ssi_hr_overtime_batch_assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js
+++ b/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js
@@ -130,18 +130,37 @@ odoo.define("ssi_hr_overtime_batch.hr_overtime_batch_tour", function (require) {
                 content: "Open the Employee tab",
                 trigger: ".o_notebook .nav-link:contains(Employee)",
             },
+            // `employee_ids` has no `widget=` attribute in the view, so it
+            // renders as the default FieldMany2Many — an embedded list
+            // with an "Add a line" control that opens a
+            // SelectCreateDialog, not a tag-input with a free-type
+            // autocomplete (verified against web/static/src/js/fields/
+            // relational_fields.js FieldMany2Many.onAddRecordOpenDialog
+            // and web/static/src/js/views/view_dialogs.js
+            // SelectCreateDialog: a single click on a dialog row fires
+            // `select_record`, which selects that record and closes the
+            // dialog immediately).
             {
-                content: "Select an Employee",
-                trigger: ".o_field_widget[name='employee_ids'] input",
+                content: "Add an Employee line",
+                trigger:
+                    ".o_field_widget[name='employee_ids'] " +
+                    ".o_field_x2many_list_row_add a",
                 extra_trigger: ".o_form_view.o_form_editable",
+            },
+            {
+                content: "Search for the Employee in the dialog",
+                trigger: ".o_searchview_input",
                 run: "text TOUR-BATCH-EMP-CREATE",
             },
             {
-                content: "Pick the Employee from the dropdown",
+                content: "Validate the search",
+                trigger: ".o_searchview_autocomplete li.o_menu_item:first",
+            },
+            {
+                content: "Select the Employee from the dialog list",
                 trigger:
-                    ".ui-autocomplete .ui-menu-item a:contains(" +
-                    "TOUR-BATCH-EMP-CREATE)",
-                in_modal: false,
+                    ".o_data_row:contains(TOUR-BATCH-EMP-CREATE) " +
+                    ".o_data_cell:first",
             },
             {
                 content: "Fill in Date Start",

--- a/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js
+++ b/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js
@@ -1,0 +1,604 @@
+odoo.define("ssi_hr_overtime_batch.hr_overtime_batch_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Overtime Batch.
+    // "Timesheets" (level 2, section) has several children (Timesheets,
+    // Leaves, Leave Allocations, Overtimes, Overtime Batch, ...) so it is
+    // clickable as a dropdown-toggle; "Overtime Batch" (level 3) is a leaf,
+    // also clickable.
+    function openOvertimeBatchMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Overtime Batch menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_overtime_batch.menu_hr_overtime"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Overtime Batch list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Overtime Batch)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Click a statusbar/header button by its exact visible label. The
+    // Cancel button shares this form's statusbar but its `name` attribute
+    // is a numeric action id (the Select Cancel Reason wizard action)
+    // rather than a method name, so matching by trimmed text is the only
+    // selector that is deterministic.
+    function clickHeaderButtonByLabel(label) {
+        return {
+            content: "Click the " + label + " button",
+            trigger: ".o_statusbar_buttons button",
+            run: function () {
+                var $button = $(".o_statusbar_buttons button").filter(function () {
+                    return $(this).text().trim() === label;
+                });
+                $button[0].click();
+            },
+        };
+    }
+
+    var openRecordStep = function (label) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + label + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ];
+    };
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeBatchMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Overtime Type, Employee(s), Date Start,
+            // Date End.
+            {
+                content: "Select the Overtime Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-BATCH-OTTYPE-CREATE",
+            },
+            {
+                content: "Pick the Overtime Type from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(" +
+                    "TOUR-BATCH-OTTYPE-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Select an Employee",
+                trigger: ".o_field_widget[name='employee_ids'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-BATCH-EMP-CREATE",
+            },
+            {
+                content: "Pick the Employee from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(" +
+                    "TOUR-BATCH-EMP-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026 08:00:00",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026 17:00:00",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new overtime batch record is created
+            // in Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-EDIT"),
+            [
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                // ── Flow 3 — Change Date End.
+                {
+                    content: "Change Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text_blur 02/05/2026 18:00:00",
+                },
+                // ── Flow 4 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                // ── Post-Condition — the record is updated.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-DELETE"),
+            [
+                // ── Flow 2-3 — Select the record and click Action >
+                // Delete. Driven from the record's own Action menu rather
+                // than the list checkbox: the 14.0 list-selector checkbox
+                // is flaky (odoo-development-ui-test skill, patterns.md
+                // §I), and this reaches the same Post-Condition.
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+                // ── Flow 4 — Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                {
+                    content:
+                        "Click the Overtime Batch breadcrumb to return to the list",
+                    trigger:
+                        ".breadcrumb-item.o_back_button a:contains(Overtime Batch)",
+                },
+                // ── Post-Condition — the record is permanently removed.
+                {
+                    content: "Deleted overtime batch no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-BATCH-OTTYPE-DELETE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-CONFIRM"),
+            [
+                // ── Flow 3 — Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Waiting for
+                // Approval, and approval records are created for the
+                // pending level (evidenced by the Approve button becoming
+                // available).
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "The Approve button becomes available",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_approve_approval']:visible",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                // ── Post-Condition — a new hr.overtime document is
+                // created for the batch's employee and appears in the
+                // Overtime(s) tab.
+                {
+                    content: "Open the Overtime tab",
+                    trigger: ".o_notebook .nav-link:contains(Overtime)",
+                },
+                {
+                    content:
+                        "The created hr.overtime document appears in the " +
+                        "Overtime(s) tab",
+                    trigger: ".o_data_row:contains(TOUR-BATCH-EMP-CONFIRM)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/05-approve.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-APPROVE"),
+            [
+                // ── Flow 3 — Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — single-level approval fulfilled
+                // immediately, so status changes to Done.
+                {
+                    content: "Status is Done",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='done']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/06-reject.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-REJECT"),
+            [
+                // ── Flow 3 — Click the Reject button.
+                {
+                    content: "Click the Reject button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reject_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Rejected.
+                {
+                    content: "Status is Rejected",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='reject']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/10-cancel.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-CANCEL"),
+            [
+                // ── Flow 3 — Click the Cancel button. `name` is a numeric
+                // action id on this button, so match its label instead.
+                clickHeaderButtonByLabel("Cancel"),
+                // ── Flow 4 — In the wizard, select the Reason.
+                {
+                    // 14.0: do NOT prefix with `.modal` — the trigger is
+                    // searched INSIDE the modal already (odoo-development-
+                    // ui-test skill, patterns.md §H).
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Select the cancellation reason",
+                    trigger:
+                        ".o_field_widget[name='cancel_reason_id'] " +
+                        ".o_radio_item:contains(TOUR-BATCH-CANCEL-REASON) input",
+                },
+                // ── Flow 5 — Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+                // ── Flow 6 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Cancelled, and the
+                // selected Reason is recorded.
+                {
+                    content: "Status is Cancelled",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='cancel']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Cancellation reason is displayed",
+                    trigger: "h2:visible:contains(Cancellation reason)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/12-restart.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-RESTART"),
+            [
+                // ── Flow 3 — Click the Restart button.
+                {
+                    content: "Click the Restart button",
+                    trigger: ".o_statusbar_buttons button[name='action_restart']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status returns to Draft.
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/13-reset-number.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-RESETNUM"),
+            [
+                // ── Flow 3 — Click the Reset Document Number button.
+                {
+                    content: "Click the Reset Document Number button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reset_document_number']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — document number returns to "/"; the
+                // dialog closing without error is the visible evidence.
+                {
+                    content: "Dialog is closed",
+                    trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/14-restart-approval.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_hr_overtime_batch_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openOvertimeBatchMenuSteps(),
+            openRecordStep("TOUR-BATCH-OTTYPE-REAPPROVAL"),
+            [
+                // ── Flow 3 — Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status remains Waiting for Approval.
+                {
+                    content: "Status remains Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js
+++ b/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js
@@ -121,6 +121,15 @@ odoo.define("ssi_hr_overtime_batch.hr_overtime_batch_tour", function (require) {
                     "TOUR-BATCH-OTTYPE-CREATE)",
                 in_modal: false,
             },
+            // Employee(s) lives on the "Employee" notebook tab, which is
+            // not the tab active by default when the form opens — it must
+            // be opened before its field is interactable (odoo-
+            // development-ui-test skill; same convention as "Open the
+            // Overtime tab" below).
+            {
+                content: "Open the Employee tab",
+                trigger: ".o_notebook .nav-link:contains(Employee)",
+            },
             {
                 content: "Select an Employee",
                 trigger: ".o_field_widget[name='employee_ids'] input",

--- a/ssi_hr_overtime_batch/tests/__init__.py
+++ b/ssi_hr_overtime_batch/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_overtime_batch
+from . import test_ui_hr_overtime_batch

--- a/ssi_hr_overtime_batch/tests/test_ui_hr_overtime_batch.py
+++ b/ssi_hr_overtime_batch/tests/test_ui_hr_overtime_batch.py
@@ -1,0 +1,333 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrOvertimeBatch(HttpSavepointCase):
+    """Tour tests for the ``hr.overtime_batch`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed overtime types, employees, timesheets and batches visible to
+    the browser session.
+
+    No group grant is needed here: ``ssi_hr_overtime_batch``'s own demo
+    data (``security/res_group_data.xml``) already adds
+    ``base.user_admin`` to ``hr_overtime_batch_validator_group`` (which
+    implies ``hr_overtime_batch_user_group`` and
+    ``hr_overtime_batch_viewer_group``) and to
+    ``hr_overtime_batch_all_group`` (data ownership), and admin is the
+    sole member of the single-level ``approval.template`` approver
+    group, so it can both act as the requesting user and the approver.
+
+    Every fixture that reaches state ``confirm`` needs a covering
+    ``hr.timesheet`` record for its employee: confirming a batch creates
+    one ``hr.overtime`` document per employee (see
+    ``docs/hr_overtime_batch/04-confirm.md``), and ``hr.overtime``'s own
+    ``sheet_id`` is a required, constrained field computed from the
+    employee's timesheets whose date range covers the overtime's date —
+    see ``ssi_hr_overtime/docs/hr_overtime/01-create.md`` Pre-Condition.
+    Every overtime type used also keeps ``apply_limit_per_day``
+    unchecked, so that Pre-Condition never applies.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one overtime type/employee/timesheet/batch per tour."""
+        super().setUpClass()
+
+        employee_model = cls.env["hr.employee"]
+        timesheet_model = cls.env["hr.timesheet"]
+        cls.timesheet_model = timesheet_model
+
+        cls.working_schedule = cls.env["resource.calendar"].search(
+            [], limit=1, order="id asc"
+        )
+
+        # --- 01-create.md: no batch fixture — the tour creates it. Only
+        # the Overtime Type and Employee it picks from the dropdowns need
+        # to pre-exist.
+        cls._create_overtime_type("TOUR-BATCH-OTTYPE-CREATE")
+        cls.employee_create = employee_model.create({"name": "TOUR-BATCH-EMP-CREATE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_create, "2026-01-01", "2026-01-31")
+        )
+
+        # --- 02-edit.md: Draft, no employee needed.
+        type_edit = cls._create_overtime_type("TOUR-BATCH-OTTYPE-EDIT")
+        cls.batch_edit = cls._create_batch(
+            type_edit, "2026-02-05 08:00:00", "2026-02-05 17:00:00"
+        )
+
+        # --- 03-delete.md: Draft, document number still "/".
+        type_delete = cls._create_overtime_type("TOUR-BATCH-OTTYPE-DELETE")
+        cls.batch_delete = cls._create_batch(
+            type_delete, "2026-03-05 08:00:00", "2026-03-05 17:00:00"
+        )
+
+        # --- 04-confirm.md: Draft, ready to Confirm.
+        type_confirm = cls._create_overtime_type("TOUR-BATCH-OTTYPE-CONFIRM")
+        cls.employee_confirm = employee_model.create({"name": "TOUR-BATCH-EMP-CONFIRM"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_confirm, "2026-04-01", "2026-04-30")
+        )
+        cls.batch_confirm = cls._create_batch(
+            type_confirm,
+            "2026-04-05 08:00:00",
+            "2026-04-05 17:00:00",
+            cls.employee_confirm,
+        )
+
+        # --- 05-approve.md: Waiting for Approval; admin (Validator) is
+        # the pending approver for the single-level "Standard" approval
+        # template.
+        type_approve = cls._create_overtime_type("TOUR-BATCH-OTTYPE-APPROVE")
+        cls.employee_approve = employee_model.create({"name": "TOUR-BATCH-EMP-APPROVE"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_approve, "2026-05-01", "2026-05-31")
+        )
+        cls.batch_approve = cls._create_batch(
+            type_approve,
+            "2026-05-05 08:00:00",
+            "2026-05-05 17:00:00",
+            cls.employee_approve,
+        )
+        cls.batch_approve.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 06-reject.md: Waiting for Approval, independent record from
+        # the approve fixture above.
+        type_reject = cls._create_overtime_type("TOUR-BATCH-OTTYPE-REJECT")
+        cls.employee_reject = employee_model.create({"name": "TOUR-BATCH-EMP-REJECT"})
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_reject, "2026-06-01", "2026-06-30")
+        )
+        cls.batch_reject = cls._create_batch(
+            type_reject,
+            "2026-06-05 08:00:00",
+            "2026-06-05 17:00:00",
+            cls.employee_reject,
+        )
+        cls.batch_reject.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 10-cancel.md: Draft (cancel_ok also applies to
+        # confirm/done). A global cancel reason is required by the
+        # wizard.
+        type_cancel = cls._create_overtime_type("TOUR-BATCH-OTTYPE-CANCEL")
+        cls.batch_cancel = cls._create_batch(
+            type_cancel, "2026-07-05 08:00:00", "2026-07-05 17:00:00"
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-BATCH-CANCEL-REASON",
+                "code": "TOUR-BATCH-CR",
+                "global_use": True,
+            }
+        )
+
+        # --- 12-restart.md: Cancelled.
+        type_restart = cls._create_overtime_type("TOUR-BATCH-OTTYPE-RESTART")
+        cls.batch_restart = cls._create_batch(
+            type_restart, "2026-08-05 08:00:00", "2026-08-05 17:00:00"
+        )
+        restart_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-BATCH-RESTART-REASON",
+                "code": "TOUR-BATCH-RR",
+                "global_use": True,
+            }
+        )
+        cls.batch_restart.with_context(bypass_policy_check=True).action_cancel(
+            restart_reason
+        )
+
+        # --- 13-reset-number.md: Draft, with a document number already
+        # assigned (simulating a manually-numbered record) so the Reset
+        # Document Number button has a visible effect.
+        type_resetnum = cls._create_overtime_type("TOUR-BATCH-OTTYPE-RESETNUM")
+        cls.batch_resetnum = cls._create_batch(
+            type_resetnum, "2026-09-05 08:00:00", "2026-09-05 17:00:00"
+        )
+        cls.batch_resetnum.sudo().write({"name": "TOUR-BATCH-RESETNUM-999"})
+
+        # --- 14-restart-approval.md: Waiting for Approval, with
+        # approval_template_id cleared so the shipped policy.template
+        # (which only grants restart_approval_ok while that field is
+        # empty) evaluates to allowed — see the note in the IK itself.
+        type_reapproval = cls._create_overtime_type("TOUR-BATCH-OTTYPE-REAPPROVAL")
+        cls.employee_reapproval = employee_model.create(
+            {"name": "TOUR-BATCH-EMP-REAPPROVAL"}
+        )
+        timesheet_model.create(
+            cls._timesheet_values(cls.employee_reapproval, "2026-10-01", "2026-10-31")
+        )
+        cls.batch_reapproval = cls._create_batch(
+            type_reapproval,
+            "2026-10-05 08:00:00",
+            "2026-10-05 17:00:00",
+            cls.employee_reapproval,
+        )
+        cls.batch_reapproval.with_context(bypass_policy_check=True).action_confirm()
+        cls.batch_reapproval.sudo().write({"approval_template_id": False})
+
+    @classmethod
+    def _create_overtime_type(cls, name):
+        """Create an ``hr.overtime_type`` fixture used by one tour.
+
+        :param str name: unique name, also used as the tour's
+            dropdown-pick and list-row search anchor
+        :return: the created ``hr.overtime_type`` record
+        :rtype: recordset
+        """
+        return cls.env["hr.overtime_type"].create(
+            {
+                "name": name,
+                "code": "/",
+                "apply_limit_per_day": False,
+            }
+        )
+
+    @classmethod
+    def _timesheet_values(cls, employee, date_start, date_end):
+        """Build ``hr.timesheet.create()`` values covering a batch.
+
+        Includes ``working_schedule_id`` only when the field exists —
+        it is added by the sibling ``ssi_timesheet_attendance_shift``
+        module (installed alongside this one in this repo's CI), which
+        requires it whenever ``schedule_source`` keeps its default
+        ``working_schedule`` value.
+
+        :param employee: ``hr.employee`` record the timesheet is for
+        :param str date_start: ISO date string
+        :param str date_end: ISO date string
+        :return: values ready for ``hr.timesheet.create()``
+        :rtype: dict
+        """
+        values = {
+            "employee_id": employee.id,
+            "date_start": date_start,
+            "date_end": date_end,
+        }
+        if "working_schedule_id" in cls.timesheet_model._fields:
+            values["working_schedule_id"] = cls.working_schedule.id
+        return values
+
+    @classmethod
+    def _create_batch(cls, overtime_type, date_start, date_end, employee=False):
+        """Create an ``hr.overtime_batch`` fixture.
+
+        :param overtime_type: ``hr.overtime_type`` record for the batch
+        :param str date_start: datetime string
+        :param str date_end: datetime string, after ``date_start``
+        :param employee: optional ``hr.employee`` record to include in
+            **Employee(s)**
+        :return: the created ``hr.overtime_batch`` record
+        :rtype: recordset
+        """
+        values = {
+            "type_id": overtime_type.id,
+            "date_start": date_start,
+            "date_end": date_end,
+        }
+        if employee:
+            values["employee_ids"] = [(6, 0, employee.ids)]
+        return cls.env["hr.overtime_batch"].create(values)
+
+    def test_create(self):
+        """Run the create tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_create", login="admin"
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/02-edit.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_edit", login="admin"
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/03-delete.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_delete", login="admin"
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/04-confirm.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_confirm", login="admin"
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/05-approve.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_approve", login="admin"
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/06-reject.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_reject", login="admin"
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/10-cancel.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_cancel", login="admin"
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/12-restart.md
+        """
+        self.start_tour(
+            "/web", "ssi_hr_overtime_batch_hr_overtime_batch_restart", login="admin"
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/13-reset-number.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_overtime_batch_hr_overtime_batch_reset_number",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_overtime_batch_hr_overtime_batch_restart_approval",
+            login="admin",
+        )

--- a/ssi_hr_overtime_batch/views/ssi_hr_overtime_batch_assets.xml
+++ b/ssi_hr_overtime_batch/views/ssi_hr_overtime_batch_assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_overtime_batch assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_overtime_batch/static/tests/tours/hr_overtime_batch_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan tour UI (Odoo Tours, `web_tour`) untuk setiap Instruksi Kerja `ssi_hr_overtime_batch`
(model `hr.overtime_batch`) yang memiliki langkah UI — mengikuti pola `ssi_hr_overtime` dan
`ssi_timesheet_attendance_shift` (kelas test `HttpSavepointCase`, satu tour per berkas IK, step
Flow dipetakan 1:1, Post-Condition sebagai assertion terakhir).

Tour yang ditambahkan (satu per berkas IK):

- `docs/hr_overtime_batch/01-create.md`
- `docs/hr_overtime_batch/02-edit.md`
- `docs/hr_overtime_batch/03-delete.md`
- `docs/hr_overtime_batch/04-confirm.md`
- `docs/hr_overtime_batch/05-approve.md`
- `docs/hr_overtime_batch/06-reject.md`
- `docs/hr_overtime_batch/10-cancel.md`
- `docs/hr_overtime_batch/12-restart.md`
- `docs/hr_overtime_batch/13-reset-number.md`
- `docs/hr_overtime_batch/14-restart-approval.md`

Tour hanya menguji bentuk (view render, tombol, dialog, state statusbar) — bukan nilai hasil
hitungan. Manifest ditambahkan dependensi `web_tour` dan aset tour diregistrasi ke bundle
`web.assets_tests`.

## Test plan

- [x] `pre-commit-gate.sh` — 6 validator (module, ik, po, web, unit-test, tour), 0 pelanggaran baru
- [ ] CI GitHub hijau (dipantau orkestrator)

Closes #155