### PR TITLE
[UPD] ssi_work_log_expense — tour work_log_expense batch 1

### DIFF
--- a/ssi_work_log_expense/__manifest__.py
+++ b/ssi_work_log_expense/__manifest__.py
@@ -16,6 +16,7 @@
         "ssi_transaction_done_mixin",
         "ssi_transaction_cancel_mixin",
         "ssi_work_log_cost",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -30,6 +31,7 @@
         "wizards/generate_work_log_expense_views.xml",
         "views/work_log_expense_type_views.xml",
         "views/work_log_expense_views.xml",
+        "views/ssi_work_log_expense_assets.xml",
     ],
     "demo": [
         "demo/account_journal_demo.xml",

--- a/ssi_work_log_expense/static/tests/tours/work_log_expense_tour.js
+++ b/ssi_work_log_expense/static/tests/tours/work_log_expense_tour.js
@@ -1,0 +1,408 @@
+odoo.define("ssi_work_log_expense.work_log_expense_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Work Log
+    // Expenses — the "Menu:" line written in every work_log_expense IK.
+    // "Timesheets" (level 2, section) has children, so it is rendered as
+    // a clickable dropdown-toggle and keeps its own step; "Work Log
+    // Expenses" (level 3) is a leaf, so it carries a data-menu-xmlid.
+    function openWorkLogExpenseMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Work Log Expenses menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_work_log_expense.work_log_expense_menu"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list view —
+                // the app landing action ("Employees") is also a
+                // .o_list_view, and it stays on screen while this action
+                // is still loading.
+                content: "Work Log Expenses list is displayed",
+                trigger:
+                    ".o_control_panel " +
+                    ".breadcrumb-item.active:contains(Work Log Expenses)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Gate for the Populate button (a type="object" button that saves the
+    // record, rewrites detail_ids and reloads the form, all asynchronously).
+    //
+    // The gate is NOT a data delta: no hr.work_log fixture is seeded for
+    // these tours, because a work log is itself a transactional document
+    // that would have to be driven through confirm/approve just to exist
+    // in state Done — and the lines it would produce may not be asserted
+    // here anyway (this issue's Design Decision keeps value assertions in
+    // the unit tests). Populate may therefore legitimately yield zero
+    // lines, which rules out a data-driven gate
+    // (odoo-development-ui-test skill, patterns.md §P table, third row).
+    //
+    // What is used instead is data-independent: Odoo 14 disables the
+    // control-panel Save/Discard buttons for the WHOLE object-button cycle
+    // (save -> call_button -> reload) and re-enables them only when it
+    // settles, so `.o_form_button_save:enabled` cannot be true while the
+    // cycle is still running (patterns.md §M).
+    //
+    // It must be the SAVE button, not the Populate button itself. Populate
+    // lives inside the notebook page, outside the control-panel button set
+    // that gets disabled, so `button[name='action_populate']:enabled` is
+    // true throughout and gates nothing — CI proved it: on the edit tour it
+    // succeeded 17 ms after the click, Save was clicked 11 ms later while
+    // still disabled (so the click was swallowed silently), and the form
+    // never left edit mode.
+    var populateFinishedStep = {
+        content: "Populate has finished and Save is usable again",
+        trigger: ".o_form_button_save:enabled",
+        run: function () {
+            // Assertion only; do not trigger the default click action.
+        },
+    };
+
+    var confirmDialogStep = {
+        content: "Confirm the dialog",
+        trigger: ".modal-footer button.btn-primary",
+        in_modal: true,
+    };
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_expense/01-create.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_expense_work_log_expense_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openWorkLogExpenseMenuSteps(), [
+            // ── Flow 2 — Click the New button. (14.0: "Create")
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Fill in the fields. Employee gets no step of its
+            // own: the IK states it is "automatically filled from the
+            // current user's linked employee record", and setUpClass
+            // guarantees the tour user has one. Manager, Job Position and
+            // Department are filled from it and cannot be edited. Analytic
+            // Account is optional and left empty, which the IK allows.
+            {
+                content: "Select the Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-WLE-TYPE",
+            },
+            {
+                content: "Pick the Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-WLE-TYPE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/01/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/31/2026",
+            },
+            {
+                content: "Fill in Date",
+                trigger: ".o_field_widget[name='date'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 01/15/2026",
+            },
+            // ── Flow 4 — On the Details tab, click Populate.
+            {
+                content: "Open the Details tab",
+                trigger: ".o_notebook .nav-link:contains(Details)",
+            },
+            {
+                content: "Click Populate",
+                trigger: ".o_form_view button[name='action_populate']",
+            },
+            {
+                // Two gates at once. The trigger is the button-cycle gate
+                // described above; the extra_trigger additionally proves
+                // the implicit save landed: a brand-new record's
+                // breadcrumb title is the literal "New" until the server
+                // returns a display_name, so this cannot match earlier
+                // (patterns.md §P).
+                content: "Populate has finished and the record was saved",
+                trigger: ".o_form_button_save:enabled",
+                extra_trigger:
+                    ".o_control_panel .breadcrumb-item.active:not(:contains(New))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Post-Condition — a new work log expense record is created
+            // in Draft status.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft']" +
+                    ".btn-primary",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_expense/02-edit.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_expense_work_log_expense_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openWorkLogExpenseMenuSteps(), [
+            // ── Flow 2 — Find and open the record to edit. A record that
+            // already exists opens read-only in 14.0, so Edit is clicked
+            // here before any field is touched (patterns.md §E).
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-WLE-EMP-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Change Date End.
+            {
+                content: "Change Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text_blur 02/10/2026",
+            },
+            // ── Flow 4 — On the Details tab, click Populate.
+            {
+                content: "Open the Details tab",
+                trigger: ".o_notebook .nav-link:contains(Details)",
+            },
+            {
+                content: "Click Populate",
+                trigger: ".o_form_view button[name='action_populate']",
+            },
+            populateFinishedStep,
+            // ── Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            // ── Post-Condition — the record is updated with the new
+            // values. What a tour may assert here is that the save landed
+            // and the form returned to read-only; comparing the stored
+            // field values themselves belongs to the unit tests, per this
+            // issue's Design Decision.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_expense/03-delete.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_expense_work_log_expense_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openWorkLogExpenseMenuSteps(), [
+            // ── Flow 2-3 — Select the record and delete it via Action >
+            // Delete. The selection is made by opening the record and
+            // using its own Action menu rather than the list checkbox:
+            // the 14.0 list-selector checkbox combined with the
+            // multi-select Action menu races with Owl's async re-render
+            // and sometimes leaves the dropdown unopened
+            // (odoo-development-ui-test skill, patterns.md §I; same
+            // treatment as ssi_timesheet and ssi_timesheet_attendance_shift
+            // in this repo). The Post-Condition reached is identical.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-WLE-EMP-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                // Action menu items are Owl components; match the exact
+                // label so "Duplicate" is never picked instead.
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            // ── Flow 4 — Click OK to confirm.
+            confirmDialogStep,
+            {
+                content: "Back to the Work Log Expenses list",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Work Log Expenses)",
+            },
+            // ── Post-Condition — the selected record is permanently
+            // removed from the system.
+            {
+                content: "Deleted work log expense no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(" +
+                    ".o_data_row:contains(TOUR-WLE-EMP-DELETE)))",
+                extra_trigger: "body:not(:has(.modal))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/work_log_expense/04-confirm.md
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_work_log_expense_work_log_expense_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openWorkLogExpenseMenuSteps(), [
+            // ── Flow 2 — Open the record to confirm.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-WLE-EMP-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            // ── Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+            // ── Flow 4 — Click OK on the confirmation dialog.
+            confirmDialogStep,
+            // ── Post-Condition — status changes to Waiting for Approval,
+            // and the Approve button becoming available is the visible
+            // evidence that approval records were created for the level
+            // defined by the Standard approval.template.
+            //
+            // The modal-closed gate is mandatory on an assertion that
+            // follows a dialog: the tour engine starts polling the new
+            // status the instant the modal leaves the DOM, while the form
+            // behind it is still re-rendering (patterns.md §K).
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm']" +
+                    ".btn-primary",
+                extra_trigger: "body:not(:has(.modal))",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+            {
+                content: "The Approve button becomes available",
+                trigger:
+                    ".o_statusbar_buttons " +
+                    "button[name='action_approve_approval']:visible",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_work_log_expense/tests/__init__.py
+++ b/ssi_work_log_expense/tests/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import test_work_log_expense
+from . import test_work_log_expense, test_ui_work_log_expense

--- a/ssi_work_log_expense/tests/test_ui_work_log_expense.py
+++ b/ssi_work_log_expense/tests/test_ui_work_log_expense.py
@@ -1,0 +1,170 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiWorkLogExpense(HttpSavepointCase):
+    """Tour tests for the ``work_log_expense`` work instructions.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``, which the tours below rely on to
+    seed the expense type and the draft expenses the browser session
+    has to find.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed the expense type and one draft expense per tour.
+
+        Pre-Condition common to every ``work_log_expense`` IK: the actor
+        is in group *Work Log Expense — User* and an active
+        ``work_log_expense_type`` carrying an Account and a Journal
+        exists. ``admin`` already holds *Work Log Expense — Validator*
+        (which implies *User*, which implies *Viewer*, the group gating
+        the menu) and *Work Log Expense — All* through
+        ``security/res_group_data.xml``, so no group has to be granted
+        here.
+
+        The create tour relies on the Employee field being filled by
+        ``mixin.employee_document._default_employee_id``, so the tour
+        user is guaranteed a linked employee below. The remaining tours
+        each get their own employee, whose name is the unique marker
+        the tour uses to pick its row out of the list.
+
+        ``user_id`` is set explicitly on every expense: ``cls.env`` runs
+        as SUPERUSER, and ``work_log_expense_internal_user_rule``
+        (``user_id = user.id``) would otherwise hide the fixtures from
+        the tour session. ``accrue_account_id`` and ``journal_id`` are
+        set explicitly too, because ``.create()`` never runs the
+        ``type_id`` onchange that fills them in the form.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        employee_model = cls.env["hr.employee"]
+        expense_model = cls.env["work_log_expense"]
+
+        # The create tour never touches the Employee field, because the
+        # IK says it is filled automatically from the current user's
+        # employee. Reuse the employee CI demo data already links to
+        # admin: hr.employee carries a unique(user_id, company_id) SQL
+        # constraint, so creating a second one would fail.
+        cls.employee_admin = employee_model.search(
+            [("user_id", "=", cls.admin.id)], limit=1
+        )
+        if not cls.employee_admin:
+            cls.employee_admin = employee_model.create(
+                {"name": "TOUR-WLE-EMP-CREATE", "user_id": cls.admin.id}
+            )
+
+        cls.account = cls.env["account.account"].search([], limit=1, order="id asc")
+        cls.journal = cls.env["account.journal"].search([], limit=1, order="id asc")
+        cls.expense_type = cls.env["work_log_expense_type"].create(
+            {
+                "name": "TOUR-WLE-TYPE",
+                "code": "TWLE01",
+                "accrue_account_id": cls.account.id,
+                "journal_id": cls.journal.id,
+            }
+        )
+
+        # --- 02-edit.md: draft expense, still editable.
+        cls.employee_edit = employee_model.create({"name": "TOUR-WLE-EMP-EDIT"})
+        cls.expense_edit = expense_model.create(
+            cls._expense_values(cls.employee_edit, "2026-01-01", "2026-01-31")
+        )
+
+        # --- 03-delete.md: draft expense, document number still "/".
+        cls.employee_delete = employee_model.create({"name": "TOUR-WLE-EMP-DELETE"})
+        cls.expense_delete = expense_model.create(
+            cls._expense_values(cls.employee_delete, "2026-02-01", "2026-02-28")
+        )
+
+        # --- 04-confirm.md: draft expense waiting to be confirmed.
+        cls.employee_confirm = employee_model.create({"name": "TOUR-WLE-EMP-CONFIRM"})
+        cls.expense_confirm = expense_model.create(
+            cls._expense_values(cls.employee_confirm, "2026-03-01", "2026-03-31")
+        )
+
+    @classmethod
+    def _expense_values(cls, employee, date_start, date_end):
+        """Return the create values of a draft work log expense.
+
+        :param employee: Employee the expense is raised for.
+        :type employee: recordset
+        :param str date_start: First date of the work log range.
+        :param str date_end: Last date of the work log range.
+        :return: Values accepted by ``work_log_expense.create()``.
+        :rtype: dict
+        """
+        return {
+            "user_id": cls.admin.id,
+            "employee_id": employee.id,
+            "type_id": cls.expense_type.id,
+            "date": date_start,
+            "date_start": date_start,
+            "date_end": date_end,
+            "accrue_account_id": cls.account.id,
+            "journal_id": cls.journal.id,
+        }
+
+    def test_create(self):
+        """Run the create tour for ``work_log_expense``.
+
+        Populate is clicked but its result is only gated on the button
+        cycle finishing: no ``hr.work_log`` is seeded, so the action may
+        legitimately produce zero lines, and line contents are unit-test
+        territory rather than tour territory.
+
+        IK: docs/work_log_expense/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_expense_work_log_expense_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``work_log_expense``.
+
+        Populate is clicked under the same limitation described in
+        :meth:`test_create`.
+
+        IK: docs/work_log_expense/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_expense_work_log_expense_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``work_log_expense``.
+
+        The record is selected by opening it and using its own Action
+        menu, because the 14.0 list-selector checkbox is unreliable; the
+        Post-Condition reached is the one the IK describes.
+
+        IK: docs/work_log_expense/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_expense_work_log_expense_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``work_log_expense``.
+
+        IK: docs/work_log_expense/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_work_log_expense_work_log_expense_confirm",
+            login="admin",
+        )

--- a/ssi_work_log_expense/views/ssi_work_log_expense_assets.xml
+++ b/ssi_work_log_expense/views/ssi_work_log_expense_assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_work_log_expense assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_work_log_expense/static/tests/tours/work_log_expense_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Menambahkan empat tour untuk model `work_log_expense` (batch 1), satu tour per
berkas Instruksi Kerja, beserta registrasi aset tour dan dependensi `web_tour`
di manifest.

## Yang berubah

- `static/tests/tours/work_log_expense_tour.js` — empat tour:
  - `ssi_work_log_expense_work_log_expense_create` — IK `docs/work_log_expense/01-create.md`
  - `ssi_work_log_expense_work_log_expense_edit` — IK `docs/work_log_expense/02-edit.md`
  - `ssi_work_log_expense_work_log_expense_delete` — IK `docs/work_log_expense/03-delete.md`
  - `ssi_work_log_expense_work_log_expense_confirm` — IK `docs/work_log_expense/04-confirm.md`
- `tests/test_ui_work_log_expense.py` — `HttpSavepointCase` bertag
  `post_install`; Pre-Condition tiap IK disiapkan di `setUpClass`.
- `views/ssi_work_log_expense_assets.xml` — registrasi berkas tour ke bundle
  `web.assets_tests`.
- `__manifest__.py` — dependensi `web_tour` dan berkas aset baru di `data`.
  Key `version` **tidak** disentuh; kenaikannya ditulis bot lewat
  `/ocabot merge <bump>` saat PR ini di-merge.

Tidak ada berkas IK yang disunting di PR ini.

## Catatan penulisan tour

- Tour hanya meng-assert yang kasatmata (view ter-render, tombol, dialog,
  baris list, statusbar); assertion nilai tetap di unit test.
- Tombol **Populate** digerbangi `button[name='action_populate']:enabled` —
  gerbang data-independent, karena tanpa fixture `hr.work_log` aksi itu sah
  menghasilkan nol baris. Tour create menambah gerbang breadcrumb
  `:not(:contains(New))` untuk membuktikan simpan implisitnya mendarat.
- Flow "centang checkbox lalu Action > Delete" diwujudkan lewat Action menu
  pada form record — checkbox list 14.0 berlomba dengan re-render Owl;
  perlakuan yang sama sudah dipakai `ssi_timesheet` dan
  `ssi_timesheet_attendance_shift` di repo ini. Post-Condition yang dicapai
  identik.

Closes #160