### PR TITLE
[UPD] ssi_timesheet_attendance: field geolokasi check-in & check-out

### DIFF
--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
@@ -42,6 +42,11 @@
 - Status becomes **Open** if only one of **Check In** / **Check Out** is filled, or
   **Present** once both are filled.
 - The matching timesheet's daily summary is recalculated automatically.
+- **Check In Latitude**, **Check In Longitude**, **Check In Accuracy**, **Check Out
+  Latitude**, **Check Out Longitude**, and **Check Out Accuracy** are recorded data:
+  they are readonly and only get a non-zero value when the record is created by the
+  attendance mobile app over the REST API. Created from this menu, all six stay
+  **`0.00`**.
 - This record is more commonly created automatically via the **Sign In** / **Sign Out**
   action on the timesheet (see `ssi_timesheet_attendance/hr_timesheet/15-sign-in.md` and
   `ssi_timesheet_attendance/hr_timesheet/16-sign-out.md`), or via the attendance widget

--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md
@@ -31,3 +31,7 @@
   filled, or back to **Open** if one of them is cleared.
 - The matching timesheet's daily summary is recalculated automatically whenever
   **Date**, **Check In**, or **Check Out** changes.
+- **Check In Latitude**, **Check In Longitude**, **Check In Accuracy**, **Check Out
+  Latitude**, **Check Out Longitude**, and **Check Out Accuracy** are recorded data:
+  they are readonly and cannot be changed from this form. They are only ever written by
+  the attendance mobile app over the REST API.

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_datetime
 
 
@@ -148,6 +148,89 @@ class HRTimesheetAttendance(models.Model):
         comodel_name="hr.attendance_reason",
         ondelete="restrict",
     )
+    check_in_latitude = fields.Float(
+        string="Check In Latitude",
+        digits=(16, 7),
+        readonly=True,
+        help="Device latitude recorded at check-in time. Filled by the "
+        "attendance mobile client; 0.0 on records created without a "
+        "geolocation reading (menu, Sign In/Sign Out, top bar widget).",
+    )
+    check_in_longitude = fields.Float(
+        string="Check In Longitude",
+        digits=(16, 7),
+        readonly=True,
+        help="Device longitude recorded at check-in time. Filled by the "
+        "attendance mobile client; 0.0 on records created without a "
+        "geolocation reading (menu, Sign In/Sign Out, top bar widget).",
+    )
+    check_in_accuracy = fields.Float(
+        string="Check In Accuracy",
+        digits=(16, 2),
+        readonly=True,
+        help="Accuracy of the check-in location reading, in meters, as "
+        "reported by the device. 0.0 when no geolocation reading was "
+        "taken.",
+    )
+    check_out_latitude = fields.Float(
+        string="Check Out Latitude",
+        digits=(16, 7),
+        readonly=True,
+        help="Device latitude recorded at check-out time. Filled by the "
+        "attendance mobile client; 0.0 on records created without a "
+        "geolocation reading (menu, Sign In/Sign Out, top bar widget).",
+    )
+    check_out_longitude = fields.Float(
+        string="Check Out Longitude",
+        digits=(16, 7),
+        readonly=True,
+        help="Device longitude recorded at check-out time. Filled by the "
+        "attendance mobile client; 0.0 on records created without a "
+        "geolocation reading (menu, Sign In/Sign Out, top bar widget).",
+    )
+    check_out_accuracy = fields.Float(
+        string="Check Out Accuracy",
+        digits=(16, 2),
+        readonly=True,
+        help="Accuracy of the check-out location reading, in meters, as "
+        "reported by the device. 0.0 when no geolocation reading was "
+        "taken.",
+    )
+
+    @api.constrains(
+        "check_in_latitude",
+        "check_in_longitude",
+        "check_out_latitude",
+        "check_out_longitude",
+    )
+    def _check_geolocation_range(self):
+        """Validate that latitude/longitude stay within valid ranges.
+
+        Devices leave these fields at their default ``0.0`` on every
+        record that never captures geolocation - menu-created rows,
+        the **Sign In** / **Sign Out** actions, and the top bar
+        widget - so ``0.0`` and the ``(0, 0)`` pair are intentionally
+        accepted here. Only a value genuinely outside a valid
+        latitude/longitude range is rejected; accuracy is not
+        validated, since its acceptable threshold is an operational
+        policy, not a modeling constraint.
+
+        :raises ValidationError: if a latitude is outside ``-90..90``
+            or a longitude is outside ``-180..180``.
+        """
+        for record in self:
+            for fname in ("check_in_latitude", "check_out_latitude"):
+                value = record[fname]
+                if value < -90.0 or value > 90.0:
+                    raise ValidationError(
+                        _("Latitude must be between -90 and 90 degrees.")
+                    )
+            for fname in ("check_in_longitude", "check_out_longitude"):
+                value = record[fname]
+                if value < -180.0 or value > 180.0:
+                    raise ValidationError(
+                        _("Longitude must be between -180 and 180 degrees.")
+                    )
 
     @api.depends(
         "date",

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -813,7 +813,7 @@ scenarios:
         values:
           check_out: "2024-05-16 17:00:00"
           check_out_latitude: -6.9147500
-          check_out_longitude: 107.6098000
+          check_out_longitude: 107.6098123
           check_out_accuracy: 9.0
 
       - step: "Assert check-out geolocation stored exactly"
@@ -825,7 +825,7 @@ scenarios:
             expected: -6.9147500
           check_out_longitude:
             type: "value"
-            expected: 107.6098000
+            expected: 107.6098123
           check_out_accuracy:
             type: "value"
             expected: 9.0

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -698,3 +698,470 @@ scenarios:
           total_attendance:
             type: "value"
             expected: "REC: attendance_daily_summary.total_hour"
+
+  - name: "HR Timesheet Attendance Geolocation - Create With Full Values"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_full"
+        values:
+          name: "Test Employee Geolocation Full"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_full"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_full"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_full.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_full.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_full"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create attendance with check-in geolocation"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_geo_full"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_full.id"
+          date: 2024-05-15
+          check_in: "2024-05-15 08:00:00"
+          sheet_id: "REC: timesheet_geo_full.id"
+          check_in_latitude: -6.9147440
+          check_in_longitude: 107.6098100
+          check_in_accuracy: 12.5
+
+      - step: "Assert check-in geolocation stored exactly"
+        action: "assert"
+        target: "attendance_geo_full"
+        asserts:
+          check_in_latitude:
+            type: "value"
+            expected: -6.9147440
+          check_in_longitude:
+            type: "value"
+            expected: 107.6098100
+          check_in_accuracy:
+            type: "value"
+            expected: 12.5
+
+  - name: "HR Timesheet Attendance Geolocation - Write Check Out Values"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_write"
+        values:
+          name: "Test Employee Geolocation Write"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_write"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_write"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_write.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_write.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_write"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create open attendance without geolocation"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_geo_write"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_write.id"
+          date: 2024-05-16
+          check_in: "2024-05-16 08:00:00"
+          sheet_id: "REC: timesheet_geo_write.id"
+
+      - step: "Write check-out geolocation"
+        action: "write"
+        target: "attendance_geo_write"
+        as_user: "base.user_admin"
+        values:
+          check_out: "2024-05-16 17:00:00"
+          check_out_latitude: -6.9147500
+          check_out_longitude: 107.6098000
+          check_out_accuracy: 9.0
+
+      - step: "Assert check-out geolocation stored exactly"
+        action: "assert"
+        target: "attendance_geo_write"
+        asserts:
+          check_out_latitude:
+            type: "value"
+            expected: -6.9147500
+          check_out_longitude:
+            type: "value"
+            expected: 107.6098000
+          check_out_accuracy:
+            type: "value"
+            expected: 9.0
+
+  - name: "HR Timesheet Attendance Geolocation - Create Without Geolocation Fields"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_none"
+        values:
+          name: "Test Employee Geolocation None"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_none"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_none"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_none.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_none.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_none"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create attendance without mentioning any geolocation field"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_geo_none"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_none.id"
+          date: 2024-05-17
+          check_in: "2024-05-17 08:00:00"
+          check_out: "2024-05-17 17:00:00"
+          sheet_id: "REC: timesheet_geo_none.id"
+
+      - step: "Assert all six geolocation fields default to 0.0"
+        action: "assert"
+        target: "attendance_geo_none"
+        asserts:
+          check_in_latitude:
+            type: "value"
+            expected: 0.0
+          check_in_longitude:
+            type: "value"
+            expected: 0.0
+          check_in_accuracy:
+            type: "value"
+            expected: 0.0
+          check_out_latitude:
+            type: "value"
+            expected: 0.0
+          check_out_longitude:
+            type: "value"
+            expected: 0.0
+          check_out_accuracy:
+            type: "value"
+            expected: 0.0
+
+  - name: "HR Timesheet Attendance Geolocation - Zero Coordinates Are Not An Error"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_zero"
+        values:
+          name: "Test Employee Geolocation Zero"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_zero"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_zero"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_zero.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_zero.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_zero"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create attendance with explicit (0, 0) check-in coordinates"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_geo_zero"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_zero.id"
+          date: 2024-05-18
+          check_in: "2024-05-18 08:00:00"
+          sheet_id: "REC: timesheet_geo_zero.id"
+          check_in_latitude: 0.0
+          check_in_longitude: 0.0
+
+      - step: "Assert the (0, 0) pair was accepted"
+        action: "assert"
+        target: "attendance_geo_zero"
+        asserts:
+          check_in_latitude:
+            type: "value"
+            expected: 0.0
+          check_in_longitude:
+            type: "value"
+            expected: 0.0
+
+  - name: "HR Timesheet Attendance Geolocation - Boundary Values Are Accepted"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_boundary"
+        values:
+          name: "Test Employee Geolocation Boundary"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_boundary"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_boundary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_boundary.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_boundary.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_boundary"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create attendance with boundary check-in coordinates"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_geo_boundary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_boundary.id"
+          date: 2024-05-19
+          check_in: "2024-05-19 08:00:00"
+          sheet_id: "REC: timesheet_geo_boundary.id"
+          check_in_latitude: -90.0
+          check_in_longitude: 180.0
+
+      - step: "Assert boundary values were accepted"
+        action: "assert"
+        target: "attendance_geo_boundary"
+        asserts:
+          check_in_latitude:
+            type: "value"
+            expected: -90.0
+          check_in_longitude:
+            type: "value"
+            expected: 180.0
+
+  - name: "HR Timesheet Attendance Geolocation - Latitude Out Of Range Raises"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_lat_error"
+        values:
+          name: "Test Employee Geolocation Latitude Error"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_lat_error"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_lat_error"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_lat_error.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_lat_error.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_lat_error"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create attendance with out-of-range check-in latitude"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Latitude"
+        values:
+          employee_id: "REC: employee_geo_lat_error.id"
+          date: 2024-05-20
+          check_in: "2024-05-20 08:00:00"
+          sheet_id: "REC: timesheet_geo_lat_error.id"
+          check_in_latitude: 91.0
+
+  - name: "HR Timesheet Attendance Geolocation - Longitude Out Of Range Raises"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_lon_error"
+        values:
+          name: "Test Employee Geolocation Longitude Error"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_lon_error"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_lon_error"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_lon_error.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_lon_error.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_lon_error"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create attendance with out-of-range check-in longitude"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Longitude"
+        values:
+          employee_id: "REC: employee_geo_lon_error.id"
+          date: 2024-05-21
+          check_in: "2024-05-21 08:00:00"
+          sheet_id: "REC: timesheet_geo_lon_error.id"
+          check_in_longitude: -181.0
+
+  - name: "HR Timesheet Attendance Geolocation - Write Latitude Out Of Range Raises"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_geo_write_error"
+        values:
+          name: "Test Employee Geolocation Write Error"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_geo_write_error"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_geo_write_error"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_write_error.id"
+          date_start: 2024-05-01
+          date_end: 2024-05-31
+          working_schedule_id: "REC: working_schedule_geo_write_error.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_geo_write_error"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create open attendance without geolocation"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_geo_write_error"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_geo_write_error.id"
+          date: 2024-05-22
+          check_in: "2024-05-22 08:00:00"
+          sheet_id: "REC: timesheet_geo_write_error.id"
+
+      - step: "Write out-of-range check-out latitude"
+        action: "write"
+        target: "attendance_geo_write_error"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Latitude"
+        values:
+          check_out_latitude: 90.1

--- a/ssi_timesheet_attendance/views/hr_timesheet_attendance_views.xml
+++ b/ssi_timesheet_attendance/views/hr_timesheet_attendance_views.xml
@@ -87,6 +87,14 @@
                         <field name="total_valid_hour" widget="float_time" />
                     </group>
                 </group>
+                <group name="attendance_2" colspan="4" col="4" string="Geolocation">
+                    <field name="check_in_latitude" />
+                    <field name="check_in_longitude" />
+                    <field name="check_in_accuracy" />
+                    <field name="check_out_latitude" />
+                    <field name="check_out_longitude" />
+                    <field name="check_out_accuracy" />
+                </group>
             </sheet>
         </form>
     </field>


### PR DESCRIPTION
## Ringkasan

Menambahkan enam field geolokasi pada `hr.timesheet_attendance` agar PWA absensi
karyawan (menulis lewat REST `muk_rest`) punya tempat menyimpan koordinat
check-in/check-out beserta akurasi pembacaannya.

- `check_in_latitude`, `check_in_longitude`, `check_in_accuracy`
- `check_out_latitude`, `check_out_longitude`, `check_out_accuracy`

Seluruhnya `Float`, `readonly=True` di level field (bukan atribut view, supaya
create()/write() lewat ORM/REST tetap bisa mengisi), tanpa `required`, tanpa
`default`. `check_*_latitude`/`longitude` memakai `digits=(16, 7)`, kedua field
akurasi `digits=(16, 2)`.

Ditambahkan `@api.constrains` `_check_geolocation_range` yang menolak lintang di
luar `-90..90` atau bujur di luar `-180..180`; pasangan `(0, 0)` **tidak**
ditolak karena itu nilai default pada absensi yang dibuat tanpa geolokasi (menu,
Sign In/Sign Out, widget bilah atas).

Keenam field ditempatkan di grup baru **Geolocation** pada form view; tree dan
search view tidak disentuh.

Post-Condition `docs/hr_timesheet_attendance/01-create.md` dan `02-edit.md`
diperbarui untuk menyebut keenam field sebagai data rekaman. Tour pasangan
kedua IK itu ditinjau (tidak diubah) — tour tidak menguji nilai field, dan
Flow/Pre-Condition/tombol tidak berubah.

Skenario uji positif & negatif ditambahkan ke
`tests/test_data_timesheet_attendance.yaml` yang sudah ada, di bagian paling
bawah; skenario lama tidak digeser.

Tidak ada migration script — field baru, tidak `required`, tanpa default, dan
tidak mengubah/menghapus identitas apa pun; Odoo menambahkan kolomnya sendiri
saat update modul. `__manifest__.py` tidak disentuh.

## Test plan

- [x] `verify-module.sh` (vs-head): 0 temuan baru
- [x] `validate-unit-test.sh` (vs-head): 0 temuan baru
- [x] `validate-ik.sh` (vs-head): 0 temuan baru
- [x] `pre-commit-gate.sh`: GATE OK
- [ ] CI GitHub Actions (dipantau orkestrator)

Closes #284