### PR TITLE
[UPD] ssi_hr_overtime_account: docstring kepatuhan validator module + unit-test

### DIFF
--- a/ssi_hr_overtime_account/models/hr_overtime.py
+++ b/ssi_hr_overtime_account/models/hr_overtime.py
@@ -8,6 +8,15 @@ from odoo.tools.safe_eval import safe_eval
 
 
 class HROvertime(models.Model):
+    """Add analytic account selection to ``hr.overtime``.
+
+    Depending on the configuration of ``hr.overtime_type``, the allowed
+    analytic accounts are either a fixed list or the result of a Python
+    code evaluation. The chosen analytic account is stored on
+    ``analytic_account_id`` and is editable only while the document is
+    in ``draft`` state.
+    """
+
     _inherit = "hr.overtime"
 
     @api.depends(
@@ -15,6 +24,13 @@ class HROvertime(models.Model):
         "employee_id",
     )
     def _compute_allowed_analytic_account_ids(self):
+        """Compute the analytic accounts allowed for this document.
+
+        The result depends on ``type_id.analytic_account_method``: for
+        ``fixed`` it is the type's configured ``analytic_account_ids``;
+        for ``python`` it is the result of evaluating
+        ``type_id.python_code`` via ``_evaluate_analytic_account``.
+        """
         for document in self:
             result = []
             if document.type_id:
@@ -46,6 +62,12 @@ class HROvertime(models.Model):
     )
 
     def _get_localdict(self):
+        """Build the local variables available to ``python_code``.
+
+        :return: dict exposing ``env`` (Odoo Environment) and
+            ``document`` (this ``hr.overtime`` record) to the
+            ``safe_eval`` call in ``_evaluate_analytic_account``
+        """
         self.ensure_one()
         return {
             "env": self.env,
@@ -53,6 +75,17 @@ class HROvertime(models.Model):
         }
 
     def _evaluate_analytic_account(self):
+        """Evaluate ``type_id.python_code`` to get analytic accounts.
+
+        Executes the overtime type's ``python_code`` with the
+        ``env``/``document`` variables from ``_get_localdict``. The
+        code is expected to assign a list of ``account.analytic.account``
+        ids to a ``result`` variable.
+
+        :return: list of analytic account ids, or ``False`` when the
+            code does not set ``result``
+        :raises UserError: when the code evaluation raises an exception
+        """
         self.ensure_one()
         res = False
         localdict = self._get_localdict()

--- a/ssi_hr_overtime_account/models/hr_overtime_type.py
+++ b/ssi_hr_overtime_account/models/hr_overtime_type.py
@@ -6,6 +6,14 @@ from odoo import fields, models
 
 
 class HROvertimeType(models.Model):
+    """Add analytic account configuration to ``hr.overtime_type``.
+
+    Configures how the analytic account offered on ``hr.overtime``
+    documents of this type is determined: a fixed list
+    (``analytic_account_ids``) or a Python code
+    (``python_code``) evaluated per document.
+    """
+
     _inherit = "hr.overtime_type"
 
     analytic_account_method = fields.Selection(

--- a/ssi_hr_overtime_account/tests/test_hr_overtime_account.py
+++ b/ssi_hr_overtime_account/tests/test_hr_overtime_account.py
@@ -9,5 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrOvertimeAccount(YamlTransactionCase):
+    """Test analytic account selection on ``hr.overtime``.
+
+    Covers both ``fixed`` and ``python`` analytic account selection
+    methods configured on ``hr.overtime_type``.
+    """
+
     def test_hr_overtime_account(self):
+        """Run the analytic account selection scenario."""
         self.run_yaml_scenario("test_data_hr_overtime_account.yaml")


### PR DESCRIPTION
## Ringkasan

Menambahkan docstring pada class & method yang sebelumnya belum
terdokumentasi di modul `ssi_hr_overtime_account`, sesuai temuan sapuan
kepatuhan validator `module` dan `unit-test`.

- `models/hr_overtime.py`: class `HROvertime`,
  `_compute_allowed_analytic_account_ids`, `_evaluate_analytic_account`,
  `_get_localdict`
- `models/hr_overtime_type.py`: class `HROvertimeType`
- `tests/test_hr_overtime_account.py`: class `TestHrOvertimeAccount`,
  method `test_hr_overtime_account`

Tidak ada perubahan perilaku/logika — murni docstring. Temuan `ik`
modul ini sengaja **tidak** disentuh di PR ini; sudah dicatat di
open-synergy/opnsynid-hr-timesheet#148 (IK) dan
open-synergy/opnsynid-hr-timesheet#168 (tour).

## Verifikasi

```
#VALIDATOR name=module target=.../ssi_hr_overtime_account series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=.../ssi_hr_overtime_account series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#GATE repo=opnsynid-hr-timesheet-210 modules=1 failed=0 skipped=0 status=OK
```

1 peringatan (`!`) unit-test adalah temuan onchange yang sudah dinyatakan
di luar lingkup issue #210 (butuh konfirmasi manusia terpisah, kontrak
validator §5b).

Closes #210