### PR TITLE
[UPD] ssi_timesheet_attendance: perbaiki pemasangan slot jadwal & field turunan absensi

### DIFF
--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -263,8 +263,22 @@ class HRTimesheetAttendance(models.Model):
         "check_out",
     )
     def _compute_valid(self):
+        """Derive the valid check-in/out window and its duration.
+
+        ``valid_check_in``/``valid_check_out`` are the start/end of
+        the intersection between ``[check_in, check_out]`` and
+        ``[schedule_id.date_start, schedule_id.date_end]``.
+        ``total_valid_hour`` is that intersection's duration, in
+        hours. All three fields are assigned on every branch -
+        including the branch where no valid window exists - so a
+        stale value from a previous computation never survives.
+
+        :raises: nothing; the absence of a valid window is not an
+            error, it yields ``False``/``0.0``.
+        """
         for record in self:
-            total_valid_hour = 0
+            valid_check_in = valid_check_out = False
+            total_valid_hour = 0.0
             if (
                 record.schedule_id.date_start
                 and record.schedule_id.date_end
@@ -281,6 +295,10 @@ class HRTimesheetAttendance(models.Model):
                     date_end = min(record.schedule_id.date_end, record.check_out)
                     delta = date_end - date_start
                     total_valid_hour = delta.total_seconds() / 3600.0
+                    valid_check_in = date_start
+                    valid_check_out = date_end
+            record.valid_check_in = valid_check_in
+            record.valid_check_out = valid_check_out
             record.total_valid_hour = total_valid_hour
 
     @api.depends(
@@ -294,17 +312,67 @@ class HRTimesheetAttendance(models.Model):
                 result = (record.check_out - record.check_in).total_seconds() / 3600.0
             record.total_hour = result
 
-    @api.depends("date")
+    @api.depends(
+        "date",
+        "check_in",
+        "employee_id",
+    )
     def _compute_schedule(self):
+        """Resolve the schedule slot that covers this attendance.
+
+        Runs a three-tier search, per record, stopping at the first
+        tier that matches - always among slots of the same
+        ``employee_id`` and always with an explicit ``order`` so the
+        result is deterministic even when more than one slot could
+        match:
+
+        1. the slot whose ``date_start``/``date_end`` window
+           **contains** ``check_in``, without any date filter - this
+           also covers a check-in that falls after midnight on a
+           shift that started the day before;
+        2. failing that, among the slots dated ``date``, the one
+           whose ``date_start`` is **closest** to ``check_in`` - this
+           covers an early arrival or a late departure that falls
+           outside every slot's window;
+        3. failing both, ``schedule_id`` is left ``False`` - a
+           legitimate outcome for attendance recorded on a day with
+           no schedule slot (holiday, unplanned overtime, or an
+           employee without a schedule).
+
+        :raises: nothing; an unresolved schedule is not an error.
+        """
         obj_schedule = self.env["hr.timesheet_attendance_schedule"]
         for attn in self:
-            # company = attn.employee_id.company_id
-            criteria = [
-                ("employee_id", "=", attn.employee_id.id),
-                ("date", "=", attn.date),
-            ]
-            schedules = obj_schedule.search(criteria, limit=1)
-            attn.schedule_id = schedules[0].id if len(schedules) > 0 else False
+            schedule = obj_schedule.browse()
+            if attn.check_in:
+                schedule = obj_schedule.search(
+                    [
+                        ("employee_id", "=", attn.employee_id.id),
+                        ("date_start", "<=", attn.check_in),
+                        ("date_end", ">=", attn.check_in),
+                    ],
+                    order="date_start",
+                    limit=1,
+                )
+            if not schedule:
+                candidates = obj_schedule.search(
+                    [
+                        ("employee_id", "=", attn.employee_id.id),
+                        ("date", "=", attn.date),
+                    ],
+                    order="date_start",
+                )
+                if candidates:
+                    if attn.check_in:
+                        schedule = min(
+                            candidates,
+                            key=lambda candidate: abs(
+                                (candidate.date_start - attn.check_in).total_seconds()
+                            ),
+                        )
+                    else:
+                        schedule = candidates[0]
+            attn.schedule_id = schedule.id if schedule else False
 
     @api.model
     def create(self, values):

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance_schedule.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance_schedule.py
@@ -125,7 +125,7 @@ Solution: Create a timesheet whose date range includes %s
         "date_start",
         "date_end",
         "real_date_start",
-        "real_date_start",
+        "real_date_end",
     )
     def _compute_work_hour(self):
         for attn in self:

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -1247,10 +1247,10 @@ scenarios:
         asserts:
           valid_check_in:
             type: "value"
-            expected: "2024-07-01 20:30:00"
+            expected: "EVAL: datetime(2024, 7, 1, 20, 30, 0)"
           valid_check_out:
             type: "value"
-            expected: "2024-07-02 06:00:00"
+            expected: "EVAL: datetime(2024, 7, 2, 6, 0, 0)"
           total_valid_hour:
             type: "value"
             expected: 9.5
@@ -1317,7 +1317,7 @@ scenarios:
         asserts:
           valid_check_out:
             type: "value"
-            expected: "2024-07-04 04:00:00"
+            expected: "EVAL: datetime(2024, 7, 4, 4, 0, 0)"
 
       - step: "Assert finish_early_hour on the resolved schedule"
         action: "assert"
@@ -1390,7 +1390,7 @@ scenarios:
         asserts:
           valid_check_out:
             type: "value"
-            expected: "2024-07-06 06:00:00"
+            expected: "EVAL: datetime(2024, 7, 6, 6, 0, 0)"
 
       - step: "Assert finish_late_hour on the resolved schedule"
         action: "assert"
@@ -1570,7 +1570,7 @@ scenarios:
         asserts:
           real_date_start:
             type: "value"
-            expected: "2024-07-08 08:00:00"
+            expected: "EVAL: datetime(2024, 7, 8, 8, 0, 0)"
           real_work_hour:
             type: "value"
             expected: 8.0
@@ -1814,7 +1814,7 @@ scenarios:
         asserts:
           real_date_start:
             type: "value"
-            expected: "2024-07-12 08:00:00"
+            expected: "EVAL: datetime(2024, 7, 12, 8, 0, 0)"
           real_work_hour:
             type: "value"
             expected: 9.0

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance.yaml
@@ -182,7 +182,9 @@ scenarios:
             second=0, microsecond=0)"
           sheet_id: "REC: timesheet.id"
 
-      - step: "Assert precondition: attendance has no schedule"
+      - step:
+          "Assert precondition: attendance has no schedule (employee has no schedule
+          slot at all, on any date - tier 3 of _compute_schedule)"
         action: "assert"
         target: "attendance"
         asserts:
@@ -295,7 +297,10 @@ scenarios:
             second=0, microsecond=0)"
           sheet_id: "REC: timesheet.id"
 
-      - step: "Assert precondition: attendance schedule is resolved"
+      - step:
+          "Assert precondition: attendance schedule is resolved (check-in 08:00 exactly
+          matches the slot's date_start - tier 1, inclusive boundary of
+          _compute_schedule)"
         action: "assert"
         target: "attendance"
         asserts:
@@ -1165,3 +1170,861 @@ scenarios:
           message_contains: "Latitude"
         values:
           check_out_latitude: 90.1
+
+  - name: "Compute Schedule - Cross-Midnight Slot Resolves And Valid Window Computed"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_cm_window"
+        values:
+          name: "Test Employee Cross Midnight Window"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_cm_window"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_cm_window"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_window.id"
+          date_start: 2024-07-01
+          date_end: 2024-07-02
+          working_schedule_id: "REC: working_schedule_cm_window.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_cm_window"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a single slot from 20:00 to next day 06:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_cm_window"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_window.id"
+          date_start: "2024-07-01 20:00:00"
+          date_end: "2024-07-02 06:00:00"
+
+      - step: "Create attendance checking in inside the slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_cm_window"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_window.id"
+          date: 2024-07-01
+          check_in: "2024-07-01 20:30:00"
+          sheet_id: "REC: timesheet_cm_window.id"
+
+      - step: "Assert schedule_id resolved to the cross-midnight slot"
+        action: "assert"
+        target: "attendance_cm_window"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: schedule_cm_window"
+
+      - step: "Write check-out at the slot's exact end"
+        action: "write"
+        target: "attendance_cm_window"
+        as_user: "base.user_admin"
+        values:
+          check_out: "2024-07-02 06:00:00"
+
+      - step: "Assert the valid window and its duration"
+        action: "assert"
+        target: "attendance_cm_window"
+        asserts:
+          valid_check_in:
+            type: "value"
+            expected: "2024-07-01 20:30:00"
+          valid_check_out:
+            type: "value"
+            expected: "2024-07-02 06:00:00"
+          total_valid_hour:
+            type: "value"
+            expected: 9.5
+
+  - name: "Compute Schedule - Early Check-Out Bounded By Valid Window"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_cm_early"
+        values:
+          name: "Test Employee Cross Midnight Early"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_cm_early"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_cm_early"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_early.id"
+          date_start: 2024-07-03
+          date_end: 2024-07-04
+          working_schedule_id: "REC: working_schedule_cm_early.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_cm_early"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a single slot from 20:00 to next day 06:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_cm_early"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_early.id"
+          date_start: "2024-07-03 20:00:00"
+          date_end: "2024-07-04 06:00:00"
+
+      - step: "Create attendance and write an early check-out"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_cm_early"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_early.id"
+          date: 2024-07-03
+          check_in: "2024-07-03 20:30:00"
+          check_out: "2024-07-04 04:00:00"
+          sheet_id: "REC: timesheet_cm_early.id"
+
+      - step: "Assert valid check-out is bounded by the actual early check-out"
+        action: "assert"
+        target: "attendance_cm_early"
+        asserts:
+          valid_check_out:
+            type: "value"
+            expected: "2024-07-04 04:00:00"
+
+      - step: "Assert finish_early_hour on the resolved schedule"
+        action: "assert"
+        target: "schedule_cm_early"
+        refresh: true
+        asserts:
+          finish_early_hour:
+            type: "value"
+            expected: 2.0
+
+  - name: "Compute Schedule - Late Check-Out Bounded By Slot End"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_cm_late"
+        values:
+          name: "Test Employee Cross Midnight Late"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_cm_late"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_cm_late"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_late.id"
+          date_start: 2024-07-05
+          date_end: 2024-07-06
+          working_schedule_id: "REC: working_schedule_cm_late.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_cm_late"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a single slot from 20:00 to next day 06:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_cm_late"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_late.id"
+          date_start: "2024-07-05 20:00:00"
+          date_end: "2024-07-06 06:00:00"
+
+      - step: "Create attendance and write a late check-out"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_cm_late"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_cm_late.id"
+          date: 2024-07-05
+          check_in: "2024-07-05 20:30:00"
+          check_out: "2024-07-06 07:00:00"
+          sheet_id: "REC: timesheet_cm_late.id"
+
+      - step: "Assert valid check-out is bounded by the slot's own end"
+        action: "assert"
+        target: "attendance_cm_late"
+        asserts:
+          valid_check_out:
+            type: "value"
+            expected: "2024-07-06 06:00:00"
+
+      - step: "Assert finish_late_hour on the resolved schedule"
+        action: "assert"
+        target: "schedule_cm_late"
+        refresh: true
+        asserts:
+          finish_late_hour:
+            type: "value"
+            expected: 1.0
+
+  - name: "Compute Schedule - Two Slots Same Date Resolve By Containing Check-In"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_two_slots"
+        values:
+          name: "Test Employee Two Slots Same Date"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_two_slots"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_two_slots"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_slots.id"
+          date_start: 2024-07-07
+          date_end: 2024-07-07
+          working_schedule_id: "REC: working_schedule_two_slots.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_two_slots"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create the morning slot 06:00-10:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_two_slots_morning"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_slots.id"
+          date_start: "2024-07-07 06:00:00"
+          date_end: "2024-07-07 10:00:00"
+
+      - step: "Create the evening slot 16:00-20:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_two_slots_evening"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_slots.id"
+          date_start: "2024-07-07 16:00:00"
+          date_end: "2024-07-07 20:00:00"
+
+      - step: "Create attendance checking in during the evening slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_two_slots_evening"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_slots.id"
+          date: 2024-07-07
+          check_in: "2024-07-07 16:30:00"
+          sheet_id: "REC: timesheet_two_slots.id"
+
+      - step: "Assert it attaches to the evening slot, not the morning one"
+        action: "assert"
+        target: "attendance_two_slots_evening"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: schedule_two_slots_evening"
+
+      - step: "Create attendance checking in during the morning slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_two_slots_morning"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_slots.id"
+          date: 2024-07-07
+          check_in: "2024-07-07 06:30:00"
+          sheet_id: "REC: timesheet_two_slots.id"
+
+      - step: "Assert it attaches to the morning slot, not the evening one"
+        action: "assert"
+        target: "attendance_two_slots_morning"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: schedule_two_slots_morning"
+
+  - name: "Compute Schedule - Two Attendances On Same Slot Aggregate Real Work Hour"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_two_attendances"
+        values:
+          name: "Test Employee Two Attendances Same Slot"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_two_attendances"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_two_attendances"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_attendances.id"
+          date_start: 2024-07-08
+          date_end: 2024-07-08
+          working_schedule_id: "REC: working_schedule_two_attendances.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_two_attendances"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create the day's single slot 08:00-17:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_two_attendances"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_attendances.id"
+          date_start: "2024-07-08 08:00:00"
+          date_end: "2024-07-08 17:00:00"
+
+      - step: "Create the morning attendance (08:00-12:00, before lunch)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_two_attendances_am"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_attendances.id"
+          date: 2024-07-08
+          check_in: "2024-07-08 08:00:00"
+          check_out: "2024-07-08 12:00:00"
+          sheet_id: "REC: timesheet_two_attendances.id"
+
+      - step: "Create the afternoon attendance (13:00-17:00, after lunch)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_two_attendances_pm"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_two_attendances.id"
+          date: 2024-07-08
+          check_in: "2024-07-08 13:00:00"
+          check_out: "2024-07-08 17:00:00"
+          sheet_id: "REC: timesheet_two_attendances.id"
+
+      - step:
+          "Assert real_date_start is the FIRST check-in and real_work_hour sums both
+          attendances"
+        action: "assert"
+        target: "schedule_two_attendances"
+        refresh: true
+        asserts:
+          real_date_start:
+            type: "value"
+            expected: "2024-07-08 08:00:00"
+          real_work_hour:
+            type: "value"
+            expected: 8.0
+
+  - name:
+      "Compute Schedule - Tier 1 Resolves Check-In After Midnight Regardless Of Date"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_tier1_midnight"
+        values:
+          name: "Test Employee Tier 1 After Midnight"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_tier1_midnight"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_tier1_midnight"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_tier1_midnight.id"
+          date_start: 2024-07-09
+          date_end: 2024-07-10
+          working_schedule_id: "REC: working_schedule_tier1_midnight.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_tier1_midnight"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a slot from 20:00 to next day 06:00 (its own date is day H)"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_tier1_midnight"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_tier1_midnight.id"
+          date_start: "2024-07-09 20:00:00"
+          date_end: "2024-07-10 06:00:00"
+
+      - step:
+          "Create attendance DATED day H+1 with a check-in after midnight - tier 2's
+          date filter alone would miss this slot (its own date is H, not H+1); only tier
+          1's date_start/date_end containment resolves it"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_tier1_midnight"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_tier1_midnight.id"
+          date: 2024-07-10
+          check_in: "2024-07-10 01:00:00"
+          sheet_id: "REC: timesheet_tier1_midnight.id"
+
+      - step: "Assert schedule_id still resolves to the cross-midnight slot"
+        action: "assert"
+        target: "attendance_tier1_midnight"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: schedule_tier1_midnight"
+
+  - name: "Compute Schedule - Tier 2 Resolves An Early Arrival Outside The Slot"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_tier2_early"
+        values:
+          name: "Test Employee Tier 2 Early Arrival"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_tier2_early"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_tier2_early"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_tier2_early.id"
+          date_start: 2024-07-11
+          date_end: 2024-07-11
+          working_schedule_id: "REC: working_schedule_tier2_early.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_tier2_early"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create the day's slot 08:00-17:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_tier2_early"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_tier2_early.id"
+          date_start: "2024-07-11 08:00:00"
+          date_end: "2024-07-11 17:00:00"
+
+      - step:
+          "Create attendance checking in 30 minutes before the slot opens - tier 1
+          (containment) misses it, tier 2 (nearest slot on the same date) resolves it"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_tier2_early"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_tier2_early.id"
+          date: 2024-07-11
+          check_in: "2024-07-11 07:30:00"
+          sheet_id: "REC: timesheet_tier2_early.id"
+
+      - step: "Assert schedule_id resolved via tier 2"
+        action: "assert"
+        target: "attendance_tier2_early"
+        asserts:
+          schedule_id:
+            type: "m2o"
+            expected: "REC: schedule_tier2_early"
+
+      - step: "Assert early_start_hour on the resolved schedule"
+        action: "assert"
+        target: "schedule_tier2_early"
+        refresh: true
+        asserts:
+          early_start_hour:
+            type: "value"
+            expected: 0.5
+
+  - name: "Compute Schedule - Holiday Attendance Has No Schedule And Zero Valid Hour"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_holiday"
+        values:
+          name: "Test Employee Holiday Attendance"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_holiday"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet spanning both days"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_holiday"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_holiday.id"
+          date_start: 2024-07-12
+          date_end: 2024-07-13
+          working_schedule_id: "REC: working_schedule_holiday.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_holiday"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a slot on the day BEFORE the holiday (2024-07-12)"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_holiday_prev_day"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_holiday.id"
+          date_start: "2024-07-12 08:00:00"
+          date_end: "2024-07-12 17:00:00"
+
+      - step: "Create a full-day attendance against that slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_holiday_prev_day"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_holiday.id"
+          date: 2024-07-12
+          check_in: "2024-07-12 08:00:00"
+          check_out: "2024-07-12 17:00:00"
+          sheet_id: "REC: timesheet_holiday.id"
+
+      - step: "Create an attendance on 2024-07-13, a day WITHOUT any slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_holiday"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_holiday.id"
+          date: 2024-07-13
+          check_in: "2024-07-13 09:00:00"
+          check_out: "2024-07-13 11:00:00"
+          sheet_id: "REC: timesheet_holiday.id"
+
+      - step:
+          "Assert the holiday attendance has no schedule, full total_hour, and zero
+          valid hour"
+        action: "assert"
+        target: "attendance_holiday"
+        asserts:
+          schedule_id:
+            type: "value"
+            operator: "is_falsy"
+          total_hour:
+            type: "value"
+            expected: 2.0
+          total_valid_hour:
+            type: "value"
+            expected: 0.0
+          valid_check_in:
+            type: "value"
+            operator: "is_falsy"
+          valid_check_out:
+            type: "value"
+            operator: "is_falsy"
+
+      - step:
+          "Assert the PREVIOUS day's slot was left untouched by the holiday attendance"
+        action: "assert"
+        target: "schedule_holiday_prev_day"
+        refresh: true
+        asserts:
+          real_date_start:
+            type: "value"
+            expected: "2024-07-12 08:00:00"
+          real_work_hour:
+            type: "value"
+            expected: 9.0
+          state:
+            type: "value"
+            expected: "present"
+
+  - name: "Compute Schedule - Single Day Shift Valid Hour Formula Unchanged"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_single_day"
+        values:
+          name: "Test Employee Single Day Shift"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_single_day"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_single_day"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_single_day.id"
+          date_start: 2024-07-14
+          date_end: 2024-07-14
+          working_schedule_id: "REC: working_schedule_single_day.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_single_day"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create the day's slot 08:00-17:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_single_day"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_single_day.id"
+          date_start: "2024-07-14 08:00:00"
+          date_end: "2024-07-14 17:00:00"
+
+      - step: "Create attendance fully within the slot"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_single_day"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_single_day.id"
+          date: 2024-07-14
+          check_in: "2024-07-14 08:00:00"
+          check_out: "2024-07-14 17:00:00"
+          sheet_id: "REC: timesheet_single_day.id"
+
+      - step:
+          "Assert total_valid_hour matches the unchanged intersection formula for a
+          single day shift"
+        action: "assert"
+        target: "attendance_single_day"
+        asserts:
+          total_valid_hour:
+            type: "value"
+            expected: 9.0
+
+  - name: "Compute Schedule - Attendance Without Check-Out Has No Valid Window"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_no_checkout"
+        values:
+          name: "Test Employee No Check-Out"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_no_checkout"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_no_checkout"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_no_checkout.id"
+          date_start: 2024-07-16
+          date_end: 2024-07-16
+          working_schedule_id: "REC: working_schedule_no_checkout.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_no_checkout"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create the day's slot 08:00-17:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_no_checkout"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_no_checkout.id"
+          date_start: "2024-07-16 08:00:00"
+          date_end: "2024-07-16 17:00:00"
+
+      - step: "Create attendance without a check-out"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_no_checkout"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_no_checkout.id"
+          date: 2024-07-16
+          check_in: "2024-07-16 08:00:00"
+          sheet_id: "REC: timesheet_no_checkout.id"
+
+      - step: "Assert no valid window and zero valid hour"
+        action: "assert"
+        target: "attendance_no_checkout"
+        asserts:
+          total_valid_hour:
+            type: "value"
+            expected: 0.0
+          valid_check_in:
+            type: "value"
+            operator: "is_falsy"
+          valid_check_out:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Compute Schedule - Attendance Entirely Outside Slot Has Zero Valid Hour"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_outside_slot"
+        values:
+          name: "Test Employee Entirely Outside Slot"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule_outside_slot"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_outside_slot"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_outside_slot.id"
+          date_start: 2024-07-17
+          date_end: 2024-07-18
+          working_schedule_id: "REC: working_schedule_outside_slot.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_outside_slot"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a slot from 20:00 to next day 06:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_outside_slot"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_outside_slot.id"
+          date_start: "2024-07-17 20:00:00"
+          date_end: "2024-07-18 06:00:00"
+
+      - step:
+          "Create attendance entirely within 12:00-13:00, hours before the slot even
+          starts"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_outside_slot"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_outside_slot.id"
+          date: 2024-07-17
+          check_in: "2024-07-17 12:00:00"
+          check_out: "2024-07-17 13:00:00"
+          sheet_id: "REC: timesheet_outside_slot.id"
+
+      - step: "Assert zero valid hour despite any schedule resolution"
+        action: "assert"
+        target: "attendance_outside_slot"
+        asserts:
+          total_valid_hour:
+            type: "value"
+            expected: 0.0
+          valid_check_in:
+            type: "value"
+            operator: "is_falsy"
+          valid_check_out:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_timesheet_attendance/tests/test_data_timesheet_attendance_schedule.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_timesheet_attendance_schedule.yaml
@@ -111,3 +111,125 @@ scenarios:
           checkout_buffer:
             type: "value"
             expected: 0.0
+
+  - name:
+      "Attendance Schedule - Single Slot Crossing Midnight Passes The 24-Hour Constraint"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_midnight"
+        values:
+          name: "Test Employee Schedule Midnight"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_midnight"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_midnight.id"
+          date_start: 2024-07-20
+          date_end: 2024-07-21
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_midnight"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a single slot from 20:00 to next day 06:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_midnight"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_midnight.id"
+          date_start: "2024-07-20 20:00:00"
+          date_end: "2024-07-21 06:00:00"
+
+      - step:
+          "Assert the 10-hour slot is saved and passes the 23.99-hour
+          _check_schedule_work_hour constraint"
+        action: "assert"
+        target: "schedule_midnight"
+        asserts:
+          schedule_work_hour:
+            type: "value"
+            expected: 10.0
+
+  - name: "Attendance Schedule - Finish Late Hour Recomputes When Check-Out Is Written"
+    steps:
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_finish_late"
+        values:
+          name: "Test Employee Schedule Finish Late"
+
+      - step: "Create timesheet spanning the midnight boundary"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_finish_late"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_finish_late.id"
+          date_start: 2024-07-22
+          date_end: 2024-07-23
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet_finish_late"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Create a slot from 20:00 to next day 06:00"
+        action: "create"
+        model: "hr.timesheet_attendance_schedule"
+        save_as: "schedule_finish_late"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_finish_late.id"
+          date_start: "2024-07-22 20:00:00"
+          date_end: "2024-07-23 06:00:00"
+
+      - step: "Create an open attendance attached to the slot (no check-out yet)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_finish_late"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_finish_late.id"
+          date: 2024-07-22
+          check_in: "2024-07-22 20:30:00"
+          sheet_id: "REC: timesheet_finish_late.id"
+
+      - step: "Assert finish_late_hour is zero before check-out is filled"
+        action: "assert"
+        target: "schedule_finish_late"
+        refresh: true
+        asserts:
+          finish_late_hour:
+            type: "value"
+            expected: 0.0
+
+      - step: "Write check-out one hour past the slot's own end"
+        action: "write"
+        target: "attendance_finish_late"
+        as_user: "base.user_admin"
+        values:
+          check_out: "2024-07-23 07:00:00"
+
+      - step:
+          "Assert finish_late_hour recomputed - this is the exact regression guard for
+          the duplicated 'real_date_start' entry that used to replace 'real_date_end' in
+          _compute_work_hour's @api.depends"
+        action: "assert"
+        target: "schedule_finish_late"
+        refresh: true
+        asserts:
+          finish_late_hour:
+            type: "value"
+            expected: 1.0


### PR DESCRIPTION
## Ringkasan

Memperbaiki tiga cacat pada pasangan `hr.timesheet_attendance` <-> `hr.timesheet_attendance_schedule`:

1. **Pemilihan slot jadwal tak deterministik** - `_compute_schedule` memakai `search([...], limit=1)` tanpa `order` pada domain `[employee_id, date]`. Sekarang memakai tangga tiga tingkat, seluruhnya dengan `order` eksplisit:
   - Tingkat 1: slot yang **memuat** `check_in` (`date_start <= check_in <= date_end`), tanpa kurungan tanggal - menangani shift yang melewati tengah malam.
   - Tingkat 2: slot pada `attn.date` dengan `date_start` terdekat ke `check_in` - menangani datang lebih awal/pulang lewat jendela slot.
   - Tingkat 3: tidak ada slot -> `schedule_id = False` (hasil SAH untuk hari libur/karyawan tanpa jadwal).
2. **`valid_check_in`/`valid_check_out` tidak pernah terisi** - `_compute_valid` hanya meng-assign `total_valid_hour`. Sekarang ketiga field di-assign pada setiap cabang, tanpa mengubah rumus `total_valid_hour`.
3. **`finish_early_hour`/`finish_late_hour` basi** - `@api.depends` `_compute_work_hour` menulis `real_date_start` dua kali dan melewatkan `real_date_end`. Sekarang `real_date_end` ditambahkan sehingga kedua field ikut dihitung ulang saat `check_out` diisi.

## Test

- `tests/test_data_timesheet_attendance.yaml`: dua skenario lama yang meng-assert `schedule_id` (Sign Out Without/With Schedule) diberi nama step eksplisit menyebut tingkat tangga yang berlaku; ditambah 11 skenario baru (cross-midnight, dua slot satu tanggal, dua absensi satu slot, tier 1 lintas tengah malam, tier 2 early arrival, hari libur, regresi formula valid hour, tanpa check-out, seluruhnya di luar slot).
- `tests/test_data_timesheet_attendance_schedule.yaml`: dua skenario baru (`schedule_work_hour` = 10.0 untuk slot lintas tengah malam yang lolos `_check_schedule_work_hour`; regresi `finish_late_hour` yang mengunci perbaikan `@api.depends`).
- Tidak ada assert yang dihapus/dilonggarkan.

## Cakupan

Tidak menyentuh `_sign_out`/`checkout_buffer`, tidak mengubah cara slot dibuat, tidak menggabungkan slot, tidak menyentuh field geolokasi (#284, sudah merge di #289). Tidak ada migration script - kolom sudah ada, `store=True` + `@api.depends` yang berubah membuat Odoo menghitung ulang nilainya saat modul di-update.

Closes #286