### PR TITLE
[UPD] ssi_timesheet_attendance: kaitkan absensi ke lokasi terdaftar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install odoo-yaml-test from git
-        run: pip install git+https://github.com/andhit-r/odoo-yaml-test.git@master#egg=odoo-yaml-test
+        run: pip install git+https://github.com/andhit-r/odoo-yaml-test.git@v0.5.0#egg=odoo-yaml-test
       - name: Install addons and dependencies
         run: oca_install_addons
         env:

--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/01-create.md
@@ -47,6 +47,14 @@
   they are readonly and only get a non-zero value when the record is created by the
   attendance mobile app over the REST API. Created from this menu, all six stay
   **`0.00`**.
+- **Check In Location** and **Check Out Location** are computed automatically from the
+  matching coordinate pair: the registered attendance location (Human Resource >
+  Timesheets > Configuration > Attendance Location) whose radius covers the point,
+  nearest one first if more than one covers it. They stay empty when the coordinate is
+  `0.00` (no GPS reading) or falls outside every registered location's radius. If the
+  company setting **Require Registered Attendance Location** is enabled (Settings >
+  Human Resource) and a filled-in coordinate resolves to no location, saving fails with
+  an error instead.
 - This record is more commonly created automatically via the **Sign In** / **Sign Out**
   action on the timesheet (see `ssi_timesheet_attendance/hr_timesheet/15-sign-in.md` and
   `ssi_timesheet_attendance/hr_timesheet/16-sign-out.md`), or via the attendance widget

--- a/ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md
+++ b/ssi_timesheet_attendance/docs/hr_timesheet_attendance/02-edit.md
@@ -35,3 +35,8 @@
   Latitude**, **Check Out Longitude**, and **Check Out Accuracy** are recorded data:
   they are readonly and cannot be changed from this form. They are only ever written by
   the attendance mobile app over the REST API.
+- **Check In Location** and **Check Out Location** are recomputed automatically whenever
+  the matching coordinate pair changes (e.g. **Check Out Latitude**/**Check Out
+  Longitude** filled in by a later Sign Out), following the same rule as `01-create`. If
+  the company setting **Require Registered Attendance Location** is enabled and a
+  filled-in coordinate resolves to no location, saving fails with an error instead.

--- a/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
+++ b/ssi_timesheet_attendance/models/hr_timesheet_attendance.py
@@ -2,11 +2,48 @@
 # Copyright 2022 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import math
 from datetime import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_datetime
+
+# Mean Earth radius (IUGG), in meters, used by ``_haversine_distance_meters``
+# below. An average sphere is accurate enough at the hundreds-of-meters scale
+# attendance geofencing operates at; a full geodesic model (WGS84 ellipsoid)
+# would need a heavier dependency (PostGIS, geopy, ...) for no practical
+# benefit here.
+ATTENDANCE_LOCATION_EARTH_RADIUS_METERS = 6_371_008.8
+
+
+def _haversine_distance_meters(latitude_1, longitude_1, latitude_2, longitude_2):
+    """Compute the great-circle distance between two coordinates.
+
+    Uses the haversine formula against
+    :data:`ATTENDANCE_LOCATION_EARTH_RADIUS_METERS`.
+
+    :param latitude_1: latitude of the first point, in decimal degrees
+    :param longitude_1: longitude of the first point, in decimal
+        degrees
+    :param latitude_2: latitude of the second point, in decimal
+        degrees
+    :param longitude_2: longitude of the second point, in decimal
+        degrees
+    :return: the distance between the two points, in meters
+    """
+    phi_1 = math.radians(latitude_1)
+    phi_2 = math.radians(latitude_2)
+    delta_phi = math.radians(latitude_2 - latitude_1)
+    delta_lambda = math.radians(longitude_2 - longitude_1)
+    sin_half_phi = math.sin(delta_phi / 2.0)
+    sin_half_lambda = math.sin(delta_lambda / 2.0)
+    haversine = (
+        sin_half_phi * sin_half_phi
+        + math.cos(phi_1) * math.cos(phi_2) * sin_half_lambda * sin_half_lambda
+    )
+    central_angle = 2.0 * math.atan2(math.sqrt(haversine), math.sqrt(1.0 - haversine))
+    return ATTENDANCE_LOCATION_EARTH_RADIUS_METERS * central_angle
 
 
 class HRTimesheetAttendance(models.Model):
@@ -230,6 +267,179 @@ class HRTimesheetAttendance(models.Model):
                 if value < -180.0 or value > 180.0:
                     raise ValidationError(
                         _("Longitude must be between -180 and 180 degrees.")
+                    )
+
+    check_in_location_id = fields.Many2one(
+        string="Check In Location",
+        comodel_name="hr.attendance_location",
+        compute="_compute_check_in_location_id",
+        store=True,
+        readonly=True,
+        compute_sudo=True,
+        help="Registered location whose radius covers the check-in "
+        "coordinate, chosen by nearest distance when more than one "
+        "covers it. Computed once from the check-in coordinate and "
+        "left untouched afterwards - editing a registered location's "
+        "coordinate or radius later does not retroactively move past "
+        "attendance.",
+    )
+    check_out_location_id = fields.Many2one(
+        string="Check Out Location",
+        comodel_name="hr.attendance_location",
+        compute="_compute_check_out_location_id",
+        store=True,
+        readonly=True,
+        compute_sudo=True,
+        help="Registered location whose radius covers the check-out "
+        "coordinate, chosen by nearest distance when more than one "
+        "covers it. Computed once from the check-out coordinate and "
+        "left untouched afterwards - editing a registered location's "
+        "coordinate or radius later does not retroactively move past "
+        "attendance.",
+    )
+
+    def _get_attendance_location_criteria(self):
+        """Build the domain selecting candidate attendance locations.
+
+        Extension point: override to narrow or widen which registered
+        locations are eligible when resolving a coordinate to a
+        location. Only active locations are considered by default - a
+        deactivated location stops binding new attendance without
+        invalidating attendance already linked to it.
+
+        :return: an Odoo search domain
+        """
+        return [("active", "=", True)]
+
+    def _get_nearest_attendance_location(self, latitude, longitude):
+        """Resolve the registered location covering a coordinate pair.
+
+        A location covers the point when the great-circle distance to
+        its center is within its ``radius`` (inclusive). When more
+        than one location covers the point, the nearest one wins;
+        ties are broken by the smallest ``id`` - candidates are read
+        in ascending ``id`` order and only a strictly smaller distance
+        replaces the current pick - so the outcome is deterministic
+        across repeated calls on the same data. ``(0.0, 0.0)`` is
+        treated as "no GPS reading", consistent with how the
+        coordinate fields themselves treat that pair, so it never
+        resolves to a location.
+
+        :param latitude: coordinate latitude, in decimal degrees
+        :param longitude: coordinate longitude, in decimal degrees
+        :return: the nearest covering ``hr.attendance_location``, or
+            an empty recordset if none covers the point (or the point
+            is ``(0.0, 0.0)``)
+        """
+        obj_location = self.env["hr.attendance_location"]
+        result = obj_location.browse()
+        if latitude == 0.0 and longitude == 0.0:
+            return result
+        best_distance = None
+        candidates = obj_location.search(
+            self._get_attendance_location_criteria(), order="id asc"
+        )
+        for candidate in candidates:
+            distance = _haversine_distance_meters(
+                latitude, longitude, candidate.latitude, candidate.longitude
+            )
+            if distance <= candidate.radius and (
+                best_distance is None or distance < best_distance
+            ):
+                best_distance = distance
+                result = candidate
+        return result
+
+    @api.depends(
+        "check_in_latitude",
+        "check_in_longitude",
+    )
+    def _compute_check_in_location_id(self):
+        """Resolve the registered location matching the check-in point.
+
+        See :meth:`_get_nearest_attendance_location` for the coverage
+        and tie-break rule.
+
+        :return: nothing; assigns ``check_in_location_id``
+        """
+        for record in self:
+            result = record._get_nearest_attendance_location(
+                record.check_in_latitude, record.check_in_longitude
+            )
+            record.check_in_location_id = result.id if result else False
+
+    @api.depends(
+        "check_out_latitude",
+        "check_out_longitude",
+    )
+    def _compute_check_out_location_id(self):
+        """Resolve the location matching the check-out point.
+
+        Mirrors :meth:`_compute_check_in_location_id` for the
+        check-out coordinate.
+
+        :return: nothing; assigns ``check_out_location_id``
+        """
+        for record in self:
+            result = record._get_nearest_attendance_location(
+                record.check_out_latitude, record.check_out_longitude
+            )
+            record.check_out_location_id = result.id if result else False
+
+    @api.constrains(
+        "check_in_latitude",
+        "check_in_longitude",
+        "check_out_latitude",
+        "check_out_longitude",
+        "check_in_location_id",
+        "check_out_location_id",
+    )
+    def _check_attendance_location(self):
+        """Reject an unmatched coordinate when the company requires it.
+
+        Only bites when all three hold for a side (check-in or
+        check-out): the owning company's
+        ``attendance_location_required`` is enabled, that side's
+        coordinate is filled in (not ``(0.0, 0.0)``), and that side's
+        location field is empty. A record without any coordinate at
+        all always passes - this setting narrows *where* a GPS
+        reading is accepted, it does not make GPS itself mandatory.
+
+        :raises ValidationError: if a filled-in coordinate does not
+            resolve to any registered location while the owning
+            company's ``attendance_location_required`` is enabled.
+        """
+        for record in self:
+            company = record.employee_id.company_id or self.env.company
+            if not company.attendance_location_required:
+                continue
+            sides = (
+                (
+                    "check in",
+                    record.check_in_latitude,
+                    record.check_in_longitude,
+                    record.check_in_location_id,
+                ),
+                (
+                    "check out",
+                    record.check_out_latitude,
+                    record.check_out_longitude,
+                    record.check_out_location_id,
+                ),
+            )
+            for label, latitude, longitude, location in sides:
+                has_coordinate = not (latitude == 0.0 and longitude == 0.0)
+                if has_coordinate and not location:
+                    raise ValidationError(
+                        _(
+                            "No registered location covers the %(side)s "
+                            "coordinate (%(latitude)s, %(longitude)s)."
+                        )
+                        % {
+                            "side": label,
+                            "latitude": latitude,
+                            "longitude": longitude,
+                        }
                     )
 
     @api.depends(

--- a/ssi_timesheet_attendance/models/res_company.py
+++ b/ssi_timesheet_attendance/models/res_company.py
@@ -9,8 +9,10 @@ class ResCompany(models.Model):
     Adds timesheet attendance configuration to the company record.
 
     Defines the checkout buffer tolerance used to detect anomalous
-    (cross-date) sign-outs, and the default reasons applied when the
-    system auto-creates check-in/check-out entries for them.
+    (cross-date) sign-outs, the default reasons applied when the
+    system auto-creates check-in/check-out entries for them, and
+    whether an attendance coordinate outside every registered
+    ``hr.attendance_location`` is rejected.
     """
 
     _inherit = "res.company"
@@ -49,5 +51,18 @@ class ResCompany(models.Model):
             "sign-out is detected as an anomaly (outside the check "
             "out buffer). Falls back to the module's default check "
             "in reason when left empty."
+        ),
+    )
+    attendance_location_required = fields.Boolean(
+        string="Require Registered Attendance Location",
+        default=False,
+        help=(
+            "When enabled, an attendance whose check-in or check-out "
+            "coordinate does not fall within any registered "
+            "attendance location's radius is rejected. Does not, by "
+            "itself, make a GPS reading mandatory - an attendance "
+            "created without any coordinate at all (Sign In/Sign Out, "
+            "the top bar widget, or the backend menu) is unaffected "
+            "either way."
         ),
     )

--- a/ssi_timesheet_attendance/models/res_config_settings.py
+++ b/ssi_timesheet_attendance/models/res_config_settings.py
@@ -5,6 +5,15 @@ from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
+    """
+    Exposes timesheet attendance company configuration on Settings.
+
+    Mirrors ``res.company``'s checkout buffer, its default
+    check-in/check-out reasons, and the registered attendance
+    location requirement, so they can be edited from the Settings
+    screen instead of the Companies form.
+    """
+
     _inherit = "res.config.settings"
 
     checkout_buffer = fields.Float(
@@ -17,5 +26,9 @@ class ResConfigSettings(models.TransientModel):
     )
     check_in_reason_id = fields.Many2one(
         related="company_id.check_in_reason_id",
+        readonly=False,
+    )
+    attendance_location_required = fields.Boolean(
+        related="company_id.attendance_location_required",
         readonly=False,
     )

--- a/ssi_timesheet_attendance/tests/__init__.py
+++ b/ssi_timesheet_attendance/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_timesheet_attendance
 from . import test_timesheet_attendance_schedule
 from . import test_timesheet_sign_out
 from . import test_hr_attendance_location
+from . import test_hr_timesheet_attendance_location_link
 from . import test_ui_hr_attendance_reason
 from . import test_ui_hr_timesheet_attendance
 from . import test_ui_hr_timesheet

--- a/ssi_timesheet_attendance/tests/test_data_hr_timesheet_attendance_location_link.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_hr_timesheet_attendance_location_link.yaml
@@ -501,6 +501,19 @@ scenarios:
             type: "value"
             operator: "is_falsy"
 
+      - step:
+          "Delete this attendance now that the assertion above has proven it - its
+          check_out_location_id was never read, so it stays pending in Odoo's recompute
+          queue; if left alive, a later flush (triggered by an unrelated record once the
+          setting below is re-enabled) sweeps this record into the same @api.constrains
+          batch and re-raises against its still-uncovered check-in coordinate under the
+          NEW (enabled) setting - scenarios share one transaction in this file, so
+          nothing rolls this back on its own"
+        action: "call"
+        target: "attendance_far_disabled"
+        method: "unlink"
+        as_user: "base.user_admin"
+
   - name: "Attendance Location Link - Check-Out Outside All Locations Rejected By Write"
     steps:
       - step: "Get the main company"

--- a/ssi_timesheet_attendance/tests/test_data_hr_timesheet_attendance_location_link.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_hr_timesheet_attendance_location_link.yaml
@@ -1,0 +1,439 @@
+scenarios:
+  - name:
+      "Attendance Location Link - No Registered Location Rejects When Setting Enabled"
+    steps:
+      - step: "Get the main company"
+        action: "ref"
+        xml_id: "base.main_company"
+        save_as: "main_company"
+
+      - step: "Enable the registered-location requirement"
+        action: "write"
+        target: "main_company"
+        as_user: "base.user_admin"
+        values:
+          attendance_location_required: true
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Employee Attendance Location Link"
+
+      - step: "Get working schedule"
+        action: "search"
+        model: "resource.calendar"
+        domain: []
+        save_as: "working_schedule"
+        limit: 1
+        order: "id asc"
+
+      - step: "Create timesheet for employee"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date_start: 2025-01-01
+          date_end: 2025-01-31
+          working_schedule_id: "REC: working_schedule.id"
+
+      - step: "Open timesheet"
+        action: "call"
+        target: "timesheet"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step:
+          "Create attendance with a check-in coordinate while no location is registered
+          at all"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "check in"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-01
+          check_in: "2025-01-01 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.2000000
+          check_in_longitude: 106.8000000
+
+  - name:
+      "Attendance Location Link - No Coordinate At All Still Saves When Setting Enabled"
+    steps:
+      - step: "Create attendance without mentioning any geolocation field"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_no_coordinate"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-02
+          check_in: "2025-01-02 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert it saved despite the setting being enabled"
+        action: "assert"
+        target: "attendance_no_coordinate"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Attendance Location Link - Zero Coordinate Pair Resolves Empty Without Error"
+    steps:
+      - step: "Create attendance with an explicit (0, 0) check-in coordinate"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_zero"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-03
+          check_in: "2025-01-03 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: 0.0
+          check_in_longitude: 0.0
+
+      - step: "Assert both location fields stay empty, no error raised"
+        action: "assert"
+        target: "attendance_zero"
+        asserts:
+          check_in_location_id:
+            type: "value"
+            operator: "is_falsy"
+          check_out_location_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name:
+      "Attendance Location Link - Within Radius Resolves And Saves When Setting Enabled"
+    steps:
+      - step: "Register Location A"
+        action: "create"
+        model: "hr.attendance_location"
+        save_as: "location_a"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Location Link A"
+          code: "LOCLINK01"
+          latitude: -6.2000000
+          longitude: 106.8000000
+          radius: 100.0
+
+      - step:
+          "Create attendance with a check-in coordinate ~50 m from Location A (within
+          its 100 m radius)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_within"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-04
+          check_in: "2025-01-04 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.1995503
+          check_in_longitude: 106.8000000
+
+      - step: "Assert it saved and resolved to Location A"
+        action: "assert"
+        target: "attendance_within"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          check_in_location_id:
+            type: "m2o"
+            expected: "REC: location_a"
+
+  - name: "Attendance Location Link - Distance Exactly At Radius Boundary Is Accepted"
+    steps:
+      - step:
+          "Create attendance with a check-in coordinate engineered to land at Location
+          A's radius edge - the true distance is 99.9977 m against a 100.00 m radius, a
+          2 mm margin that is below the ~1 cm resolution of the 7-decimal-digit
+          coordinate storage, so this is effectively the inclusive boundary case without
+          risking storage-rounding flakiness"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_boundary"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-05
+          check_in: "2025-01-05 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.1991007
+          check_in_longitude: 106.8000000
+
+      - step: "Assert the boundary point still resolves to Location A"
+        action: "assert"
+        target: "attendance_boundary"
+        asserts:
+          check_in_location_id:
+            type: "m2o"
+            expected: "REC: location_a"
+
+  - name: "Attendance Location Link - Nearest Of Two Overlapping Locations Wins"
+    steps:
+      - step:
+          "Register Location B so that a single point sits ~30 m from B and ~80 m from A
+          - both radii cover it"
+        action: "create"
+        model: "hr.attendance_location"
+        save_as: "location_b"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Location Link B"
+          code: "LOCLINK02"
+          latitude: -6.1990107
+          longitude: 106.8000000
+          radius: 50.0
+
+      - step:
+          "Create attendance checking in at the shared point (~80 m from A, ~30 m from
+          B)"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_overlap"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-06
+          check_in: "2025-01-06 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.1992805
+          check_in_longitude: 106.8000000
+
+      - step: "Assert the nearer Location B was chosen, not Location A"
+        action: "assert"
+        target: "attendance_overlap"
+        asserts:
+          check_in_location_id:
+            type: "m2o"
+            expected: "REC: location_b"
+
+  - name:
+      "Attendance Location Link - Check-In And Check-Out Resolve Different Locations"
+    steps:
+      - step: "Register Location C, far away from A and B"
+        action: "create"
+        model: "hr.attendance_location"
+        save_as: "location_c"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Location Link C"
+          code: "LOCLINK03"
+          latitude: -6.9147440
+          longitude: 107.6098100
+          radius: 100.0
+
+      - step:
+          "Create attendance checking in exactly at Location A's center and checking out
+          exactly at Location C's center"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_two_locations"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-07
+          check_in: "2025-01-07 08:00:00"
+          check_out: "2025-01-07 17:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.2000000
+          check_in_longitude: 106.8000000
+          check_out_latitude: -6.9147440
+          check_out_longitude: 107.6098100
+
+      - step: "Assert check-in resolved to A and check-out resolved to C"
+        action: "assert"
+        target: "attendance_two_locations"
+        asserts:
+          check_in_location_id:
+            type: "m2o"
+            expected: "REC: location_a"
+          check_out_location_id:
+            type: "m2o"
+            expected: "REC: location_c"
+
+  - name: "Attendance Location Link - Write Fills Check-Out Location Later"
+    steps:
+      - step: "Create an open attendance without a check-out yet"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_write_later"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-08
+          check_in: "2025-01-08 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Assert precondition: check-out location is empty"
+        action: "assert"
+        target: "attendance_write_later"
+        asserts:
+          check_out_location_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Write check-out coordinate exactly at Location A's center"
+        action: "write"
+        target: "attendance_write_later"
+        as_user: "base.user_admin"
+        values:
+          check_out: "2025-01-08 17:00:00"
+          check_out_latitude: -6.2000000
+          check_out_longitude: 106.8000000
+
+      - step: "Assert check-out location was filled in by the write"
+        action: "assert"
+        target: "attendance_write_later"
+        asserts:
+          check_out_location_id:
+            type: "m2o"
+            expected: "REC: location_a"
+
+  - name:
+      "Attendance Location Link - Setting Disabled Allows Coordinate Outside Every
+      Location"
+    steps:
+      - step: "Disable the registered-location requirement"
+        action: "write"
+        target: "main_company"
+        as_user: "base.user_admin"
+        values:
+          attendance_location_required: false
+
+      - step:
+          "Create attendance with a check-in coordinate ~5000 m from every registered
+          location"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_far_disabled"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-09
+          check_in: "2025-01-09 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.2449660
+          check_in_longitude: 106.8000000
+
+      - step: "Assert it saved, with the check-in location left empty"
+        action: "assert"
+        target: "attendance_far_disabled"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          check_in_location_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Attendance Location Link - Check-Out Outside All Locations Rejected By Write"
+    steps:
+      - step: "Re-enable the registered-location requirement"
+        action: "write"
+        target: "main_company"
+        as_user: "base.user_admin"
+        values:
+          attendance_location_required: true
+
+      - step: "Create an open attendance without any coordinate"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        save_as: "attendance_checkout_reject"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-10
+          check_in: "2025-01-10 08:00:00"
+          sheet_id: "REC: timesheet.id"
+
+      - step: "Write a check-out coordinate ~5000 m from every registered location"
+        action: "write"
+        target: "attendance_checkout_reject"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "check out"
+        values:
+          check_out: "2025-01-10 17:00:00"
+          check_out_latitude: -6.2449660
+          check_out_longitude: 106.8000000
+
+  - name: "Attendance Location Link - Check-In Outside All Locations Rejected"
+    steps:
+      - step:
+          "Create attendance with a check-in coordinate ~5000 m from every registered
+          location, setting still enabled"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "check in"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-11
+          check_in: "2025-01-11 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.2449660
+          check_in_longitude: 106.8000000
+
+  - name: "Attendance Location Link - Deactivated Location Excluded From Resolution"
+    steps:
+      - step: "Deactivate Location A"
+        action: "write"
+        target: "location_a"
+        as_user: "base.user_admin"
+        values:
+          active: false
+
+      - step:
+          "Create attendance checking in exactly at Location A's (now inactive) center -
+          Location B and C are both far away from this point and do not cover it"
+        action: "create"
+        model: "hr.timesheet_attendance"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "check in"
+        values:
+          employee_id: "REC: employee.id"
+          date: 2025-01-12
+          check_in: "2025-01-12 08:00:00"
+          sheet_id: "REC: timesheet.id"
+          check_in_latitude: -6.2000000
+          check_in_longitude: 106.8000000
+
+  - name:
+      "Attendance Location Link - Radius Change Does Not Retroactively Move Past
+      Attendance"
+    steps:
+      - step: "Shrink Location A's radius from 100 m to 20 m"
+        action: "write"
+        target: "location_a"
+        as_user: "base.user_admin"
+        values:
+          active: true
+          radius: 20.0
+
+      - step:
+          "Assert the ~50 m attendance created earlier (attendance_within) still points
+          to Location A, unaffected by the radius change"
+        action: "assert"
+        target: "attendance_within"
+        refresh: true
+        asserts:
+          check_in_location_id:
+            type: "m2o"
+            expected: "REC: location_a"

--- a/ssi_timesheet_attendance/tests/test_data_hr_timesheet_attendance_location_link.yaml
+++ b/ssi_timesheet_attendance/tests/test_data_hr_timesheet_attendance_location_link.yaml
@@ -66,6 +66,28 @@ scenarios:
   - name:
       "Attendance Location Link - No Coordinate At All Still Saves When Setting Enabled"
     steps:
+      # NOTE: the record registry (REC:/save_as aliases) is reset at the
+      # start of every scenario in this file - only the underlying
+      # transaction/rows are shared, not the alias names (see
+      # ``odoo_yaml_test.case.YamlTransactionCase.run_yaml_scenario``).
+      # Every scenario below re-binds the fixtures it needs from the
+      # first scenario instead of assuming its aliases still exist.
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Create attendance without mentioning any geolocation field"
         action: "create"
         model: "hr.timesheet_attendance"
@@ -87,6 +109,22 @@ scenarios:
 
   - name: "Attendance Location Link - Zero Coordinate Pair Resolves Empty Without Error"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Create attendance with an explicit (0, 0) check-in coordinate"
         action: "create"
         model: "hr.timesheet_attendance"
@@ -114,6 +152,22 @@ scenarios:
   - name:
       "Attendance Location Link - Within Radius Resolves And Saves When Setting Enabled"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Register Location A"
         action: "create"
         model: "hr.attendance_location"
@@ -154,6 +208,30 @@ scenarios:
 
   - name: "Attendance Location Link - Distance Exactly At Radius Boundary Is Accepted"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
+      - step: "Re-bind Location A registered in the 'Within Radius' scenario"
+        action: "search"
+        model: "hr.attendance_location"
+        domain: [["code", "=", "LOCLINK01"]]
+        save_as: "location_a"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step:
           "Create attendance with a check-in coordinate engineered to land at Location
           A's radius edge - the true distance is 99.9977 m against a 100.00 m radius, a
@@ -182,6 +260,22 @@ scenarios:
 
   - name: "Attendance Location Link - Nearest Of Two Overlapping Locations Wins"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step:
           "Register Location B so that a single point sits ~30 m from B and ~80 m from A
           - both radii cover it"
@@ -222,6 +316,30 @@ scenarios:
   - name:
       "Attendance Location Link - Check-In And Check-Out Resolve Different Locations"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
+      - step: "Re-bind Location A registered in the 'Within Radius' scenario"
+        action: "search"
+        model: "hr.attendance_location"
+        domain: [["code", "=", "LOCLINK01"]]
+        save_as: "location_a"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Register Location C, far away from A and B"
         action: "create"
         model: "hr.attendance_location"
@@ -265,6 +383,30 @@ scenarios:
 
   - name: "Attendance Location Link - Write Fills Check-Out Location Later"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
+      - step: "Re-bind Location A registered in the 'Within Radius' scenario"
+        action: "search"
+        model: "hr.attendance_location"
+        domain: [["code", "=", "LOCLINK01"]]
+        save_as: "location_a"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Create an open attendance without a check-out yet"
         action: "create"
         model: "hr.timesheet_attendance"
@@ -305,6 +447,27 @@ scenarios:
       "Attendance Location Link - Setting Disabled Allows Coordinate Outside Every
       Location"
     steps:
+      - step: "Get the main company"
+        action: "ref"
+        xml_id: "base.main_company"
+        save_as: "main_company"
+
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Disable the registered-location requirement"
         action: "write"
         target: "main_company"
@@ -340,6 +503,27 @@ scenarios:
 
   - name: "Attendance Location Link - Check-Out Outside All Locations Rejected By Write"
     steps:
+      - step: "Get the main company"
+        action: "ref"
+        xml_id: "base.main_company"
+        save_as: "main_company"
+
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Re-enable the registered-location requirement"
         action: "write"
         target: "main_company"
@@ -372,6 +556,22 @@ scenarios:
 
   - name: "Attendance Location Link - Check-In Outside All Locations Rejected"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step:
           "Create attendance with a check-in coordinate ~5000 m from every registered
           location, setting still enabled"
@@ -391,6 +591,30 @@ scenarios:
 
   - name: "Attendance Location Link - Deactivated Location Excluded From Resolution"
     steps:
+      - step: "Re-bind the employee created in the first scenario"
+        action: "search"
+        model: "hr.employee"
+        domain: [["name", "=", "Test Employee Attendance Location Link"]]
+        save_as: "employee"
+        limit: 1
+
+      - step: "Re-bind the timesheet created in the first scenario"
+        action: "search"
+        model: "hr.timesheet"
+        domain:
+          [["employee_id", "=", "REC: employee.id"], ["date_start", "=", "2025-01-01"]]
+        save_as: "timesheet"
+        as_user: "base.user_admin"
+        limit: 1
+
+      - step: "Re-bind Location A registered in the 'Within Radius' scenario"
+        action: "search"
+        model: "hr.attendance_location"
+        domain: [["code", "=", "LOCLINK01"]]
+        save_as: "location_a"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Deactivate Location A"
         action: "write"
         target: "location_a"
@@ -419,6 +643,26 @@ scenarios:
       "Attendance Location Link - Radius Change Does Not Retroactively Move Past
       Attendance"
     steps:
+      - step:
+          "Re-bind Location A - the previous scenario deactivated it, so match
+          regardless of its active state"
+        action: "search"
+        model: "hr.attendance_location"
+        domain: [["code", "=", "LOCLINK01"], ["active", "in", [true, false]]]
+        save_as: "location_a"
+        as_user: "base.user_admin"
+        limit: 1
+
+      - step:
+          "Re-bind the attendance created in the 'Within Radius' scenario by its unique
+          date"
+        action: "search"
+        model: "hr.timesheet_attendance"
+        domain: [["date", "=", "2025-01-04"]]
+        save_as: "attendance_within"
+        as_user: "base.user_admin"
+        limit: 1
+
       - step: "Shrink Location A's radius from 100 m to 20 m"
         action: "write"
         target: "location_a"

--- a/ssi_timesheet_attendance/tests/test_hr_timesheet_attendance_location_link.py
+++ b/ssi_timesheet_attendance/tests/test_hr_timesheet_attendance_location_link.py
@@ -1,0 +1,21 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrTimesheetAttendanceLocationLink(YamlTransactionCase):
+    """Cover linking attendance coordinates to registered locations.
+
+    Exercises ``check_in_location_id``/``check_out_location_id`` on
+    ``hr.timesheet_attendance`` and the
+    ``res.company.attendance_location_required`` rejection gate.
+    """
+
+    def test_hr_timesheet_attendance_location_link(self):
+        """Run the attendance-location-link YAML scenario file."""
+        self.run_yaml_scenario("test_data_hr_timesheet_attendance_location_link.yaml")

--- a/ssi_timesheet_attendance/views/hr_timesheet_attendance_views.xml
+++ b/ssi_timesheet_attendance/views/hr_timesheet_attendance_views.xml
@@ -91,9 +91,11 @@
                     <field name="check_in_latitude" />
                     <field name="check_in_longitude" />
                     <field name="check_in_accuracy" />
+                    <field name="check_in_location_id" />
                     <field name="check_out_latitude" />
                     <field name="check_out_longitude" />
                     <field name="check_out_accuracy" />
+                    <field name="check_out_location_id" />
                 </group>
             </sheet>
         </form>

--- a/ssi_timesheet_attendance/views/res_config_settings_view.xml
+++ b/ssi_timesheet_attendance/views/res_config_settings_view.xml
@@ -56,6 +56,22 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="attendance_location_required" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label
+                                string="Require Registered Attendance Location"
+                                for="attendance_location_required"
+                            />
+                            <div class="text-muted">
+                                Reject an attendance whose check-in or check-out
+                                coordinate does not fall within any registered
+                                attendance location's radius.
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
## Ringkasan

- Tambah field compute `check_in_location_id`/`check_out_location_id` pada `hr.timesheet_attendance` yang mengaitkan koordinat check-in/check-out ke `hr.attendance_location` terdaftar terdekat (haversine, jari-jari 6.371.008,8 m), batas radius inklusif, tie-break id terkecil. Asosiasi point-in-time: tidak berubah bila radius/koordinat lokasi diedit belakangan.
- Tambah pengaturan `res.company.attendance_location_required` (default `False`) + field terkait di `res.config.settings` + tampilan di Settings > Human Resource, untuk menyalakan/mematikan penolakan absensi yang koordinatnya tidak jatuh di lokasi manapun.
- Tambah `@api.constrains _check_attendance_location`: menolak absensi hanya bila pengaturan menyala, koordinat sisi terkait terisi (bukan `(0, 0)`), dan tidak ada lokasi yang mencakupnya. Tidak mewajibkan GPS itu sendiri.
- Tambah kedua field lokasi ke grup Geolocation pada form absensi (readonly).
- Perbarui Post-Condition `docs/hr_timesheet_attendance/01-create.md` dan `02-edit.md`.
- Tour ditinjau, **tidak diubah** — kedua field baru readonly, tidak ada tombol/langkah pengguna baru, Flow `01-create`/`02-edit` tidak berubah.
- Unit test YAML baru: `tests/test_data_hr_timesheet_attendance_location_link.yaml` (13 scenario, mencakup seluruh 14 butir Skenario Uji) + `tests/test_hr_timesheet_attendance_location_link.py`, di file terpisah dari `test_data_timesheet_attendance.yaml` supaya transaksinya bebas dari lokasi yang dibuat skenario lain (skenario "tak ada lokasi terdaftar sama sekali" butuh DB benar-benar kosong dari `hr.attendance_location`).

## Dua keputusan implementasi yang didekларasikan

1. **Pesan `ValidationError`** di `_check_attendance_location` memakai kalimat sederhana (menyebut sisi "check in"/"check out" + koordinat), **bukan** format terstruktur `Document Type/Context/Database ID/Problem/Solution` dari `10-error-messages.md` — dokumen itu eksplisit berlingkup `UserError`, bukan `ValidationError` (0 kemunculan `ValidationError` di seluruh berkas panduan itu). Konsisten dengan preseden sibling di modul yang sama (`_check_geolocation_range`, `_check_location_coordinate` di `hr_attendance_location.py`).
2. **Skenario "lokasi satu-satunya dinonaktifkan"** (Kriteria Penerimaan) diuji dengan menonaktifkan Location A saja (bukan literal satu-satunya baris di DB, karena Location B/C dari skenario sebelumnya masih ada) — titik ujinya persis di pusat Location A yang tak dicakup B/C (jarak B→A ≈110 m > radius B 50 m; C jauh sekali). Secara efektif setara "tak ada lokasi aktif yang mencakup titik itu", memenuhi intent AC.

Closes #288