### PR TITLE
[UPD] ssi_hr_overtime_documenso_signing - kepatuhan skill 14.0

### DIFF
--- a/ssi_hr_overtime_documenso_signing/README.rst
+++ b/ssi_hr_overtime_documenso_signing/README.rst
@@ -12,6 +12,11 @@ an open-source digital signature platform.
 It adds a *Documenso* tab to the HR Overtime form view, allowing users to
 manage signature requests directly from the overtime record.
 
+Work Instruction
+================
+
+* `Approve Overtime <docs/hr_overtime/index.html>`_
+
 Configuration
 =============
 

--- a/ssi_hr_overtime_documenso_signing/__manifest__.py
+++ b/ssi_hr_overtime_documenso_signing/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_hr_overtime",
         "ssi_connector_documenso_signing",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_hr_overtime_documenso_signing/docs/hr_overtime/05-approve.md
+++ b/ssi_hr_overtime_documenso_signing/docs/hr_overtime/05-approve.md
@@ -1,0 +1,37 @@
+# Approve Overtime
+
+> **Module:** ssi_hr_overtime_documenso_signing
+>
+> **Extends:** ssi_hr_overtime — model `hr.overtime`, action `05-approve`
+
+## Modified Flow
+
+- Anchor: at Flow base step 2 (open the record to approve), the form already shows a
+  **Signature Requests** tab (injected because `_documenso_signing_create_page = True`).
+  This tab is always present once this module is installed, regardless of whether
+  Documenso signing is actually used for the current approval.
+- The behavior below only applies **when the record's active Approval Template has a
+  Documenso Signing Template configured**. If it does not, the base Flow (steps 3–4,
+  click **Approve** / click **OK**) applies unchanged, exactly as documented in
+  `ssi_hr_overtime/docs/hr_overtime/05-approve.md`.
+- When a Documenso Signing Template **is** configured: no per-approver approval record
+  is created for this document — a single `documenso.signature.request` is created and
+  linked instead (during the earlier Confirm action, before this record reaches
+  **Waiting for Approval**). Because there is no per-approver record naming the current
+  user as an active approver, the **Approve** button (Flow base step 3) stays invisible
+  for every user — it can never be clicked.
+- Instead of clicking Approve, the user opens the linked request — shown under the
+  **Approval Signing Request** group as the **Approval Signature Request** field in the
+  **Signature Requests** tab (or via the **Open Signature Requests** button in the same
+  tab) — and, on that request's own form, clicks **Send to Documenso** to send the
+  document for e-signature. The designated signer(s) then sign the document outside
+  Odoo, in Documenso.
+- Approval completes automatically — without any button click on this Overtime record —
+  once the linked signature request reaches the **Signed** status (checked manually via
+  **Check Status** on the request, or synced automatically by the connector). At that
+  point, the base Post-Condition applies as usual: status automatically changes to
+  **Done** (single-level "Standard" approval template).
+- If the linked signature request is **cancelled** instead (e.g. a signer declines in
+  Documenso), the record moves directly to **Rejected** — the same end state as the base
+  Reject action, but triggered automatically by the cancelled request rather than by a
+  user clicking Reject.

--- a/ssi_hr_overtime_documenso_signing/models/hr_overtime.py
+++ b/ssi_hr_overtime_documenso_signing/models/hr_overtime.py
@@ -6,6 +6,17 @@ from odoo import models
 
 
 class HrOvertime(models.Model):
+    """Adds Documenso e-signature approval to overtime requests.
+
+    A **Signature Requests** tab is added to the form. When the
+    ``approval.template`` in effect defines a Documenso signing
+    template, confirming the overtime creates a single
+    ``documenso.signature.request`` instead of standard approval
+    records, and the document is approved automatically once that
+    request is signed (or moved to the rejection state if the signer
+    cancels) — see ``mixin.documenso_signing_approval``.
+    """
+
     _name = "hr.overtime"
     _inherit = [
         "hr.overtime",

--- a/ssi_hr_overtime_documenso_signing/static/tests/tours/hr_overtime_tour.js
+++ b/ssi_hr_overtime_documenso_signing/static/tests/tours/hr_overtime_tour.js
@@ -1,0 +1,110 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_hr_overtime_documenso_signing.hr_overtime_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/hr_overtime/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record) is retraced from the base IK
+    // ssi_hr_overtime/docs/hr_overtime/05-approve.md Flow steps 1-2 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("E2a
+    // -- telusur-ulang aksi itu dari base sampai titik ubah"). The delta
+    // assertion, anchored at base Flow step 2 (open the record to
+    // approve), verifies the Signature Requests tab injected because
+    // `_documenso_signing_create_page = True`, then stops -- base Flow
+    // steps 3-4 (Approve / OK) and the resulting Done status are NOT
+    // exercised here, since whether the Approve button is even visible
+    // depends on whether the active Approval Template has a Documenso
+    // Signing Template configured, and this tour's fixture leaves that
+    // unconfigured. The final signed/rejected outcome is driven by the
+    // external Documenso connector and out of scope for a tour
+    // (Keputusan Desain, issue
+    // open-synergy/opnsynid-hr-timesheet#213).
+    tour.register(
+        "ssi_hr_overtime_documenso_signing_hr_overtime_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Human Resource > Timesheets >
+            // Overtimes menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Overtimes menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_overtime.menu_hr_overtime"]',
+            },
+            {
+                // Gate: wait for the TARGET action to be mounted, not
+                // just any list view (the app may land on a stale list
+                // first).
+                content: "Overtimes list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Overtimes)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-EMP-OT-DOCUMENSO-APPROVE) " +
+                    ".o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record form is displayed",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // ── Delta assertion (anchor: base Flow step 2) — the
+            // Signature Requests tab is always present once this module
+            // is installed, regardless of whether Documenso signing is
+            // actually used for the current approval.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored on the group label rather than the (currently
+                // empty) `approval_signature_request_id` many2one widget
+                // itself -- a many2one rendered with no value has no text
+                // node inside its link, so it collapses to a zero-size
+                // box and jQuery's `:visible` (offsetWidth/offsetHeight)
+                // never matches it, hanging the tour until timeout. The
+                // group label always has text, so it is a stable proxy
+                // for "the Approval Signing Request group is rendered".
+                content:
+                    "Signature Requests tab shows the Approval Signing " +
+                    "Request group",
+                trigger: ".o_horizontal_separator:contains(Approval Signing Request)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                    // The tour stops here -- it does not click Approve, does
+                    // not assert a final state, and never calls the external
+                    // Documenso service.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_hr_overtime_documenso_signing/tests/__init__.py
+++ b/ssi_hr_overtime_documenso_signing/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_overtime_documenso_signing
+from . import test_ui_hr_overtime

--- a/ssi_hr_overtime_documenso_signing/tests/test_hr_overtime_documenso_signing.py
+++ b/ssi_hr_overtime_documenso_signing/tests/test_hr_overtime_documenso_signing.py
@@ -9,5 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrOvertimeDocumensoSigning(YamlTransactionCase):
+    """Cover the ``hr.overtime`` Documenso signing mixin installation.
+
+    Verifies the ``mixin.documenso_signing_approval`` inherit does not
+    break the base ``hr.overtime`` creation flow.
+    """
+
     def test_hr_overtime_documenso_signing(self):
+        """Run the "HR Overtime - Documenso Signing Mixin" scenario."""
         self.run_yaml_scenario("test_data_hr_overtime_documenso_signing.yaml")

--- a/ssi_hr_overtime_documenso_signing/tests/test_ui_hr_overtime.py
+++ b/ssi_hr_overtime_documenso_signing/tests/test_ui_hr_overtime.py
@@ -1,0 +1,92 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. In 14.0, plain HttpCase does not
+# set up cls.env in setUpClass; HttpSavepointCase does.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrOvertime(HttpSavepointCase):
+    """Tour test for the ``hr.overtime`` Documenso signing delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an Overtime already Waiting for Approval.
+
+        ``base.user_admin`` is already a member of
+        ``hr_overtime_validator_group`` (which implies the ``User``
+        and ``Viewer`` groups) via ``ssi_hr_overtime``'s
+        ``security/res_group_data.xml``, so it can create and confirm
+        the record directly, without extra group setup. A dedicated
+        Overtime Type with ``apply_limit_per_day = False`` is created,
+        matching the fixture pattern in
+        ``ssi_hr_overtime/tests/test_ui_hr_overtime.py``. An
+        ``hr.timesheet`` covering the overtime's date is also created
+        for the employee — ``_constrains_sheet_id`` requires
+        ``sheet_id`` (computed from a matching ``hr.timesheet``) to be
+        set. Pre-Condition IK 05-approve.md (delta): the record is
+        already Waiting for Approval, reached here via
+        ``action_confirm()`` in Python, not via UI clicks. The
+        "Standard" approval template used by ``ssi_hr_overtime`` demo
+        data has no Documenso Signing Template configured, so the
+        Signature Requests tab is present
+        (``_documenso_signing_create_page = True``) but the base
+        Approve/OK Flow is unaffected -- this tour does not exercise
+        it.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        employee = (
+            cls.env["hr.employee"]
+            .with_user(cls.admin)
+            .create({"name": "TOUR-EMP-OT-DOCUMENSO-APPROVE"})
+        )
+        overtime_type = (
+            cls.env["hr.overtime_type"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "name": "TOUR-OTTYPE-DOCUMENSO",
+                    "code": "/",
+                    "apply_limit_per_day": False,
+                }
+            )
+        )
+        timesheet_values = {
+            "employee_id": employee.id,
+            "date_start": "2026-01-01",
+            "date_end": "2026-01-31",
+        }
+        if "working_schedule_id" in cls.env["hr.timesheet"]._fields:
+            timesheet_values[
+                "working_schedule_id"
+            ] = cls.env.company.resource_calendar_id.id
+        cls.env["hr.timesheet"].with_user(cls.admin).create(timesheet_values)
+        cls.overtime = (
+            cls.env["hr.overtime"]
+            .with_user(cls.admin)
+            .create(
+                {
+                    "employee_id": employee.id,
+                    "type_id": overtime_type.id,
+                    "date": "2026-01-15",
+                    "date_start": "2026-01-15 08:00:00",
+                    "date_end": "2026-01-15 10:00:00",
+                }
+            )
+        )
+        cls.overtime.with_context(bypass_policy_check=True).action_confirm()
+
+    def test_approve(self):
+        """Run the approve tour for the Documenso signing delta.
+
+        IK: docs/hr_overtime/05-approve.md (E2a delta -- Modified Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_overtime_documenso_signing_hr_overtime_approve",
+            login="admin",
+        )

--- a/ssi_hr_overtime_documenso_signing/views/assets.xml
+++ b/ssi_hr_overtime_documenso_signing/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_overtime_documenso_signing assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_overtime_documenso_signing/static/tests/tours/hr_overtime_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 6 temuan ERROR sapuan kepatuhan (`audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet`) pada modul `ssi_hr_overtime_documenso_signing`:

* Docstring class `HrOvertime` + class/method test YAML (`module`)
* Docstring class/method test tour baru (`unit-test`)
* Instruksi Kerja delta `docs/hr_overtime/05-approve.md` (E2a — extends `ssi_hr_overtime` aksi `05-approve`), karena modul ini tidak punya model sendiri, hanya mengaktifkan `mixin.documenso_signing_approval` pada `hr.overtime` (`ik`)

Tour `static/tests/tours/hr_overtime_tour.js` + `tests/test_ui_hr_overtime.py` ditulis mengikuti pola yang sudah ditegakkan `ssi_hr_holiday_documenso_signing` (issue #201, sudah merge di repo yang sama): tour berhenti pada assert tab **Signature Requests** muncul, tidak mengklik Approve (sinyal akhir signing/reject digerakkan konektor eksternal Documenso, di luar cakupan tour).

Murni kepatuhan — tidak ada perubahan perilaku/fitur.

## Bukti validator

```
#VALIDATOR name=module    target=ssi_hr_overtime_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_overtime_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_overtime_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_overtime_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_overtime_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_overtime_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-hr-timesheet-213 modules=1 failed=0 skipped=0 precommit=OK status=OK`

Closes #213