### PR TITLE
[UPD] ssi_hr_leave_request_batch_documenso_signing - docstring kepatuhan

### DIFF
--- a/ssi_hr_leave_request_batch_documenso_signing/models/hr_leave_request_batch.py
+++ b/ssi_hr_leave_request_batch_documenso_signing/models/hr_leave_request_batch.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class HrLeaveRequestBatch(models.Model):
+    """Add Documenso-backed approval to the leave request batch.
+
+    When the batch's approval template defines a Documenso signing
+    template, its multiple-approval flow is replaced by a single
+    ``documenso.signature.request``: the batch is approved once that
+    request is signed, and rejected if it is cancelled.
+    """
+
     _name = "hr.leave_request_batch"
     _inherit = [
         "hr.leave_request_batch",

--- a/ssi_hr_leave_request_batch_documenso_signing/tests/test_hr_leave_request_batch_documenso_signing.py
+++ b/ssi_hr_leave_request_batch_documenso_signing/tests/test_hr_leave_request_batch_documenso_signing.py
@@ -9,7 +9,10 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrLeaveRequestBatchDocumensoSigning(YamlTransactionCase):
+    """Cover Documenso-backed approval on ``hr.leave_request_batch``."""
+
     def test_hr_leave_request_batch_documenso_signing(self):
+        """Run the Documenso signing approval scenario."""
         self.run_yaml_scenario(
             "test_data_hr_leave_request_batch_documenso_signing.yaml"
         )


### PR DESCRIPTION
## Ringkasan

Menambahkan docstring pada class `HrLeaveRequestBatch` (`models/hr_leave_request_batch.py`) dan pada class test `TestHrLeaveRequestBatchDocumensoSigning` + method `test_hr_leave_request_batch_documenso_signing` (`tests/test_hr_leave_request_batch_documenso_signing.py`), memenuhi temuan sapuan kepatuhan `audit-sweep.sh 14.0` pada validator `module` dan `unit-test`.

Murni penambahan docstring — **tidak ada perubahan perilaku**.

Closes #207

## Bukti validator (setelah perubahan kode terakhir)

```
#VALIDATOR name=module target=.../ssi_hr_leave_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=.../ssi_hr_leave_request_batch_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

## Gerbang pra-commit

```
#GATE repo=opnsynid-hr-timesheet-207 modules=1 failed=0 skipped=0 status=OK
```