### PR TITLE
[UPD] ssi_hr_overtime_batch_operating_unit - kepatuhan skill 14.0

### DIFF
--- a/ssi_hr_overtime_batch_operating_unit/README.rst
+++ b/ssi_hr_overtime_batch_operating_unit/README.rst
@@ -6,6 +6,10 @@
 Overtime Batch + Operating Unit
 ===============================
 
+Work Instruction
+=================
+
+* `Create Overtime Batch <docs/hr_overtime_batch/index.html>`_
 
 Installation
 ============

--- a/ssi_hr_overtime_batch_operating_unit/__manifest__.py
+++ b/ssi_hr_overtime_batch_operating_unit/__manifest__.py
@@ -12,10 +12,12 @@
     "depends": [
         "ssi_hr_overtime_batch",
         "ssi_operating_unit_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_group/res_group_data.xml",
         "security/ir_rule/ir_rule_data.xml",
         "views/hr_overtime_batch_views.xml",
+        "views/ssi_hr_overtime_batch_operating_unit_assets_tests.xml",
     ],
 }

--- a/ssi_hr_overtime_batch_operating_unit/docs/hr_overtime_batch/01-create.md
+++ b/ssi_hr_overtime_batch_operating_unit/docs/hr_overtime_batch/01-create.md
@@ -1,0 +1,22 @@
+# Create Overtime Batch
+
+> **Module:** ssi_hr_overtime_batch_operating_unit
+>
+> **Extends:** ssi_hr_overtime_batch — model `hr.overtime_batch`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field:
+
+- **Operating Unit**: The operating unit this overtime batch belongs to. Defaults to the
+  current user's default operating unit. Only visible to users in the _Multi Operating
+  Unit_ group (`operating_unit.group_multi_operating_unit`); hidden for
+  single-operating-unit installations. The same field is also added (hidden by default)
+  as an optional column in the **Overtime Batch** list, and as a **Group By: Operating
+  Unit** filter in the search view — both gated by the same group.
+
+## Modified — Record Visibility
+
+- A user granted the _Operating Unit_ data-ownership group for this model only sees
+  overtime batches whose **Operating Unit** is one of the operating units assigned to
+  them (record rule). This is not a Flow step.

--- a/ssi_hr_overtime_batch_operating_unit/models/hr_overtime_batch.py
+++ b/ssi_hr_overtime_batch_operating_unit/models/hr_overtime_batch.py
@@ -5,7 +5,16 @@
 from odoo import models
 
 
-class HROvertimeBatch(models.Model):
+class HrOvertimeBatch(models.Model):
+    """Add Operating Unit requirement to overtime batches.
+
+    Pure ``_inherit`` extension: no method is added or overridden here.
+    Mixing in ``mixin.single_operating_unit`` makes an Operating Unit
+    mandatory on every ``hr.overtime_batch`` record, gating its
+    visibility to users granted the operating units the record belongs
+    to (see the ``ir.rule`` shipped by this module).
+    """
+
     _name = "hr.overtime_batch"
     _inherit = [
         "hr.overtime_batch",

--- a/ssi_hr_overtime_batch_operating_unit/static/tests/tours/hr_overtime_batch_tour.js
+++ b/ssi_hr_overtime_batch_operating_unit/static/tests/tours/hr_overtime_batch_tour.js
@@ -1,0 +1,95 @@
+odoo.define("ssi_hr_overtime_batch_operating_unit.hr_overtime_batch_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps: Human Resource > Timesheets > Overtime
+    // Batch.
+    function openOvertimeBatchMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Overtime Batch menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_overtime_batch.menu_hr_overtime"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any
+                // list view — the app landing action is also a
+                // .o_list_view.
+                content: "Overtime Batch list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(Overtime Batch)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default
+                    // click action.
+                },
+            },
+        ];
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime_batch/01-create.md
+    // (delta on top of
+    // ssi_hr_overtime_batch/hr_overtime_batch/01-create.md — adds
+    // the Operating Unit field, visible only to users in the
+    // Multi Operating Unit group). Per the E1 extension pattern
+    // (odoo-development-ui-test skill, patterns.md §O /
+    // scope-and-boundaries.md §3): navigation is taken from the
+    // base tour (open menu → Create), then a single assertion
+    // proves the added field is displayed. Does NOT continue into
+    // Save/Confirm/etc. — those belong to the base
+    // ssi_hr_overtime_batch create tour.
+    // ═══════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_batch_operating_unit_hr_overtime_batch_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOvertimeBatchMenuSteps(), [
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default
+                    // click action.
+                },
+            },
+            // ── Additional Fields — Operating Unit is displayed
+            // on the create form (actor is in
+            // group_multi_operating_unit, see setUpClass).
+            // Anchored to the field's label rather than the
+            // widget itself, matching the pattern recommended for
+            // delta tours (patterns.md §O).
+            {
+                content: "Operating Unit field is displayed",
+                trigger: ".o_form_label:contains(Operating Unit)",
+                run: function () {
+                    // Assertion only; do not trigger the default
+                    // click action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_hr_overtime_batch_operating_unit/tests/__init__.py
+++ b/ssi_hr_overtime_batch_operating_unit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_overtime_batch_operating_unit
+from . import test_ui_hr_overtime_batch

--- a/ssi_hr_overtime_batch_operating_unit/tests/test_hr_overtime_batch_operating_unit.py
+++ b/ssi_hr_overtime_batch_operating_unit/tests/test_hr_overtime_batch_operating_unit.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrOvertimeBatchOperatingUnit(YamlTransactionCase):
+    """Cover the Operating Unit extension on ``hr.overtime_batch``."""
+
     def test_hr_overtime_batch_operating_unit(self):
+        """Run the Operating Unit scenario for ``hr.overtime_batch``."""
         self.run_yaml_scenario("test_data_hr_overtime_batch_operating_unit.yaml")

--- a/ssi_hr_overtime_batch_operating_unit/tests/test_ui_hr_overtime_batch.py
+++ b/ssi_hr_overtime_batch_operating_unit/tests/test_ui_hr_overtime_batch.py
@@ -1,0 +1,44 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrOvertimeBatch(HttpSavepointCase):
+    """Tour test for the create-delta work instruction added by
+    ``ssi_hr_overtime_batch_operating_unit`` (the Operating Unit
+    field) on ``hr.overtime_batch``.
+
+    Uses ``HttpSavepointCase`` rather than plain ``HttpCase``: in 14.0
+    ``TransactionCase`` only assigns ``self.env`` inside instance
+    ``setUp()``, so ``cls.env`` is not available in ``setUpClass()``.
+    ``HttpSavepointCase`` (via ``SingleTransactionCase``) does set
+    ``cls.env`` in ``setUpClass()``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the Multi Operating Unit group so the field is shown.
+
+        Pre-Condition common to ``01-create.md``'s ``Additional
+        Fields`` delta: the actor must belong to
+        ``operating_unit.group_multi_operating_unit`` for the
+        Operating Unit field to be visible on the create form.
+        """
+        super().setUpClass()
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.env.ref("base.user_admin").id)]}
+        )
+
+    def test_create(self):
+        """Run the create-delta tour for ``hr.overtime_batch``.
+
+        IK: docs/hr_overtime_batch/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_overtime_batch_operating_unit_hr_overtime_batch_create",
+            login="admin",
+        )

--- a/ssi_hr_overtime_batch_operating_unit/views/ssi_hr_overtime_batch_operating_unit_assets_tests.xml
+++ b/ssi_hr_overtime_batch_operating_unit/views/ssi_hr_overtime_batch_operating_unit_assets_tests.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_overtime_batch_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_overtime_batch_operating_unit/static/tests/tours/hr_overtime_batch_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menyelesaikan 3 dari 6 validator kepatuhan (module, ik, unit-test) yang FAILED pada
sapuan `audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet` untuk modul
`ssi_hr_overtime_batch_operating_unit`:

* Ganti nama class Python `HROvertimeBatch` menjadi `HrOvertimeBatch` (PascalCase dari `_name`).
* Tambahkan docstring pada class model, class test, dan method test.
* Tulis IK delta `docs/hr_overtime_batch/01-create.md` (arketipe E1 Additional Fields +
  E6 Modified Record Visibility) untuk field Operating Unit yang ditambahkan modul ini.
* Tulis tour pasangan IK (`static/tests/tours/hr_overtime_batch_tour.js`) + HttpCase
  `test_ui_hr_overtime_batch.py`, terdaftar ke bundle `web.assets_tests`.
* Tambahkan bagian *Work Instruction* di `README.rst`.

Perubahan murni kepatuhan (naming/docstring/dokumentasi/test) — tidak ada perubahan
perilaku/fitur.

## Bukti validator (setelah perubahan kode terakhir)

```
#VALIDATOR name=module    target=ssi_hr_overtime_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_overtime_batch_operating_unit series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_overtime_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_overtime_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_overtime_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_overtime_batch_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-hr-timesheet-212 modules=1 failed=0 skipped=0 precommit=OK status=OK`

Closes #212