### PR TITLE
[UPD] ssi_hr_leave_request_batch_operating_unit — docstring kepatuhan audit

### DIFF
--- a/ssi_hr_leave_request_batch_operating_unit/models/hr_leave_request_batch.py
+++ b/ssi_hr_leave_request_batch_operating_unit/models/hr_leave_request_batch.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class HrLeaveRequestBatch(models.Model):
+    """Add Operating Unit requirement to leave request batches.
+
+    Pure ``_inherit`` extension: no method is added or overridden here.
+    Mixing in ``mixin.single_operating_unit`` makes an Operating Unit
+    mandatory on every ``hr.leave_request_batch`` record.
+    """
+
     _name = "hr.leave_request_batch"
     _inherit = [
         "hr.leave_request_batch",

--- a/ssi_hr_leave_request_batch_operating_unit/tests/test_hr_leave_request_batch_operating_unit.py
+++ b/ssi_hr_leave_request_batch_operating_unit/tests/test_hr_leave_request_batch_operating_unit.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrLeaveRequestBatchOperatingUnit(YamlTransactionCase):
+    """Cover the Operating Unit extension on ``hr.leave_request_batch``."""
+
     def test_hr_leave_request_batch_operating_unit(self):
+        """Run the Operating Unit scenario for ``hr.leave_request_batch``."""
         self.run_yaml_scenario("test_data_hr_leave_request_batch_operating_unit.yaml")


### PR DESCRIPTION
## Ringkasan

Menambahkan docstring class & method yang hilang pada modul
`ssi_hr_leave_request_batch_operating_unit`, sesuai temuan sapuan kepatuhan
`audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` (validator `module` +
`unit-test`). Item ini murni kepatuhan — tidak ada perubahan perilaku.

- Docstring kelas pada `HrLeaveRequestBatch` (`models/hr_leave_request_batch.py`).
- Docstring class `TestHrLeaveRequestBatchOperatingUnit` dan method
  `test_hr_leave_request_batch_operating_unit`
  (`tests/test_hr_leave_request_batch_operating_unit.py`).

## Verifikasi

```
#VALIDATOR name=module target=ssi_hr_leave_request_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_leave_request_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=opnsynid-hr-timesheet-209 modules=1 failed=0 skipped=0 status=OK
```

Closes #209