### PR TITLE
[UPD] ssi_timesheet_attendance_operating_unit - kepatuhan skill 14.0

### DIFF
--- a/ssi_timesheet_attendance_operating_unit/README.rst
+++ b/ssi_timesheet_attendance_operating_unit/README.rst
@@ -7,6 +7,12 @@ Timesheet + Attendance + Operating Unit
 =======================================
 
 
+Work Instruction
+================
+
+* `Create Timesheet Attendance <docs/hr_timesheet_attendance/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_timesheet_attendance_operating_unit/__manifest__.py
+++ b/ssi_timesheet_attendance_operating_unit/__manifest__.py
@@ -12,9 +12,11 @@
     "depends": [
         "ssi_timesheet_attendance",
         "ssi_timesheet_operating_unit",
+        "web_tour",
     ],
     "data": [
         "security/ir_rule/hr_timesheet_attendance.xml",
         "views/hr_timesheet_attendance_views.xml",
+        "views/assets.xml",
     ],
 }

--- a/ssi_timesheet_attendance_operating_unit/docs/hr_timesheet_attendance/01-create.md
+++ b/ssi_timesheet_attendance_operating_unit/docs/hr_timesheet_attendance/01-create.md
@@ -1,0 +1,29 @@
+# Create Timesheet Attendance
+
+> **Module:** ssi_timesheet_attendance_operating_unit
+>
+> **Extends:** ssi_timesheet_attendance — model `hr.timesheet_attendance`, aksi
+> `01-create`
+
+## Additional Pre-Condition
+
+- **Config:** Group `operating_unit.group_multi_operating_unit` is active — the
+  **Operating Unit** field described below is only visible when this group is enabled.
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: The operating unit that owns this attendance record. Defaults to
+  the current user's default operating unit. Automatically re-filled from the selected
+  **Sheet**'s operating unit whenever **Sheet** changes. Visible only when group
+  `operating_unit.group_multi_operating_unit` is active. The same field is also added
+  (hidden by default) as an optional column in the **Attendances** list, and as a
+  **Group By: Operating Unit** filter in the search view — both gated by the same group.
+
+## Modified — Record Visibility
+
+- A user granted the _Operating Unit_ data-ownership group for this model
+  (`ssi_timesheet_operating_unit.hr_timesheet_ou_group`) only sees attendance records
+  whose **Operating Unit** is one of the operating units assigned to them (record rule
+  `hr_timesheet_attendance_rule_ou`). This is not a Flow step.

--- a/ssi_timesheet_attendance_operating_unit/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance_operating_unit/models/hr_timesheet_attendance.py
@@ -5,7 +5,17 @@
 from odoo import api, models
 
 
-class HRTimesheetAttendance(models.Model):
+class HrTimesheetAttendance(models.Model):
+    """Adds Operating Unit ownership to timesheet attendance records.
+
+    Restricts each attendance record to a single operating unit via
+    ``mixin.single_operating_unit``, enabling operating unit based
+    visibility and security rules for the document. The field
+    auto-fills from the linked ``sheet_id`` (see
+    ``onchange_operating_unit_id``) instead of only the current user's
+    default operating unit.
+    """
+
     _name = "hr.timesheet_attendance"
     _inherit = [
         "hr.timesheet_attendance",

--- a/ssi_timesheet_attendance_operating_unit/static/tests/tours/hr_timesheet_attendance_tour.js
+++ b/ssi_timesheet_attendance_operating_unit/static/tests/tours/hr_timesheet_attendance_tour.js
@@ -1,0 +1,92 @@
+odoo.define(
+    "ssi_timesheet_attendance_operating_unit.hr_timesheet_attendance_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/hr_timesheet_attendance/01-create.md (E1 delta --
+        // Additional Fields)
+        // Navigation (open menu -> New) is retraced from the base IK
+        // ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
+        // Flow steps 1-2 -- see skill odoo-development-ui-test,
+        // scope-and-boundaries.md §3 ("Backing dua file: tour extension =
+        // base IK ∪ delta IK"). The delta assertion comes from this
+        // module's own IK: the Operating Unit field is visible on the
+        // create form for a user in the
+        // operating_unit.group_multi_operating_unit group. The tour stops
+        // there; it does not fill, save, or confirm (E1 delta-only).
+        tour.register(
+            "ssi_timesheet_attendance_operating_unit_hr_timesheet_attendance_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [
+                // ── Base Flow 1 — Open the Human Resource > Timesheets >
+                // Attendances menu.
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Human Resource app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_hr.menu_root_human_resource"]',
+                },
+                {
+                    content: "Open the Timesheets section",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_timesheet.timesheet_menu"]',
+                },
+                {
+                    content: "Open the Attendances menu item",
+                    trigger:
+                        ".o_menu_sections " +
+                        '[data-menu-xmlid="ssi_timesheet_attendance.hr_timesheet_attendance_menu"]',
+                },
+                {
+                    // Gate: wait for the TARGET action, not just any list
+                    // view — the app landing action is also a
+                    // .o_list_view.
+                    content: "Attendances list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Attendances)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Base Flow 2 — Click the New button. (14.0: "Create")
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+
+                // ── Delta assertion — the Operating Unit field is
+                // visible on the create form for a user in the multi
+                // operating unit group. The tour stops here (E1
+                // delta-only).
+                {
+                    content: "Operating Unit field is visible on the form",
+                    trigger:
+                        ".o_form_view.o_form_editable " +
+                        ".o_field_widget[name='operating_unit_id']",
+                    run: function () {
+                        // Assertion only; do not trigger the default
+                        // click action.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_timesheet_attendance_operating_unit/tests/__init__.py
+++ b/ssi_timesheet_attendance_operating_unit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_timesheet_attendance_operating_unit
+from . import test_ui_hr_timesheet_attendance

--- a/ssi_timesheet_attendance_operating_unit/tests/test_timesheet_attendance_operating_unit.py
+++ b/ssi_timesheet_attendance_operating_unit/tests/test_timesheet_attendance_operating_unit.py
@@ -9,5 +9,13 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestTimesheetAttendanceOperatingUnit(YamlTransactionCase):
+    """Test Operating Unit ownership on ``hr.timesheet_attendance``.
+
+    Covers creating an attendance record with an explicit Operating
+    Unit, and the ``onchange_operating_unit_id`` auto-fill from the
+    linked timesheet ``sheet_id``.
+    """
+
     def test_timesheet_attendance_operating_unit(self):
+        """Run the Operating Unit scenarios for attendance records."""
         self.run_yaml_scenario("test_data_timesheet_attendance_operating_unit.yaml")

--- a/ssi_timesheet_attendance_operating_unit/tests/test_ui_hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance_operating_unit/tests/test_ui_hr_timesheet_attendance.py
@@ -1,0 +1,63 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiHrTimesheetAttendance(HttpSavepointCase):
+    """Tour test for the create-time Operating Unit field."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant ``admin`` access + the multi operating unit group.
+
+        Pre-Condition IK: the Operating Unit field is gated by
+        ``groups="operating_unit.group_multi_operating_unit"`` in the
+        form view -- without membership, the field is never rendered
+        and the delta assertion would never find it. ``admin`` also
+        needs the base ``hr_timesheet_attendance_group`` to reach the
+        Attendances menu at all, and at least one operating unit
+        assigned so the field has a meaningful (non-empty) allowed
+        set.
+        """
+        super().setUpClass()
+        cls.user_admin = cls.env.ref("base.user_admin")
+        cls.env.ref(
+            "ssi_timesheet_attendance.hr_timesheet_attendance_group"
+        ).sudo().write({"users": [(4, cls.user_admin.id)]})
+
+        operating_unit_partner = cls.env["res.partner"].create(
+            {"name": "Tour Attendance OU Partner"}
+        )
+        cls.operating_unit = cls.env["operating.unit"].create(
+            {
+                "name": "Tour Attendance Operating Unit",
+                "code": "TATOU",
+                "partner_id": operating_unit_partner.id,
+            }
+        )
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.user_admin.id)]}
+        )
+        cls.user_admin.sudo().write(
+            {
+                "assigned_operating_unit_ids": [(4, cls.operating_unit.id)],
+                "default_operating_unit_id": cls.operating_unit.id,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``hr.timesheet_attendance``.
+
+        IK: docs/hr_timesheet_attendance/01-create.md (E1 delta --
+        Additional Fields)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_timesheet_attendance_operating_unit_hr_timesheet_attendance_create",
+            login="admin",
+        )

--- a/ssi_timesheet_attendance_operating_unit/views/assets.xml
+++ b/ssi_timesheet_attendance_operating_unit/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_timesheet_attendance_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_timesheet_attendance_operating_unit/static/tests/tours/hr_timesheet_attendance_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memperbaiki temuan ERROR sapuan kepatuhan (`audit-sweep.sh 14.0 --repo opnsynid-hr-timesheet`) pada modul `ssi_timesheet_attendance_operating_unit`:

* Ganti nama class Python `HRTimesheetAttendance` -> `HrTimesheetAttendance` (PascalCase dari `_name`), `module`
* Docstring class `HrTimesheetAttendance` + class/method test YAML, `module`
* Docstring class/method test tour baru, `unit-test`
* Instruksi Kerja delta `docs/hr_timesheet_attendance/01-create.md` (E1 — Additional Fields, E6 — Modified Record Visibility), `ik`

## Penyimpangan dari `## Keputusan Desain` issue #218

Modul ini murni glue module yang meng-`_inherit` `hr.timesheet_attendance` tanpa model
sendiri — mengikuti preseden yang sudah tegak di repo yang sama (#269, #270, #271): IK
ditulis sebagai **delta**, bukan IK penuh. Ini penyimpangan dari `## Keputusan Desain`
issue #218, yang mengasumsikan IK ditulis dari nol untuk "setiap model master/setting/
transaksional milik modul ini" — asumsi itu tidak berlaku untuk modul glue murni.

Tour `static/tests/tours/hr_timesheet_attendance_tour.js` + `tests/test_ui_hr_timesheet_attendance.py`
ditulis mengikuti pola `ssi_hr_overtime_operating_unit` (mixin identik:
`mixin.single_operating_unit`) yang sudah ada di repo yang sama: tour hanya menguji
`01-create.md` (E1 delta-only — buka menu, klik New, assert field **Operating Unit**
tampil di form, berhenti; tidak fill/save/confirm).

Murni kepatuhan — tidak ada perubahan perilaku/fitur.

## Temuan yang TIDAK diperbaiki (sesuai `## Ruang Lingkup` issue — sengaja dikecualikan)

* `unit-test`: 1 peringatan (`!`) — `@api.onchange` `onchange_operating_unit_id` belum
  diuji lewat `action: form` di YAML. Ini persis temuan bertingkat peringatan yang issue
  #218 sebutkan sebagai "Tidak termasuk" (validator sendiri belum yakin, butuh konfirmasi
  manusia). Dibiarkan apa adanya.

## Bukti validator (setelah perubahan kode terakhir)

```
#VALIDATOR name=module    target=ssi_timesheet_attendance_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_timesheet_attendance_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=po        target=ssi_timesheet_attendance_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_timesheet_attendance_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_timesheet_attendance_operating_unit series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_timesheet_attendance_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`#GATE repo=opnsynid-hr-timesheet-218 modules=1 failed=0 skipped=0 precommit=OK status=OK`
`#PRECOMMIT repo=opnsynid-hr-timesheet-218 hook=dipasang runs=1 status=OK`

Closes #218