### PR TITLE
[UPD] ssi_hr_leave_request_batch - tour dari Instruksi Kerja

### DIFF
--- a/ssi_hr_leave_request_batch/__manifest__.py
+++ b/ssi_hr_leave_request_batch/__manifest__.py
@@ -11,6 +11,7 @@
     "installable": True,
     "depends": [
         "ssi_hr_holiday",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -23,6 +24,7 @@
         "data/approval_template_data.xml",
         "views/hr_leave_request_batch_view.xml",
         "views/hr_leave_views.xml",
+        "views/hr_leave_request_batch_assets.xml",
     ],
     "demo": [],
     "images": [],

--- a/ssi_hr_leave_request_batch/static/tests/tours/hr_leave_request_batch_tour.js
+++ b/ssi_hr_leave_request_batch/static/tests/tours/hr_leave_request_batch_tour.js
@@ -1,0 +1,631 @@
+odoo.define("ssi_hr_leave_request_batch.hr_leave_request_batch_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Leave Request
+    // Batch. "Timesheets" (level 2, section) has several children
+    // (Timesheets, Leaves, Leave Allocations, Overtimes, Leave Request
+    // Batch, ...) so it is clickable as a dropdown-toggle; "Leave Request
+    // Batch" (level 3) is a leaf, also clickable.
+    function openLeaveRequestBatchMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Leave Request Batch menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_leave_request_batch.menu_hr_leave_request_batch"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action is also a .o_list_view.
+                content: "Leave Request Batch list is displayed",
+                trigger:
+                    ".o_control_panel " +
+                    ".breadcrumb-item.active:contains(Leave Request Batch)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Click a statusbar/header button by its exact visible label. The
+    // Cancel button shares this form's statusbar but its `name` attribute
+    // is a numeric action id (the Select Cancel Reason wizard action)
+    // rather than a method name, so matching by trimmed text is the only
+    // selector that is deterministic.
+    function clickHeaderButtonByLabel(label) {
+        return {
+            content: "Click the " + label + " button",
+            trigger: ".o_statusbar_buttons button",
+            run: function () {
+                var $button = $(".o_statusbar_buttons button").filter(function () {
+                    return $(this).text().trim() === label;
+                });
+                $button[0].click();
+            },
+        };
+    }
+
+    var openRecordStep = function (label) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + label + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ];
+    };
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openLeaveRequestBatchMenuSteps(), [
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in Type, Employee(s), Date Start, Date End.
+            {
+                content: "Select the Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-LRBATCH-TYPE-CREATE",
+            },
+            {
+                content: "Pick the Type from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(" +
+                    "TOUR-LRBATCH-TYPE-CREATE)",
+                in_modal: false,
+            },
+            // The "Employee" notebook page is inserted (together with
+            // "Leave Request") immediately before the base "Note" page,
+            // which makes it the FIRST page in the resulting notebook —
+            // i.e. the tab active by default when the form opens. No
+            // "click the tab" step is needed before interacting with
+            // `employee_ids` (odoo-development-ui-test skill: only
+            // non-default tabs need an explicit click step; verified
+            // against views/hr_leave_request_batch_view.xml).
+            //
+            // `employee_ids` has no `widget=` attribute in the view, so it
+            // renders as the default FieldMany2Many — an embedded list
+            // with an "Add a line" control that opens a
+            // SelectCreateDialog, not a tag-input with a free-type
+            // autocomplete (verified against web/static/src/js/fields/
+            // relational_fields.js FieldMany2Many.onAddRecordOpenDialog
+            // and web/static/src/js/views/view_dialogs.js
+            // SelectCreateDialog: a single click on a dialog row fires
+            // `select_record`, which selects that record and closes the
+            // dialog immediately).
+            {
+                content: "Add an Employee line",
+                trigger:
+                    ".o_field_widget[name='employee_ids'] " +
+                    ".o_field_x2many_list_row_add a",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+            {
+                content: "Search for the Employee in the dialog",
+                trigger: ".o_searchview_input",
+                run: "text TOUR-LRBATCH-EMP-CREATE",
+            },
+            {
+                content: "Validate the search",
+                trigger: ".o_searchview_autocomplete li.o_menu_item:first",
+            },
+            {
+                content: "Select the Employee from the dialog list",
+                trigger:
+                    ".o_data_row:contains(TOUR-LRBATCH-EMP-CREATE) " +
+                    ".o_data_cell:first",
+            },
+            {
+                // Date_start/date_end come from `mixin.date_duration`
+                // (fields.Date, not Datetime) — the widget takes a plain
+                // date, no time component.
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/05/2026",
+            },
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new leave request batch record is
+            // created in Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-EDIT"),
+            [
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                // ── Flow 3 — Change Date End.
+                {
+                    content: "Change Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text_blur 02/10/2026",
+                },
+                // ── Flow 4 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                // ── Post-Condition — the record is updated.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-DELETE"),
+            [
+                // ── Flow 2-3 — Select the record and click Action >
+                // Delete. Driven from the record's own Action menu rather
+                // than the list checkbox: the 14.0 list-selector checkbox
+                // is flaky (odoo-development-ui-test skill, patterns.md
+                // §I), and this reaches the same Post-Condition.
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    // Action menu items are Owl components; match the exact
+                    // label so "Archive" is never picked instead.
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+                // ── Flow 4 — Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                {
+                    content:
+                        "Click the Leave Request Batch breadcrumb to return " +
+                        "to the list",
+                    trigger:
+                        ".breadcrumb-item.o_back_button a:contains(" +
+                        "Leave Request Batch)",
+                },
+                // ── Post-Condition — the record is permanently removed.
+                {
+                    content:
+                        "Deleted leave request batch no longer appears in " +
+                        "the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(" +
+                        "TOUR-LRBATCH-TYPE-DELETE)))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-CONFIRM"),
+            [
+                // ── Flow 3 — Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Waiting for
+                // Approval, and approval records are created for the
+                // pending level (evidenced by the Approve button becoming
+                // available). This fixture's Employee(s) is empty, so no
+                // hr.leave document is created (see the "If Employee(s)
+                // is empty" branch of this IK's Post-Condition) — that
+                // branch, and the hr.leave documents it produces, are out
+                // of scope here (see ssi_hr_holiday's own hr.leave tour
+                // set).
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "The Approve button becomes available",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_approve_approval']:visible",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/05-approve.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-APPROVE"),
+            [
+                // ── Flow 3 — Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — single-level approval fulfilled
+                // immediately, so status changes to Done.
+                {
+                    content: "Status is Done",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='done']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/06-reject.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-REJECT"),
+            [
+                // ── Flow 3 — Click the Reject button.
+                {
+                    content: "Click the Reject button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reject_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Rejected.
+                {
+                    content: "Status is Rejected",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='reject']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/10-cancel.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-CANCEL"),
+            [
+                // ── Flow 3 — Click the Cancel button. `name` is a numeric
+                // action id on this button, so match its label instead.
+                clickHeaderButtonByLabel("Cancel"),
+                // ── Flow 4 — In the wizard, select the Reason.
+                {
+                    // 14.0: do NOT prefix with `.modal` — the trigger is
+                    // searched INSIDE the modal already (odoo-development-
+                    // ui-test skill, patterns.md §H).
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Select the cancellation reason",
+                    trigger:
+                        ".o_field_widget[name='cancel_reason_id'] " +
+                        ".o_radio_item:contains(TOUR-LRBATCH-CANCEL-REASON) input",
+                },
+                // ── Flow 5 — Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+                // ── Flow 6 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Cancelled, and the
+                // selected Reason is recorded.
+                {
+                    content: "Status is Cancelled",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='cancel']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Cancellation reason is displayed",
+                    trigger: "h2:visible:contains(Cancellation reason)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/12-restart.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-RESTART"),
+            [
+                // ── Flow 3 — Click the Restart button.
+                {
+                    content: "Click the Restart button",
+                    trigger: ".o_statusbar_buttons button[name='action_restart']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status returns to Draft.
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/13-reset-number.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-RESETNUM"),
+            [
+                // ── Flow 3 — Click the Reset Document Number button.
+                {
+                    content: "Click the Reset Document Number button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reset_document_number']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — document number returns to "/"; the
+                // dialog closing without error is the visible evidence.
+                {
+                    content: "Dialog is closed",
+                    trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_leave_request_batch/14-restart-approval.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_leave_request_batch_hr_leave_request_batch_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openLeaveRequestBatchMenuSteps(),
+            openRecordStep("TOUR-LRBATCH-TYPE-REAPPROVAL"),
+            [
+                // ── Flow 3 — Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status remains Waiting for Approval.
+                {
+                    content: "Status remains Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_hr_leave_request_batch/tests/__init__.py
+++ b/ssi_hr_leave_request_batch/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_leave_request_batch
+from . import test_ui_hr_leave_request_batch

--- a/ssi_hr_leave_request_batch/tests/test_ui_hr_leave_request_batch.py
+++ b/ssi_hr_leave_request_batch/tests/test_ui_hr_leave_request_batch.py
@@ -1,0 +1,281 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrLeaveRequestBatch(HttpSavepointCase):
+    """Tour tests for the ``hr.leave_request_batch`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed leave types, employees, and batches visible to the browser
+    session.
+
+    ``base.user_admin`` is already a member of
+    ``hr_leave_request_batch_validator_group`` (this module's own demo
+    data, ``security/res_group_data.xml``), which implies
+    ``hr_leave_request_batch_user_group``/``..._viewer_group`` and is
+    the sole member of the single-level "Standard" ``approval.template``
+    approver group, so it can both act as the requesting user and the
+    approver. Unlike ``hr_leave_request_batch_validator_group``, none of
+    the data-ownership groups (Company / Company and All Child
+    Companies / All) are pre-granted to admin, so every fixture below
+    sets ``user_id`` explicitly to ``base.user_admin`` — otherwise
+    ``hr_leave_request_batch_internal_user_rule``
+    (``[('user_id', '=', user.id)]``) would hide records created by
+    ``cls.env`` (which runs as SUPERUSER) from the "admin" browser
+    session (odoo-development-ui-test skill, "Base class 14.0" note).
+
+    Every fixture from ``04-confirm`` onward leaves **Employee(s)**
+    empty: confirming with employees populated creates one
+    ``hr.leave`` document per employee, which in turn needs a covering
+    ``hr.timesheet`` (and, if the leave type needs allocation, an
+    ``hr.leave_allocation``) — see
+    ``docs/hr_leave_request_batch/04-confirm.md`` Pre-Condition and its
+    "If Employee(s) is empty" Post-Condition branch. That
+    hr.leave-creation branch, and the prerequisites it drags in, are out
+    of scope for this tour set (covered by ``ssi_hr_holiday``'s own
+    ``hr.leave`` tour set).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one leave type/employee/batch fixture per tour."""
+        super().setUpClass()
+
+        cls.admin_user = cls.env.ref("base.user_admin")
+
+        # --- 01-create.md: no batch fixture — the tour creates it. Only
+        # the Type and Employee it picks from the dropdown/dialog need
+        # to pre-exist.
+        cls._create_leave_type("TOUR-LRBATCH-TYPE-CREATE")
+        cls.employee_create = cls.env["hr.employee"].create(
+            {"name": "TOUR-LRBATCH-EMP-CREATE"}
+        )
+
+        # --- 02-edit.md: Draft.
+        type_edit = cls._create_leave_type("TOUR-LRBATCH-TYPE-EDIT")
+        cls.batch_edit = cls._create_batch(type_edit, "2026-02-05", "2026-02-05")
+
+        # --- 03-delete.md: Draft, document number still "/".
+        type_delete = cls._create_leave_type("TOUR-LRBATCH-TYPE-DELETE")
+        cls.batch_delete = cls._create_batch(type_delete, "2026-03-05", "2026-03-05")
+
+        # --- 04-confirm.md: Draft, ready to Confirm.
+        type_confirm = cls._create_leave_type("TOUR-LRBATCH-TYPE-CONFIRM")
+        cls.batch_confirm = cls._create_batch(type_confirm, "2026-04-05", "2026-04-05")
+
+        # --- 05-approve.md: Waiting for Approval; admin (Validator) is
+        # the pending approver for the single-level "Standard" approval
+        # template.
+        type_approve = cls._create_leave_type("TOUR-LRBATCH-TYPE-APPROVE")
+        cls.batch_approve = cls._create_batch(type_approve, "2026-05-05", "2026-05-05")
+        cls.batch_approve.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 06-reject.md: Waiting for Approval, independent record
+        # from the approve fixture above.
+        type_reject = cls._create_leave_type("TOUR-LRBATCH-TYPE-REJECT")
+        cls.batch_reject = cls._create_batch(type_reject, "2026-06-05", "2026-06-05")
+        cls.batch_reject.with_context(bypass_policy_check=True).action_confirm()
+
+        # --- 10-cancel.md: Draft (cancel_ok also applies to
+        # confirm/done/reject). A global cancel reason is required by
+        # the wizard.
+        type_cancel = cls._create_leave_type("TOUR-LRBATCH-TYPE-CANCEL")
+        cls.batch_cancel = cls._create_batch(type_cancel, "2026-07-05", "2026-07-05")
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-LRBATCH-CANCEL-REASON",
+                "code": "TOUR-LRB-CR",
+                "global_use": True,
+            }
+        )
+
+        # --- 12-restart.md: Cancelled.
+        type_restart = cls._create_leave_type("TOUR-LRBATCH-TYPE-RESTART")
+        cls.batch_restart = cls._create_batch(type_restart, "2026-08-05", "2026-08-05")
+        restart_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR-LRBATCH-RESTART-REASON",
+                "code": "TOUR-LRB-RR",
+                "global_use": True,
+            }
+        )
+        cls.batch_restart.with_context(bypass_policy_check=True).action_cancel(
+            restart_reason
+        )
+
+        # --- 13-reset-number.md: Draft, with a document number already
+        # assigned (simulating a manually-numbered record) so the Reset
+        # Document Number button has a visible effect.
+        type_resetnum = cls._create_leave_type("TOUR-LRBATCH-TYPE-RESETNUM")
+        cls.batch_resetnum = cls._create_batch(
+            type_resetnum, "2026-09-05", "2026-09-05"
+        )
+        cls.batch_resetnum.sudo().write({"name": "TOUR-LRBATCH-RESETNUM-999"})
+
+        # --- 14-restart-approval.md: Waiting for Approval, with
+        # approval_template_id cleared so the shipped policy.template
+        # (which only grants restart_approval_ok while that field is
+        # empty) evaluates to allowed — see the note in the IK itself.
+        type_reapproval = cls._create_leave_type("TOUR-LRBATCH-TYPE-REAPPROVAL")
+        cls.batch_reapproval = cls._create_batch(
+            type_reapproval, "2026-10-05", "2026-10-05"
+        )
+        cls.batch_reapproval.with_context(bypass_policy_check=True).action_confirm()
+        cls.batch_reapproval.sudo().write({"approval_template_id": False})
+
+    @classmethod
+    def _create_leave_type(cls, name):
+        """Create an ``hr.leave_type`` fixture used by one tour.
+
+        :param str name: unique name, also used as the tour's
+            dropdown-pick and list-row search anchor
+        :return: the created ``hr.leave_type`` record
+        :rtype: recordset
+        """
+        return cls.env["hr.leave_type"].create(
+            {
+                "name": name,
+                "code": "/",
+                "need_allocation": False,
+            }
+        )
+
+    @classmethod
+    def _create_batch(cls, leave_type, date_start, date_end, employee=False):
+        """Create an ``hr.leave_request_batch`` fixture.
+
+        :param leave_type: ``hr.leave_type`` record for the batch
+        :param str date_start: ISO date string
+        :param str date_end: ISO date string, not before ``date_start``
+        :param employee: optional ``hr.employee`` record to include in
+            **Employee(s)**
+        :return: the created ``hr.leave_request_batch`` record
+        :rtype: recordset
+        """
+        values = {
+            "type_id": leave_type.id,
+            "date_start": date_start,
+            "date_end": date_end,
+            "user_id": cls.admin_user.id,
+        }
+        if employee:
+            values["employee_ids"] = [(6, 0, employee.ids)]
+        return cls.env["hr.leave_request_batch"].create(values)
+
+    def test_create(self):
+        """Run the create tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_restart",
+            login="admin",
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``hr.leave_request_batch``.
+
+        IK: docs/hr_leave_request_batch/13-reset-number.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_reset_number",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for the batch model.
+
+        IK: docs/hr_leave_request_batch/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_leave_request_batch_hr_leave_request_batch_restart_approval",
+            login="admin",
+        )

--- a/ssi_hr_leave_request_batch/views/hr_leave_request_batch_assets.xml
+++ b/ssi_hr_leave_request_batch/views/hr_leave_request_batch_assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_leave_request_batch assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_leave_request_batch/static/tests/tours/hr_leave_request_batch_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan tour Odoo untuk seluruh berkas Instruksi Kerja `ssi_hr_leave_request_batch`
(`hr.leave_request_batch`), satu tour per berkas IK: create, edit, delete, confirm,
approve, reject, cancel, restart, reset-number, dan restart-approval.

- `static/tests/tours/hr_leave_request_batch_tour.js` — 10 tour, dipetakan 1:1 dari
  Flow tiap berkas IK di `docs/hr_leave_request_batch/`.
- `tests/test_ui_hr_leave_request_batch.py` — `HttpSavepointCase` yang menyiapkan
  Pre-Condition tiap tour di `setUpClass` lalu menjalankannya sebagai user "admin".
- `views/hr_leave_request_batch_assets.xml` — registrasi aset tour ke bundle
  `web.assets_tests`.
- `__manifest__.py` — menambahkan dependensi `web_tour` dan entri data di atas.

Tour `04-confirm` s.d. `14-restart-approval` memakai batch dengan **Employee(s)**
kosong (cabang yang didokumentasikan eksplisit di Post-Condition `04-confirm.md`),
sehingga tidak perlu prasyarat `hr.leave`/`hr.timesheet`/`hr.leave_allocation` — itu
wilayah tour `hr.leave` milik `ssi_hr_holiday`.

## Referensi

Closes #156

## Test plan

- [x] `~/.claude/skills/odoo-development-ui-test/assets/validate-tour.sh` — LOLOS
- [x] `~/.claude/skills/odoo-development-repo-ops/assets/pre-commit-gate.sh` — GATE OK
- [ ] CI GitHub (test with Odoo) — dipantau orkestrator