### PR TITLE
[UPD] ssi_work_log_cost — tour work_log_rate batch 1

### DIFF
--- a/ssi_work_log_cost/__manifest__.py
+++ b/ssi_work_log_cost/__manifest__.py
@@ -13,6 +13,7 @@
         "ssi_work_log_mixin",
         "ssi_product_line_account_mixin",
         "ssi_transaction_ready_mixin",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -27,5 +28,6 @@
         "views/ir_model_views.xml",
         "views/work_log_rate_views.xml",
         "views/hr_employee_views.xml",
+        "views/ssi_work_log_cost_assets.xml",
     ],
 }

--- a/ssi_work_log_cost/static/tests/tours/work_log_rate_tour.js
+++ b/ssi_work_log_cost/static/tests/tours/work_log_rate_tour.js
@@ -1,0 +1,390 @@
+odoo.define("ssi_work_log_cost.work_log_rate_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Work Log Rates.
+    // "Timesheets" (level 2, section) has children of its own but level-2
+    // sections are still rendered as clickable <a data-menu-xmlid=...>;
+    // only level >= 3 items with children degrade into a non-clickable
+    // .dropdown-header. "Work Log Rates" is a level-3 leaf, so both get a
+    // step — matching the three menu segments written in every
+    // work_log_rate IK ("Menu: Human Resource > Timesheets > Work Log
+    // Rates").
+    function openWorkLogRateMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Work Log Rates menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_work_log_cost.menu_work_log_rate"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action ("Employees") is also a
+                // .o_list_view, so it would match while this action is
+                // still loading.
+                content: "Work Log Rates list is displayed",
+                trigger:
+                    ".o_control_panel " +
+                    ".breadcrumb-item.active:contains(Work Log Rates)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Every draft work_log_rate still carries "/" as its document number
+    // (the sequence is only assigned on the transition to Ready to Start,
+    // _create_sequence_state = "ready"), so list rows are located by the
+    // Employee column instead — it is present in work_log_rate_view_tree.
+    function openRecordSteps(employeeName) {
+        return [
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(" + employeeName + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form view is displayed",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    var confirmDialogStep = {
+        content: "Click OK on the confirmation dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_rate/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_cost_work_log_rate_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openWorkLogRateMenuSteps(), [
+            // ── Flow 2 — Click the New button ("Create" in 14.0).
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+            // ── Flow 3 — Fill in Employee, Date, Date Start, Date End.
+            {
+                content: "Select the Employee",
+                trigger: ".o_field_many2one[name='employee_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-WLR-EMP-CREATE",
+            },
+            {
+                content: "Pick the Employee from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR-WLR-EMP-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date",
+                trigger: ".o_field_widget[name='date'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/15/2026",
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/01/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/31/2026",
+            },
+            // ── Flow 4 — On the General Rates tab, click Add a line, then
+            // fill in Product and Pricelist.
+            {
+                content: "Open the General Rates tab",
+                trigger: ".o_notebook .nav-link:contains(General Rates)",
+            },
+            {
+                content: "Add a general rate line",
+                trigger:
+                    ".o_field_x2many[name='general_rate_ids'] " +
+                    ".o_field_x2many_list_row_add a",
+            },
+            {
+                content: "Select the Product",
+                trigger: ".o_selected_row .o_field_widget[name='product_id'] input",
+                run: "text TOUR-WLR-PRODUCT",
+            },
+            {
+                content: "Pick the Product from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-WLR-PRODUCT)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Pricelist",
+                trigger: ".o_selected_row .o_field_widget[name='pricelist_id'] input",
+                run: "text TOUR-WLR-PRICELIST",
+            },
+            {
+                content: "Pick the Pricelist from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR-WLR-PRICELIST)",
+                in_modal: false,
+            },
+            {
+                // Mechanics, not a Flow step: a cell still in edit mode when
+                // Save is clicked does not send its value to the record
+                // (odoo-development-ui-test skill, patterns.md §C "Jebakan
+                // 2"). The <td> wrapping an o2m cell carries no `name`
+                // attribute in 14.0 and this is the only row, so there is no
+                // sibling cell to click; clicking the notebook tab — an
+                // element outside the editable list — unselects the row via
+                // ListRenderer._onWindowClicked without navigating anywhere,
+                // because the General Rates tab is already the active one.
+                content: "Commit the general rate line",
+                trigger: ".o_notebook .nav-link:contains(General Rates)",
+            },
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+            // ── Post-Condition — a new record is created in Draft status.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_rate/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_cost_work_log_rate_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openWorkLogRateMenuSteps(),
+            // ── Flow 2 — Find and open the record to edit.
+            openRecordSteps("TOUR-WLR-EMP-EDIT"),
+            [
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                // ── Flow 3 — Change Date End (the IK leaves which of
+                // Employee / Date / Date Start / Date End to change up to
+                // the actor: "as needed").
+                {
+                    content: "Change Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text_blur 02/28/2026",
+                },
+                // ── Flow 4 — The General Rates tab is left as it is; the IK
+                // makes changing its lines optional ("as needed"), and the
+                // line mechanics are already exercised by the create tour.
+                // ── Flow 5 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                // ── Post-Condition — the record is updated with the new
+                // values.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    content: "Date End shows the new value",
+                    trigger:
+                        ".o_form_view.o_form_readonly " +
+                        ".o_field_widget[name='date_end']:contains(02/28/2026)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_rate/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_cost_work_log_rate_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openWorkLogRateMenuSteps(),
+            // ── Flow 2-3 — select the record and delete it. Deletion is
+            // driven from the record's own Action menu rather than the list
+            // checkbox: the 14.0 list-selector checkbox is flaky
+            // (odoo-development-ui-test skill, patterns.md §I), and this
+            // reaches the same Post-Condition.
+            openRecordSteps("TOUR-WLR-EMP-DELETE"),
+            [
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    // Action menu items are Owl components; match the exact
+                    // label so "Duplicate" is never picked instead.
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+                // ── Flow 4 — Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+                {
+                    content: "Back to the Work Log Rates list",
+                    trigger:
+                        ".breadcrumb-item.o_back_button a:contains(Work Log Rates)",
+                },
+                // ── Post-Condition — the selected record is permanently
+                // removed from the system.
+                {
+                    content: "Deleted work log rate no longer appears in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row" +
+                        ":contains(TOUR-WLR-EMP-DELETE)))",
+                    extra_trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_rate/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_cost_work_log_rate_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            openWorkLogRateMenuSteps(),
+            // ── Flow 2 — Open the record to confirm.
+            openRecordSteps("TOUR-WLR-EMP-CONFIRM"),
+            [
+                // ── Flow 3 — Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+                // ── Flow 4 — Click OK on the confirmation dialog.
+                confirmDialogStep,
+                // ── Post-Condition — status changes to Waiting for Approval.
+                // The modal-closed gate is mandatory here: once the dialog
+                // leaves the DOM the tour engine starts polling immediately
+                // while the form behind it is still re-rendering, which trips
+                // FieldWrapper.updateModifiersValue in 14.0
+                // (odoo-development-ui-test skill, patterns.md §K).
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                        ".btn-primary",
+                    extra_trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+                {
+                    // Approval records were created for the single approver
+                    // level of the "Standard" approval.template — the
+                    // kasatmata evidence of that is the Approve button
+                    // becoming available.
+                    content: "The Approve button becomes available",
+                    trigger:
+                        ".o_statusbar_buttons " +
+                        "button[name='action_approve_approval']:visible",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_work_log_cost/tests/__init__.py
+++ b/ssi_work_log_cost/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_work_log_cost
+from . import test_ui_work_log_rate

--- a/ssi_work_log_cost/tests/test_ui_work_log_rate.py
+++ b/ssi_work_log_cost/tests/test_ui_work_log_rate.py
@@ -1,0 +1,138 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiWorkLogRate(HttpSavepointCase):
+    """Tour tests for the ``work_log_rate`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed the employees and work log rates the browser session opens.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed one fixture per tour, in the state its IK requires.
+
+        Access is already satisfied by module data and therefore not
+        granted here: ``security/res_group_data.xml`` puts
+        ``base.user_admin`` in *Work Log Rate — Validator* (which
+        implies *User*, which implies *Viewer*, the group gating the
+        menu) and in the *All* data-ownership group, so the record rule
+        never hides the seeded records from the tour session.
+
+        The create tour also needs a product and a pricelist to pick in
+        the *General Rates* tab; both carry tour-specific names so the
+        autocomplete dropdown can never resolve to a record shipped by
+        another module.
+        """
+        super().setUpClass()
+
+        employee_model = cls.env["hr.employee"]
+        rate_model = cls.env["work_log_rate"]
+        cls.rate_model = rate_model
+
+        # --- 01-create.md: the general rate line the tour adds needs a
+        # product and a pricelist that exist before the browser starts.
+        cls.product = cls.env["product.product"].create({"name": "TOUR-WLR-PRODUCT"})
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {"name": "TOUR-WLR-PRICELIST"}
+        )
+        cls.employee_create = employee_model.create({"name": "TOUR-WLR-EMP-CREATE"})
+
+        # --- 02-edit.md: Draft. Date End is seeded to a value the tour
+        # does not reuse, so the Post-Condition assertion cannot pass on
+        # the fixture value alone. It still has to sit *after* Date Start:
+        # mixin.date_duration._check_date_start_end raises "Date end must
+        # be greater than date start" whenever date_end < date_start, and
+        # the tour's own new value (02/28/2026) obeys the same rule.
+        cls.employee_edit = employee_model.create({"name": "TOUR-WLR-EMP-EDIT"})
+        cls.rate_edit = rate_model.create(
+            cls._rate_values(cls.employee_edit, "2026-02-01", "2026-02-10")
+        )
+
+        # --- 03-delete.md: Draft, document number still "/".
+        cls.employee_delete = employee_model.create({"name": "TOUR-WLR-EMP-DELETE"})
+        cls.rate_delete = rate_model.create(
+            cls._rate_values(cls.employee_delete, "2026-03-01", "2026-03-31")
+        )
+
+        # --- 04-confirm.md: Draft, confirmed by the tour itself.
+        cls.employee_confirm = employee_model.create({"name": "TOUR-WLR-EMP-CONFIRM"})
+        cls.rate_confirm = rate_model.create(
+            cls._rate_values(cls.employee_confirm, "2026-04-01", "2026-04-30")
+        )
+
+    @classmethod
+    def _rate_values(cls, employee, date_start, date_end):
+        """Build the create values for one draft work log rate.
+
+        Dates are always passed as fixed literals, never derived from
+        "today": a relative base makes the fixture cross a month or year
+        boundary depending on when CI happens to run.
+
+        :param employee: ``hr.employee`` record the rate applies to.
+        :param str date_start: First date the rate is valid for.
+        :param str date_end: Last date the rate is valid for. Must not
+            be earlier than ``date_start``, or
+            ``mixin.date_duration._check_date_start_end`` aborts
+            ``setUpClass`` before any tour runs.
+        :return: Dict of values accepted by ``work_log_rate.create``.
+        """
+        return {
+            "employee_id": employee.id,
+            "date": date_start,
+            "date_start": date_start,
+            "date_end": date_end,
+        }
+
+    def test_create(self):
+        """Run the create tour for ``work_log_rate``.
+
+        IK: docs/work_log_rate/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_cost_work_log_rate_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``work_log_rate``.
+
+        IK: docs/work_log_rate/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_cost_work_log_rate_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``work_log_rate``.
+
+        IK: docs/work_log_rate/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_cost_work_log_rate_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``work_log_rate``.
+
+        IK: docs/work_log_rate/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_cost_work_log_rate_confirm",
+            login="admin",
+        )

--- a/ssi_work_log_cost/views/ssi_work_log_cost_assets.xml
+++ b/ssi_work_log_cost/views/ssi_work_log_cost_assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_work_log_cost assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_work_log_cost/static/tests/tours/work_log_rate_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Menambahkan 4 tour Odoo untuk model `work_log_rate` (batch 1), dipetakan 1:1 dari berkas Instruksi Kerja-nya.

## Lingkup

| Berkas IK | Tour |
|---|---|
| `docs/work_log_rate/01-create.md` | `ssi_work_log_cost_work_log_rate_create` |
| `docs/work_log_rate/02-edit.md` | `ssi_work_log_cost_work_log_rate_edit` |
| `docs/work_log_rate/03-delete.md` | `ssi_work_log_cost_work_log_rate_delete` |
| `docs/work_log_rate/04-confirm.md` | `ssi_work_log_cost_work_log_rate_confirm` |

Ditambahkan juga registrasi aset tour (`web.assets_tests`) dan dependensi `web_tour` di manifest — keduanya dipakai bersama oleh batch 2 (#251) dan batch 3 (#252).

## Catatan

- Langkah tour mengikuti Flow IK berurutan 1:1; Pre-Condition disiapkan di `setUpClass`, Post-Condition jadi step assertion terakhir.
- Tour tidak meng-assert nilai hasil hitungan — hanya yang kasatmata (view ter-render, tombol ada, state di statusbar, record hilang dari list).
- Tidak ada berkas IK yang disunting.
- Tour `delete` dijalankan lewat menu Action pada form record, bukan checkbox baris list (checkbox list 14.0 flaky — skill `odoo-development-ui-test`, `patterns.md` §I), sama seperti tour saudara `ssi_timesheet_hr_timesheet_delete` yang Flow IK-nya identik.

```
#GATE repo=opnsynid-hr-timesheet-159 modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=tour target=ssi_work_log_cost series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik target=ssi_work_log_cost series=14.0 error=0 warn=4 defer=0 excepted=0 status=OK
```

(4 peringatan `ik` yang tersisa adalah berkas IK batch 2/3 — `05-approve`, `07-start`, `09-finish`, `10-cancel` — yang dicakup #251 dan #252, di luar lingkup PR ini.)

Closes #159