### PR TITLE
[UPD] ssi_hr_overtime_state_change_constrain - kepatuhan skill 14.0

### DIFF
--- a/ssi_hr_overtime_state_change_constrain/README.rst
+++ b/ssi_hr_overtime_state_change_constrain/README.rst
@@ -7,6 +7,12 @@ Overtime State Change Constrain
 ===============================
 
 
+Work Instruction
+================
+
+* `Create Overtime <docs/hr_overtime/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_hr_overtime_state_change_constrain/__manifest__.py
+++ b/ssi_hr_overtime_state_change_constrain/__manifest__.py
@@ -12,6 +12,9 @@
     "depends": [
         "ssi_hr_overtime",
         "ssi_state_change_constrain_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
 }

--- a/ssi_hr_overtime_state_change_constrain/docs/hr_overtime/01-create.md
+++ b/ssi_hr_overtime_state_change_constrain/docs/hr_overtime/01-create.md
@@ -1,0 +1,22 @@
+# Create Overtime
+
+> **Module:** ssi_hr_overtime_state_change_constrain
+>
+> **Extends:** ssi_hr_overtime — model `hr.overtime`, aksi `01-create`
+
+## Modified Flow
+
+- Anchor: on the base Flow, after the form is opened for a new record, the form now also
+  shows a **Status Checks** tab. It lists the check items pulled from the **Status Check
+  Template** that matches this record (selected automatically when the record is created
+  — see Additional Post-Condition).
+
+## Additional Post-Condition
+
+- **Status Check Template** is automatically filled with the first matching
+  `status.check.template` configured for `hr.overtime`, if any, and the **Status
+  Checks** tab is populated with that template's items. **State Change Constrain
+  Template** is then automatically filled with the matching
+  `state.change.constrain.template` linked to that **Status Check Template**, if any.
+  Which template applies (or whether none does) is configuration-driven, not fixed by
+  this module.

--- a/ssi_hr_overtime_state_change_constrain/docs/hr_overtime/04-confirm.md
+++ b/ssi_hr_overtime_state_change_constrain/docs/hr_overtime/04-confirm.md
@@ -1,0 +1,13 @@
+# Confirm Overtime
+
+> **Module:** ssi_hr_overtime_state_change_constrain
+>
+> **Extends:** ssi_hr_overtime — model `hr.overtime`, aksi `04-confirm`
+
+## Modified Validation
+
+- Confirm (and every other state transition) fails with a validation error **when** a
+  **State Change Constrain Template** applies to this record (see `01-create`) and
+  defines check items for the target state, **and** one or more of those items on the
+  **Status Checks** tab are not yet ticked. Which template applies, and which items it
+  requires per state, is configuration-driven, not fixed by this module.

--- a/ssi_hr_overtime_state_change_constrain/models/hr_overtime.py
+++ b/ssi_hr_overtime_state_change_constrain/models/hr_overtime.py
@@ -5,7 +5,15 @@
 from odoo import models
 
 
-class HROvertime(models.Model):
+class HrOvertime(models.Model):
+    """
+    Blocks ``hr.overtime`` state transitions until configured Status
+    Check items are satisfied. Adds ``mixin.state_change_constrain``
+    and ``mixin.status_check`` on top of the base overtime document,
+    so the ``state`` constraint enforces any active
+    ``state.change.constrain.template`` that targets this model.
+    """
+
     _name = "hr.overtime"
     _inherit = [
         "hr.overtime",

--- a/ssi_hr_overtime_state_change_constrain/static/tests/tours/hr_overtime_tour.js
+++ b/ssi_hr_overtime_state_change_constrain/static/tests/tours/hr_overtime_tour.js
@@ -1,0 +1,97 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_hr_overtime_state_change_constrain.hr_overtime_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // ═══════════════════════════════════════════════════════════════
+    // IK: docs/hr_overtime/01-create.md (delta — Modified Flow)
+    //
+    // Delta-only: this tour reuses the base ssi_hr_overtime Flow (open
+    // menu, click New) up to the point of change, asserts the Status
+    // Checks tab this module adds, then stops — it does not continue
+    // into Save/Confirm (odoo-development-ui-test skill,
+    // scope-and-boundaries.md §3, arketipe E2a).
+    // ═══════════════════════════════════════════════════════════════
+    tour.register(
+        "ssi_hr_overtime_state_change_constrain_hr_overtime_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Flow 1 (base) — Open the Human Resource > Timesheets >
+            // Overtimes menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Human Resource app",
+                trigger: '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+            },
+            {
+                content: "Open the Timesheets section",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+            },
+            {
+                content: "Open the Overtimes menu item",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_hr_overtime.menu_hr_overtime"]',
+            },
+            {
+                // Gate: wait for the TARGET action, not just any list
+                // view — the app landing action is also a
+                // .o_list_view.
+                content: "Overtimes list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Overtimes)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+
+            // ── Flow 2 (base) — Click the New button. (14.0: "Create")
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+
+            // ── Delta — Modified Flow: the Status Checks tab, added by
+            // this module's mixin.status_check, is shown on the form.
+            {
+                content: "Open the Status Checks tab",
+                trigger: ".o_notebook .nav-link:contains(Status Checks)",
+            },
+            {
+                // Gate: the tab content only exists once the tab above
+                // is actually selected, so this cannot match before
+                // the click above ran. Odoo 14 wraps the active page in
+                // `.tab-pane.active` (Bootstrap tabs) — there is no
+                // `.o_notebook_content` class in this series.
+                content: "Status Checks tab content is rendered",
+                trigger: ".tab-pane.active .o_field_x2many[name='status_check_ids']",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action. Delta-only tour: stop here, do not
+                    // continue into Save/Confirm.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_hr_overtime_state_change_constrain/tests/__init__.py
+++ b/ssi_hr_overtime_state_change_constrain/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_hr_overtime_state_change_constrain
+from . import test_ui_hr_overtime

--- a/ssi_hr_overtime_state_change_constrain/tests/test_hr_overtime_state_change_constrain.py
+++ b/ssi_hr_overtime_state_change_constrain/tests/test_hr_overtime_state_change_constrain.py
@@ -9,5 +9,13 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestHrOvertimeStateChangeConstrain(YamlTransactionCase):
+    """Cover the ``hr.overtime`` State Change Constrain mixin install.
+
+    Verifies the ``mixin.state_change_constrain`` and
+    ``mixin.status_check`` inherit does not break the base
+    ``hr.overtime`` creation flow.
+    """
+
     def test_hr_overtime_state_change_constrain(self):
+        """Run the "HR Overtime - State Change Constrain" scenario."""
         self.run_yaml_scenario("test_data_hr_overtime_state_change_constrain.yaml")

--- a/ssi_hr_overtime_state_change_constrain/tests/test_ui_hr_overtime.py
+++ b/ssi_hr_overtime_state_change_constrain/tests/test_ui_hr_overtime.py
@@ -1,0 +1,30 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. In 14.0, plain HttpCase does not
+# set up cls.env in setUpClass; HttpSavepointCase does.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrOvertime(HttpSavepointCase):
+    """Tour test for the ``hr.overtime`` state change constrain delta.
+
+    ``base.user_admin`` is already a member of
+    ``hr_overtime_validator_group`` (which implies the ``User`` group)
+    via ``ssi_hr_overtime``'s ``security/res_group_data.xml``, so no
+    extra group setup is needed here for the Overtimes menu or the
+    Status Checks tab this module adds.
+    """
+
+    def test_create(self):
+        """Run the create delta tour for ``hr.overtime``.
+
+        IK: docs/hr_overtime/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_hr_overtime_state_change_constrain_hr_overtime_create",
+            login="admin",
+        )

--- a/ssi_hr_overtime_state_change_constrain/views/assets.xml
+++ b/ssi_hr_overtime_state_change_constrain/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_hr_overtime_state_change_constrain assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_hr_overtime_state_change_constrain/static/tests/tours/hr_overtime_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki 7 temuan ERROR sapuan kepatuhan (`audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet`) pada modul `ssi_hr_overtime_state_change_constrain`:

* Ganti nama class Python `HROvertime` -> `HrOvertime` (PascalCase dari `_name`), `module`
* Docstring class `HrOvertime` + class/method test YAML, `module`
* Docstring class/method test tour baru, `unit-test`
* Instruksi Kerja delta `docs/hr_overtime/01-create.md` (E2a — tab Status Checks) dan
  `docs/hr_overtime/04-confirm.md` (E2b — validasi state change constrain), `ik`

Modul ini murni glue module yang meng-`_inherit` `hr.overtime` tanpa model sendiri —
mengikuti preseden yang sudah tegak di repo yang sama (#269, #270): IK ditulis sebagai
**delta**, bukan IK penuh. Ini penyimpangan dari `## Keputusan Desain` issue #216, yang
mengasumsikan IK ditulis dari nol untuk "setiap model master/setting/transaksional milik
modul ini" — asumsi itu tidak berlaku untuk modul glue murni. Tour
`static/tests/tours/hr_overtime_tour.js` + `tests/test_ui_hr_overtime.py` ditulis mengikuti
pola `ssi_holiday_state_change_constrain` (mixin kombinasi identik: `mixin.state_change_constrain`
+ `mixin.status_check`) yang sudah ada di repo yang sama: tour hanya menguji `01-create.md`
(E2a, tab Status Checks kasatmata); `04-confirm.md` adalah E2b (validasi tak kasatmata,
digerakkan konfigurasi) dan **tidak** melahirkan tour — sesuai skill
`odoo-development-instruksi-kerja` (`references/modul-extension.md`).

Murni kepatuhan — tidak ada perubahan perilaku/fitur.

## Bukti validator

```
#VALIDATOR name=module    target=ssi_hr_overtime_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_hr_overtime_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_hr_overtime_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_hr_overtime_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_hr_overtime_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_hr_overtime_state_change_constrain series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-hr-timesheet-216 modules=1 failed=0 skipped=0 precommit=OK status=OK`

Closes #216